### PR TITLE
make the scheduler configurable

### DIFF
--- a/src/Dagger.jl
+++ b/src/Dagger.jl
@@ -5,6 +5,11 @@ using Compat
 
 import Base.collect
 
+const PLUGINS = Dict{Symbol,Any}()
+const PLUGIN_CONFIGS = Dict{Symbol,String}(
+    :scheduler => "Dagger.Sch"
+)
+
 include("lib/util.jl")
 include("lib/logging.jl")
 
@@ -16,6 +21,7 @@ include("chunks.jl")
 
 # Task scheduling
 include("compute.jl")
+include("scheduler.jl")
 
 # Array computations
 include("array/darray.jl")

--- a/src/array/darray.jl
+++ b/src/array/darray.jl
@@ -165,7 +165,7 @@ size(x::DArray) = size(domain(x))
 stage(ctx, c::DArray) = c
 
 function collect(ctx::Context, d::DArray; tree=false)
-    a = compute(ctx, d, persist=false)
+    a = compute(ctx, d)
     ps_input = chunks(a)
 
     if isempty(d.chunks)

--- a/src/array/darray.jl
+++ b/src/array/darray.jl
@@ -342,8 +342,20 @@ function stage(ctx, d::Distribute)
         if d.domainchunks == domainchunks(x)
             return x # already properly distributed
         end
+        Nd = ndims(x)
+        T = eltype(d.data)
+        concat = x.concat
         cs = map(d.domainchunks) do idx
-            delayed(collect)(x[idx])
+            chunks = cached_stage(ctx, x[idx]).chunks
+            shape = size(chunks)
+            (delayed() do shape, parts...
+                if prod(shape) == 0
+                    return Array{T}(shape)
+                end
+                dimcatfuncs = [(x...) -> concat(i, x...) for i in 1:length(shape)]
+                ps = reshape(Any[parts...], shape)
+                collect(treereduce_nd(dimcatfuncs, ps))
+            end)(shape, chunks...)
         end
     else
         cs = map(c -> delayed(identity)(d.data[c]), d.domainchunks)

--- a/src/array/sort.jl
+++ b/src/array/sort.jl
@@ -117,12 +117,13 @@ function transpose_vecvec(xs)
     end
 end
 
+const use_shared_array = Ref(true)
 function _promote_array{T,S}(x::AbstractArray{T}, y::AbstractArray{S})
     Q = promote_type(T,S)
     samehost = Distributed.check_same_host(procs())
     ok = (isa(x, Array) || isa(x, SharedArray)) && (isa(y, Array) || isa(y, SharedArray))
-    if samehost && ok && isbits(Q)
-        return Array{Q}(length(x)+length(y)) #, pids=procs())
+    if use_shared_array[] && samehost && ok && isbits(Q)
+        return SharedArray{Q}(length(x)+length(y), pids=procs())
     else
         return similar(x, Q, length(x)+length(y))
     end

