### PR TITLE
Design Discussion: API

### DIFF
--- a/src/ComputeFramework.jl
+++ b/src/ComputeFramework.jl
@@ -28,6 +28,7 @@ include("array/operators.jl")
 include("array/getindex.jl")
 include("array/matrix.jl")
 
+include("api.jl")
 include("array/show.jl")
 
 end # module

--- a/src/api.jl
+++ b/src/api.jl
@@ -10,6 +10,7 @@ export CFArray, @cf
 type CFArray{T,N} <: AbstractArray{T,N}
   head::Computation
 end
+@forward CFArray.head size
 
 function CFArray(xs::Computation)
   xs = compute(xs)
@@ -20,12 +21,12 @@ macro cf(ex)
   @capture(shortdef(ex), name_(arg_) = exs__) ||
     error("invalid @cf function")
   quote
-    ex
-    $name($arg::ComputeFramework) = ComputeFramework.CFArray($name($arg.head))
+    $ex
+    $name($arg::ComputeFramework.CFArray) = ComputeFramework.CFArray($name($arg.head))
   end |> esc
 end
 
-Base.getindex(xs::CFArray, args::Integer...) = compute($f($xs.head, args...))
+Base.getindex(xs::CFArray, args::Integer...) = compute(getindex(xs.head, args...))
 
 for f in :[getindex map reduce exp log].args
   @eval $f(xs::CFArray, args...) = CFArray($f(xs.head, args...))

--- a/src/api.jl
+++ b/src/api.jl
@@ -28,7 +28,9 @@ end
 
 # x = CFArray(rand(BlockPartition(100), 10^3))
 
-Base.getindex(xs::CFArray, args::Integer...) = @> getindex(xs.head, args...) gather first
+Base.collect(xs::CFArray) = gather(xs.head)
+
+Base.getindex(xs::CFArray, args::Integer...) = @> xs.head getindex(args...) gather first
 
 for f in :[getindex map reduce exp log].args
   @eval $f(xs::CFArray, args...) = CFArray($f(xs.head, args...))

--- a/src/api.jl
+++ b/src/api.jl
@@ -1,0 +1,42 @@
+using MacroTools, Lazy
+
+import Base: eltype, ndims
+
+export CFArray, @cf
+
+@forward Computed.result eltype, ndims
+@forward Cat.parttype eltype, ndims
+
+type CFArray{T,N} <: AbstractArray{T,N}
+  head::Computation
+end
+
+function CFArray(xs::Computation)
+  xs = compute(xs)
+  CFArray{eltype(xs),ndims(xs)}(xs)
+end
+
+macro cf(ex)
+  @capture(shortdef(ex), name_(arg_) = exs__) ||
+    error("invalid @cf function")
+  quote
+    ex
+    $name($arg::ComputeFramework) = ComputeFramework.CFArray($name($arg.head))
+  end |> esc
+end
+
+Base.getindex(xs::CFArray, args::Integer...) = compute($f($xs.head, args...))
+
+for f in :[getindex map reduce exp log].args
+  @eval $f(xs::CFArray, args...) = CFArray($f(xs.head, args...))
+end
+
+for f in :[(+) (*)].args
+  @eval $f(xs::CFArray, ys::CFArray) = $f(xs, ys)
+end
+
+for f in :[(.+) (.*) ].args
+  @eval $f(xs::CFArray, ys::Number) = $f(xs, ys)
+  @eval $f(xs::Number, ys::CFArray) = $f(xs, ys)
+  @eval $f(xs::CFArray, ys::CFArray) = $f(xs, ys)
+end

--- a/src/array/getindex.jl
+++ b/src/array/getindex.jl
@@ -5,6 +5,9 @@ end
 
 Base.getindex(c::Computation, idx...) = GetIndex(c, idx)
 
+Base.size(c::Computed, i::Int) = size(domain(c.result),i)
+Base.size(c::Computed) = size(domain(c.result))
+
 function stage(ctx, gidx::GetIndex)
     inp = cached_stage(ctx, gidx.input)
     dmn = domain(inp)


### PR DESCRIPTION
This is the prototype for an experimental new programming model for ComputeFramework.

Although we discussed this in the context of Flow.jl, I've actually stripped it out from here since I wanted to distill the various issues as much as possible. So this is the simplest hack that demonstrates what I'd like the frontend to look like.

### Background

Right now you use CF by building expression trees and evaluating them. It's analogous to working with Julia code like this:

```julia
compute(x) = eval(x) # or some custom interpreter
f(x) = :($x^2)
g(xs) = :(sum([$(map(x -> f(x), xs)...)])

g(1:10) == :(sum([1 ^ 2,2 ^ 2,3 ^ 2 ... ]))
compute(g(1:10)) == 385
```

Some think of this as "lazy" or "symbolic" programming, but I hope this illustrates why I disagree; Julia's semantics didn't change just because we called `compute` explicitly. Likewise, CF's DSL is both strict and non-symbolic, it just doesn't (yet) have proper syntax. `</nitpicking>`

What I'd like to do is move from "build expression and eval" to "write a function, take some data, run `f(x)`. This has a number of benefits (including making a few things easier on the developer side), but first and foremost is that it's potentially much more intuitive, since the semantics and programming model are very close to the host language. Let me explain:

### Implementation

[at the moment this is mainly illustrative, the implementation has some issues due to `getindex` not working in CF.]

This PR introduces the `CFArray` type. `CFArray` is just a regular ol' piece of data, and as an `AbstractArray` you can use the same functions you know and love. Of course, the data and operations on it are all parallelised.

```julia
xs = rand(CFArray, 10^4, 10^4)
10000×10000 CFArray{Float64,2}:
 0.315912  …  0.42977
 ⋮         ⋱         
 0.484693     0.69204

julia> exp(xs)
10000×10000 CFArray{Float64,2}:
 1.51383  …  1.42473
 ⋮        ⋱         
 1.03595     1.59556

julia> xs'*xs
10000×10000 CFArray{Float64,2}:
 3321.84  …  2514.66
    ⋮     ⋱         
 2514.66     3328.39

mvgavg(xs,n) = (xs[1:end-n]+xs[n+1:end])/n

julia> mvgavg(rand(CFArray, 100), 2)
98-element Array{Float64,1}:
 0.504985
 ⋮       
 0.55807
```

Notice how many fewer concepts are required to get going.

The main issue here is that the operations within `mvgavg` aren't visible to CF's runtime, which means they'll execute in sequence (though each one will be parallelised in itself – like sequential calls to BLAS). CF may be able to apply more optimisations if it has a view of the whole program graph, and to enable this we use the `@cf` macro:

```julia
@cf mvgavg(xs,n) = (xs[1:end-n]+xs[n+1:end])/n
```

When `mvgavg` is called with a `CFArray`, the function will build up a larger DAG and ask CF to run it – all in a way which is transparent to the user. `@cf` functions can also be used to extend existing functions, and can work with standard Julia data types like `Array` as well.

Pretty straightforward, I think – but of course, that's the point. What do people think?