### PR TITLE
fix darray chunk refcount to survive serialization

### DIFF
--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -119,9 +119,12 @@ end
 
 const refcount = Dict{MemPool.DRef, Int}()
 const refcountlck = ReentrantLock()
-addrefcount(r::DRef, x) = lock(refcountlck) do
+addrefcount(r::DRef, x) = remotecall_fetch(_addrefcount, r.owner, r, x)
+_addrefcount(r::DRef, x) = lock(refcountlck) do
     refcount[r] = get(refcount, r, 0) + x
 end
+
+
 
 Base.@deprecate_binding AbstractPart Union{Chunk, Thunk}
 Base.@deprecate_binding Part Chunk

--- a/test/array.jl
+++ b/test/array.jl
@@ -208,3 +208,12 @@ end
 @testset "show_plan" begin
     @test !isempty(Dagger.show_plan(Dagger.Thunk(()->10)))
 end
+
+@testset "darray distributed refcount" begin
+    D2 = remotecall_fetch(2, compute(Distribute(Blocks(10, 20), rand(40,40)))) do D
+        D2 = D
+    end
+    @test size(collect(D2)) == (40,40)
+    gc()
+    @test size(collect(D2)) == (40,40)
+end


### PR DESCRIPTION
This fixes #79.

Reasons for #79:
- Reference ounting for chunk needs to be done centrally. Isolated reference counting at each worker can lead to a case where one worker loses all refererences and tries to deallocate chunks while other workers are still holding references.
- Sending a DArray reference to a remote process can trigger a `free!` even before the other end has deserialized it.
- Finalizers are not re-established after a serialization - deserialization. (https://github.com/JuliaLang/julia/issues/16667)

This fixes that with:
- custom serializer that increments refcount before serialization
- custom deserializer that adds back the finalizer
- chunk reference counting is done at the origin of the chunk

This still does not address:
- multiple deserializations from the same serialized buffer
- overhead of RPC due to reference counting
- case where chunks can be serialized independently