--- a/src/array/sort.jl
+++ b/src/array/sort.jl
@@ -244,6 +244,7 @@ function Base.sort(v::ArrayOp;
     nchunks = nchunks === nothing ? length(v1.chunks) : nchunks
     cs = dsort_chunks(v1.chunks, nchunks, nsamples,
                       order=ord, merge=(x,y)->merge_sorted(ord, x,y))
+    map(persist!, cs)
     t=delayed((xs...)->[xs...]; meta=true)(cs...)
     chunks = compute(t)
     dmn = ArrayDomain((1:sum(length(domain(c)) for c in chunks),))

--- a/src/array/sort.jl
+++ b/src/array/sort.jl
@@ -208,9 +208,11 @@ function dsort_chunks(cs, nchunks=length(cs), nsamples=2000;
     end
 
     cs = batchedsplitmerge(map((x,c) -> first(x) === nothing ? c : first(x), xs, cs), splitters, batchsize; merge=merge, by=by, sub=sub, order=order)
+    #=
     for (w, c) in zip(Iterators.cycle(affinities), cs)
         propagate_affinity!(c, Dagger.OSProc(w) => 1)
     end
+    =#
     cs
 end
 

--- a/src/compute.jl
+++ b/src/compute.jl
@@ -1,5 +1,7 @@
-export stage, cached_stage, compute, debug_compute, cached, free!
+export stage, cached_stage, compute, debug_compute, cached, free!, cleanup
 using Compat
+
+###### Scheduler #######
 
 compute(x) = compute(Context(), x)
 compute(ctx, c::Chunk) = c
@@ -12,203 +14,51 @@ abstract type Computation end
 compute(ctx, c::Computation) = compute(ctx, stage(ctx, c))
 collect(c::Computation) = collect(Context(), c)
 
-
-function finish_task!(state, node, node_order; free=true)
-    if istask(node) && node.cache
-        node.cache_ref = Nullable{Any}(state.cache[node])
-    end
-    immediate_next = false
-    for dep in sort!(collect(state.dependents[node]), by=node_order)
-        set = state.waiting[dep]
-        pop!(set, node)
-        if isempty(set)
-            pop!(state.waiting, dep)
-            push!(state.ready, dep)
-            immediate_next = true
-        end
-        # todo: free data
-    end
-    for inp in inputs(node)
-        if inp in keys(state.waiting_data)
-            s = state.waiting_data[inp]
-            if node in s
-                pop!(s, node)
-            end
-            if free && isempty(s)
-                if haskey(state.cache, inp)
-                    _node = state.cache[inp]
-                    free!(_node, force=false, cache=(istask(inp) && inp.cache))
-                    pop!(state.cache, inp)
-                end
-            end
-        end
-    end
-    push!(state.finished, node)
-    pop!(state.running, node)
-    immediate_next
-end
-
-###### Scheduler #######
 """
 Compute a Thunk - creates the DAG, assigns ranks to
 nodes for tie breaking and runs the scheduler.
 """
 function compute(ctx, d::Thunk)
-    master = OSProc(myid())
-    @dbg timespan_start(ctx, :scheduler_init, 0, master)
-
-    ps = procs(ctx)
-    chan = Channel{Any}(32)
-    deps = dependents(d)
-    ord = order(d, noffspring(deps))
-
-    node_order = x -> -get(ord, x, 0)
-    state = start_state(deps, node_order)
-    # start off some tasks
-    for p in ps
-        isempty(state.ready) && break
-        task = pop_with_affinity!(ctx, state.ready, p, false)
-        if task !== nothing
-            fire_task!(ctx, task, p, state, chan, node_order)
-        end
+    if !(:scheduler in keys(PLUGINS))
+        PLUGINS[:scheduler] = get_type(PLUGIN_CONFIGS[:scheduler])
     end
-    @dbg timespan_end(ctx, :scheduler_init, 0, master)
-
-    while !isempty(state.ready) || !isempty(state.running)
-
-        if isempty(state.running) && !isempty(state.ready)
-            for p in ps
-                isempty(state.ready) && break
-                task = pop_with_affinity!(ctx, state.ready, p, false)
-                if task !== nothing
-                    fire_task!(ctx, task, p, state, chan, node_order)
-                end
-            end
-        end
-
-        if isempty(state.running)
-            # the block above fired only meta tasks
-            continue
-        end
-
-        proc, thunk_id, res = take!(chan)
-        if isa(res, CapturedException) || isa(res, RemoteException)
-            rethrow(res)
-        end
-        node = _thunk_dict[thunk_id]
-        @logmsg("WORKER $(proc.pid) - $node ($(node.f)) input:$(node.inputs)")
-        state.cache[node] = res
-
-        @dbg timespan_start(ctx, :scheduler, thunk_id, master)
-        immediate_next = finish_task!(state, node, node_order)
-        if !isempty(state.ready)
-            thunk = pop_with_affinity!(Context(ps), state.ready, proc, immediate_next)
-            if thunk !== nothing
-                fire_task!(ctx, thunk, proc, state, chan, node_order)
-            end
-        end
-        @dbg timespan_end(ctx, :scheduler, thunk_id, master)
-    end
-    state.cache[d]
+    scheduler = PLUGINS[:scheduler]
+    (scheduler).compute_dag(ctx, d)
 end
 
-function pop_with_affinity!(ctx, tasks, proc, immediate_next)
-    if immediate_next
-        # fast path
-        if proc in first.(affinity(tasks[end]))
-            return pop!(tasks)
-        end
-    end
-    parent_affinities = affinity.(tasks)
-    for i=length(tasks):-1:1
-        # TODO: use the size
-        if proc in first.(parent_affinities[i])
-            t = tasks[i]
-            deleteat!(tasks, i)
-            return t
-        end
-    end
-    for i=length(tasks):-1:1
-        # use up tasks without affinitites
-        # let the procs with the respective affinities pick up
-        # other tasks
-        if isempty(parent_affinities[i])
-            t = tasks[i]
-            deleteat!(tasks, i)
-            return t
-        end
-        aff = first.(parent_affinities[i])
-        if all(!(p in aff) for p in procs(ctx)) # no proc is ever going to ask for it
-            t = tasks[i]
-            deleteat!(tasks, i)
-            return t
-        end
-    end
-    return nothing
+function debug_compute(ctx::Context, args...; profile=false)
+    @time res = compute(ctx, args...)
+    get_logs!(ctx.log_sink), res
 end
 
-function fire_task!(ctx, thunk, proc, state, chan, node_order)
-    @logmsg("W$(proc.pid) + $thunk ($(showloc(thunk.f, length(thunk.inputs)))) input:$(thunk.inputs) cache:$(thunk.cache) $(thunk.cache_ref)")
-    push!(state.running, thunk)
-    if thunk.cache && !isnull(thunk.cache_ref)
-        # the result might be already cached
-        data = unrelease(get(thunk.cache_ref)) # ask worker to keep the data around
-                                          # till this compute cycle frees it
-        if !isnull(data)
-            @logmsg("cache hit: $(get(thunk.cache_ref))")
-            state.cache[thunk] = get(data)
-            immediate_next = finish_task!(state, thunk, node_order; free=false)
-            if !isempty(state.ready)
-                thunk = pop_with_affinity!(ctx, state.ready, proc, immediate_next)
-                if thunk !== nothing
-                    fire_task!(ctx, thunk, proc, state, chan, node_order)
-                end
-            end
-            return
-        else
-            thunk.cache_ref = Nullable{Any}()
-            @logmsg("cache miss: $(thunk.cache_ref) recomputing $(thunk)")
-        end
-    end
-
-    if thunk.meta
-        # Run it on the parent node
-        # do not _move data.
-        p = OSProc(myid())
-        @dbg timespan_start(ctx, :comm, thunk.id, p)
-        fetched = map(thunk.inputs) do x
-            istask(x) ? state.cache[x] : x
-        end
-        @dbg timespan_end(ctx, :comm, thunk.id, p)
-
-        @dbg timespan_start(ctx, :compute, thunk.id, p)
-        res = thunk.f(fetched...)
-        @dbg timespan_end(ctx, :compute, thunk.id, p)
-
-        #push!(state.running, thunk)
-        state.cache[thunk] = res
-        immediate_next = finish_task!(state, thunk, node_order; free=false)
-        if !isempty(state.ready)
-            if immediate_next
-                thunk = pop!(state.ready)
-            else
-                thunk = pop_with_affinity!(ctx, state.ready, proc, immediate_next)
-            end
-            if thunk !== nothing
-                fire_task!(ctx, thunk, proc, state, chan, node_order)
-            end
-        end
-        return
-    end
-
-    data = map(thunk.inputs) do x
-        istask(x) ? state.cache[x] : x
-    end
-    async_apply(ctx, proc, thunk.id, thunk.f, data, chan, thunk.get_result, thunk.persist, thunk.cache)
+function debug_compute(arg; profile=false)
+    ctx = Context()
+    dbgctx = Context(procs(ctx), LocalEventLog(), profile)
+    debug_compute(dbgctx, arg)
 end
 
+Base.@deprecate gather(ctx, x) collect(ctx, x)
+Base.@deprecate gather(x) collect(x)
 
-##### Scheduling logic #####
+cleanup() = cleanup(Context())
+function cleanup(ctx::Context)
+    if :scheduler in keys(PLUGINS)
+        scheduler = PLUGINS[:scheduler]
+        (scheduler).cleanup(ctx)
+        delete!(PLUGINS, :scheduler)
+    end
+    nothing
+end
+
+function get_type(s::String)
+    T = Main
+    for t in split(s, ".")
+        T = eval(T, Symbol(t))
+    end
+    T
+end
+
+##### Dag utilities #####
 
 "find the set of direct dependents for each task"
 function dependents(node::Thunk, deps=Dict{Thunk, Set{Thunk}}())
@@ -267,87 +117,3 @@ function order(node::Thunk, ndeps)
     recur([node], 0)
     return output
 end
-
-const OneToMany = Dict{Thunk, Set{Thunk}}
-struct ComputeState
-    dependents::OneToMany
-    finished::Set{Thunk}
-    waiting::OneToMany
-    waiting_data::OneToMany
-    ready::Vector{Thunk}
-    cache::Dict{Thunk, Any}
-    running::Set{Thunk}
-end
-
-function start_state(deps::Dict, node_order)
-    state = ComputeState(
-                  deps,
-                  Set{Thunk}(),
-                  OneToMany(),
-                  OneToMany(),
-                  Vector{Thunk}(0),
-                  Dict{Thunk, Any}(),
-                  Set{Thunk}()
-                 )
-
-    nodes = sort(collect(keys(deps)), by=node_order)
-    merge!(state.waiting_data, deps)
-    for k in nodes
-        if istask(k)
-            waiting = Set{Thunk}(Iterators.filter(istask,
-                                                  inputs(k)))
-            if isempty(waiting)
-                push!(state.ready, k)
-            else
-                state.waiting[k] = waiting
-            end
-        end
-    end
-    state
-end
-
-_move(ctx, to_proc, x) = x
-_move(ctx, to_proc::OSProc, x::Union{Chunk, Thunk}) = collect(ctx, x)
-
-function do_task(ctx, proc, thunk_id, f, data, send_result, persist, cache)
-    @dbg timespan_start(ctx, :comm, thunk_id, proc)
-    time_cost = @elapsed fetched = map(x->_move(ctx, proc, x), data)
-    @dbg timespan_end(ctx, :comm, thunk_id, proc)
-
-    @dbg timespan_start(ctx, :compute, thunk_id, proc)
-    result_meta = try
-        res = f(fetched...)
-        (proc, thunk_id, send_result ? res : tochunk(res, persist=persist, cache=persist ? true : cache)) #todo: add more metadata
-    catch ex
-        bt = catch_backtrace()
-        (proc, thunk_id, RemoteException(myid(), CapturedException(ex, bt)))
-    end
-    @dbg timespan_end(ctx, :compute, thunk_id, proc)
-    result_meta
-end
-
-function async_apply(ctx, p::OSProc, thunk_id, f, data, chan, send_res, persist, cache)
-    @schedule begin
-        try
-            put!(chan, Base.remotecall_fetch(do_task, p.pid, ctx, p, thunk_id, f, data, send_res, persist, cache))
-        catch ex
-            bt = catch_backtrace()
-            put!(chan, (p, thunk_id, CapturedException(ex, bt)))
-        end
-        nothing
-    end
-end
-
-function debug_compute(ctx::Context, args...; profile=false)
-    @time res = compute(ctx, args...)
-    get_logs!(ctx.log_sink), res
-end
-
-function debug_compute(arg; profile=false)
-    ctx = Context()
-    dbgctx = Context(procs(ctx), LocalEventLog(), profile)
-    debug_compute(dbgctx, arg)
-end
-
-Base.@deprecate gather(ctx, x) collect(ctx, x)
-Base.@deprecate gather(x) collect(x)

--- a/src/scheduler.jl
+++ b/src/scheduler.jl
@@ -1,0 +1,267 @@
+module Sch
+
+import ..Dagger: Context, Thunk, Chunk, OSProc, order, free!, dependents, noffspring, istask, inputs, affinity, tochunk, _thunk_dict, @dbg, @logmsg, timespan_start, timespan_end
+
+const OneToMany = Dict{Thunk, Set{Thunk}}
+struct ComputeState
+    dependents::OneToMany
+    finished::Set{Thunk}
+    waiting::OneToMany
+    waiting_data::OneToMany
+    ready::Vector{Thunk}
+    cache::Dict{Thunk, Any}
+    running::Set{Thunk}
+end
+
+function cleanup(ctx)
+end
+
+function compute_dag(ctx, d::Thunk)
+    master = OSProc(myid())
+    @dbg timespan_start(ctx, :scheduler_init, 0, master)
+
+    ps = procs(ctx)
+    chan = Channel{Any}(32)
+    deps = dependents(d)
+    ord = order(d, noffspring(deps))
+
+    node_order = x -> -get(ord, x, 0)
+    state = start_state(deps, node_order)
+    # start off some tasks
+    for p in ps
+        isempty(state.ready) && break
+        task = pop_with_affinity!(ctx, state.ready, p, false)
+        if task !== nothing
+            fire_task!(ctx, task, p, state, chan, node_order)
+        end
+    end
+    @dbg timespan_end(ctx, :scheduler_init, 0, master)
+
+    while !isempty(state.ready) || !isempty(state.running)
+
+        if isempty(state.running) && !isempty(state.ready)
+            for p in ps
+                isempty(state.ready) && break
+                task = pop_with_affinity!(ctx, state.ready, p, false)
+                if task !== nothing
+                    fire_task!(ctx, task, p, state, chan, node_order)
+                end
+            end
+        end
+
+        if isempty(state.running)
+            # the block above fired only meta tasks
+            continue
+        end
+
+        proc, thunk_id, res = take!(chan)
+        if isa(res, CapturedException) || isa(res, RemoteException)
+            rethrow(res)
+        end
+        node = _thunk_dict[thunk_id]
+        @logmsg("WORKER $(proc.pid) - $node ($(node.f)) input:$(node.inputs)")
+        state.cache[node] = res
+
+        @dbg timespan_start(ctx, :scheduler, thunk_id, master)
+        immediate_next = finish_task!(state, node, node_order)
+        if !isempty(state.ready)
+            thunk = pop_with_affinity!(Context(ps), state.ready, proc, immediate_next)
+            if thunk !== nothing
+                fire_task!(ctx, thunk, proc, state, chan, node_order)
+            end
+        end
+        @dbg timespan_end(ctx, :scheduler, thunk_id, master)
+    end
+    state.cache[d]
+end
+
+function pop_with_affinity!(ctx, tasks, proc, immediate_next)
+    if immediate_next
+        # fast path
+        if proc in first.(affinity(tasks[end]))
+            return pop!(tasks)
+        end
+    end
+    parent_affinities = affinity.(tasks)
+    for i=length(tasks):-1:1
+        # TODO: use the size
+        if proc in first.(parent_affinities[i])
+            t = tasks[i]
+            deleteat!(tasks, i)
+            return t
+        end
+    end
+    for i=length(tasks):-1:1
+        # use up tasks without affinitites
+        # let the procs with the respective affinities pick up
+        # other tasks
+        if isempty(parent_affinities[i])
+            t = tasks[i]
+            deleteat!(tasks, i)
+            return t
+        end
+        aff = first.(parent_affinities[i])
+        if all(!(p in aff) for p in procs(ctx)) # no proc is ever going to ask for it
+            t = tasks[i]
+            deleteat!(tasks, i)
+            return t
+        end
+    end
+    return nothing
+end
+
+function fire_task!(ctx, thunk, proc, state, chan, node_order)
+    @logmsg("W$(proc.pid) + $thunk ($(showloc(thunk.f, length(thunk.inputs)))) input:$(thunk.inputs) cache:$(thunk.cache) $(thunk.cache_ref)")
+    push!(state.running, thunk)
+    if thunk.cache && !isnull(thunk.cache_ref)
+        # the result might be already cached
+        data = unrelease(get(thunk.cache_ref)) # ask worker to keep the data around
+                                          # till this compute cycle frees it
+        if !isnull(data)
+            @logmsg("cache hit: $(get(thunk.cache_ref))")
+            state.cache[thunk] = get(data)
+            immediate_next = finish_task!(state, thunk, node_order; free=false)
+            if !isempty(state.ready)
+                thunk = pop_with_affinity!(ctx, state.ready, proc, immediate_next)
+                if thunk !== nothing
+                    fire_task!(ctx, thunk, proc, state, chan, node_order)
+                end
+            end
+            return
+        else
+            thunk.cache_ref = Nullable{Any}()
+            @logmsg("cache miss: $(thunk.cache_ref) recomputing $(thunk)")
+        end
+    end
+
+    if thunk.meta
+        # Run it on the parent node
+        # do not _move data.
+        p = OSProc(myid())
+        @dbg timespan_start(ctx, :comm, thunk.id, p)
+        fetched = map(thunk.inputs) do x
+            istask(x) ? state.cache[x] : x
+        end
+        @dbg timespan_end(ctx, :comm, thunk.id, p)
+
+        @dbg timespan_start(ctx, :compute, thunk.id, p)
+        res = thunk.f(fetched...)
+        @dbg timespan_end(ctx, :compute, thunk.id, p)
+
+        #push!(state.running, thunk)
+        state.cache[thunk] = res
+        immediate_next = finish_task!(state, thunk, node_order; free=false)
+        if !isempty(state.ready)
+            if immediate_next
+                thunk = pop!(state.ready)
+            else
+                thunk = pop_with_affinity!(ctx, state.ready, proc, immediate_next)
+            end
+            if thunk !== nothing
+                fire_task!(ctx, thunk, proc, state, chan, node_order)
+            end
+        end
+        return
+    end
+
+    data = map(thunk.inputs) do x
+        istask(x) ? state.cache[x] : x
+    end
+    async_apply(ctx, proc, thunk.id, thunk.f, data, chan, thunk.get_result, thunk.persist, thunk.cache)
+end
+
+function finish_task!(state, node, node_order; free=true)
+    if istask(node) && node.cache
+        node.cache_ref = Nullable{Any}(state.cache[node])
+    end
+    immediate_next = false
+    for dep in sort!(collect(state.dependents[node]), by=node_order)
+        set = state.waiting[dep]
+        pop!(set, node)
+        if isempty(set)
+            pop!(state.waiting, dep)
+            push!(state.ready, dep)
+            immediate_next = true
+        end
+        # todo: free data
+    end
+    for inp in inputs(node)
+        if inp in keys(state.waiting_data)
+            s = state.waiting_data[inp]
+            if node in s
+                pop!(s, node)
+            end
+            if free && isempty(s)
+                if haskey(state.cache, inp)
+                    _node = state.cache[inp]
+                    free!(_node, force=false, cache=(istask(inp) && inp.cache))
+                    pop!(state.cache, inp)
+                end
+            end
+        end
+    end
+    push!(state.finished, node)
+    pop!(state.running, node)
+    immediate_next
+end
+
+function start_state(deps::Dict, node_order)
+    state = ComputeState(
+                  deps,
+                  Set{Thunk}(),
+                  OneToMany(),
+                  OneToMany(),
+                  Vector{Thunk}(0),
+                  Dict{Thunk, Any}(),
+                  Set{Thunk}()
+                 )
+
+    nodes = sort(collect(keys(deps)), by=node_order)
+    merge!(state.waiting_data, deps)
+    for k in nodes
+        if istask(k)
+            waiting = Set{Thunk}(Iterators.filter(istask,
+                                                  inputs(k)))
+            if isempty(waiting)
+                push!(state.ready, k)
+            else
+                state.waiting[k] = waiting
+            end
+        end
+    end
+    state
+end
+
+_move(ctx, to_proc, x) = x
+_move(ctx, to_proc::OSProc, x::Union{Chunk, Thunk}) = collect(ctx, x)
+
+function do_task(ctx, proc, thunk_id, f, data, send_result, persist, cache)
+    @dbg timespan_start(ctx, :comm, thunk_id, proc)
+    time_cost = @elapsed fetched = map(x->_move(ctx, proc, x), data)
+    @dbg timespan_end(ctx, :comm, thunk_id, proc)
+
+    @dbg timespan_start(ctx, :compute, thunk_id, proc)
+    result_meta = try
+        res = f(fetched...)
+        (proc, thunk_id, send_result ? res : tochunk(res, persist=persist, cache=persist ? true : cache)) #todo: add more metadata
+    catch ex
+        bt = catch_backtrace()
+        (proc, thunk_id, RemoteException(myid(), CapturedException(ex, bt)))
+    end
+    @dbg timespan_end(ctx, :compute, thunk_id, proc)
+    result_meta
+end
+
+function async_apply(ctx, p::OSProc, thunk_id, f, data, chan, send_res, persist, cache)
+    @schedule begin
+        try
+            put!(chan, Base.remotecall_fetch(do_task, p.pid, ctx, p, thunk_id, f, data, send_res, persist, cache))
+        catch ex
+            bt = catch_backtrace()
+            put!(chan, (p, thunk_id, CapturedException(ex, bt)))
+        end
+        nothing
+    end
+end
+
+end # module Sch

--- a/src/thunk.jl
+++ b/src/thunk.jl
@@ -2,7 +2,8 @@ export Thunk, delayed, delayedmap
 
 let counter=0
     global next_id
-    next_id() = counter+=1
+    const MAX_ID = (1 << 30)
+    next_id() = (counter >= MAX_ID) ? (counter = 1) : (counter += 1)
 end
 
 global _thunk_dict = Dict{Int, Any}()

--- a/src/thunk.jl
+++ b/src/thunk.jl
@@ -27,7 +27,7 @@ mutable struct Thunk
                    persist::Bool=false,
                    cache::Bool=false,
                    cache_ref::Nullable{Any}=Nullable{Any}(),
-                   affinity=Nullable(),
+                   affinity=Nullable()
                   )
         thunk = new(f,xs,id,get_result,meta,persist, cache, cache_ref, affinity)
         _thunk_dict[id] = thunk

--- a/src/ui/graph.jl
+++ b/src/ui/graph.jl
@@ -3,9 +3,9 @@ export show_plan
 
 function node_label(io, t::Thunk, c)
     if isa(t.f, Function)
-        println(io, "$(t.id) [label=\"$(t.f)\"]")
+        println(io, "$(t.id) [label=\"$(t.f) - $(t.id)\"]")
     else
-        println(io, "$(t.id) [label=\"fn\"]")
+        println(io, "$(t.id) [label=\"fn - $(t.id)\"]")
     end
     c
 end

--- a/test/array.jl
+++ b/test/array.jl
@@ -190,3 +190,15 @@ end
     y = compute(Distribute(Blocks(3), x))
     #@test map(x->length(collect(x)), compute(sort(y)).chunks) == [3,3,3,1]
 end
+
+@testset "affinity" begin
+    x = Dagger.tochunk([1:10;])
+    aff = Dagger.affinity(x)
+    @test length(aff) == 1
+    @test aff[1][1] == Dagger.OSProc(myid())
+    @test aff[1][2] == sizeof(Int)*10
+end
+
+@testset "show_plan" begin
+    @test !isempty(Dagger.show_plan(Dagger.Thunk(()->10)))
+end

--- a/test/array.jl
+++ b/test/array.jl
@@ -53,6 +53,9 @@ end
     @test Distribute(Blocks(1,1), x) == x
     #test_dist(rand(100, 100))
     #test_dist(sprand(100, 100, 0.1))
+
+    x = distribute(rand(10), 2)
+    @test collect(distribute(x, 3)) == collect(x)
 end
 
 @testset "transpose" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,4 +5,5 @@ using Dagger
 
 include("domain.jl")
 include("array.jl")
+Dagger.cleanup()
 #include("cache.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,4 +5,4 @@ using Dagger
 
 include("domain.jl")
 include("array.jl")
-include("cache.jl")
+#include("cache.jl")


### PR DESCRIPTION
creating a PR to make this easy to review.

-----------------------------------
updating some details:

This makes the dag scheduler and executor a configurable module, with the existing implementation included as the default.

A scheduler/executor module must implement:
- `compute_dag(ctx, d::Dagger.Thunk)`: schedules the dag, waits for the top node (`d`) and returns its result
- `cleanup(ctx)`: cleans up any state/IPC before process exit


To switch to a different implementation, set the full module name that implements the above methods in the plugin config. E.g:
```
Dagger.PLUGIN_CONFIGS[:scheduler] = "MyCustomModule.MyScheduler"
```

Apart from that this PR also includes:
- Add the thunk or chunk id to the label when visualizing dag with `show_plan`
- Option not to use shared arrays (in array sort).
- Rollover thunk ids, limit them to 30bits. Need to rollover when processes are long running. And keeping the remaining bits for scheduler/executor to pass annotations around easily.
- Disable cache tests till it is reworked on. They fail at the moment (unrelated to this PR).
- Disables affinity propagation in array sort, which was setting specific affinities on dag nodes to get a uniform distribution of the result. Maybe distributing result should be a separate step.
- Avoids calling `compute` from worker processes. Workers are considered executors and master the scheduler.