### PR TITLE
WIP: Slice utility + fix map

### DIFF
--- a/src/array/map-reduce.jl
+++ b/src/array/map-reduce.jl
@@ -18,7 +18,7 @@ function stage(ctx, node::Map)
     thunks = similar(domains, Any)
     f = node.f
     for i=eachindex(domains)
-        inps = map(x->chunks(x)[i], inputs)
+        inps = map(x->chslice(x, domains[i]), inputs)
         thunks[i] = Thunk((args...) -> map(f, args...), inps...)
     end
     DArray(Any, domain(primary), domainchunks(primary), thunks)


### PR DESCRIPTION
Here's a small utility we need to mix arrays of different block layouts in general. To show it working I've fixed `map` to handle this case, e.g.

```julia
using Dagger

xs = distribute(rand(10,10), Blocks(5,5))
ys = distribute(rand(10,10), Blocks(3,3))

map(+, xs, ys) |> collect
```

There's some overhead added in the case that currently works, not sure what the impact will be but it it's easy to optimise if needed.

In future I think this should just be called `getindex`. That will be possible with #46 and a more general notion of chunks; e.g. if you can pass a `DArray` directly to a thunk.