### PR TITLE
import unrelease function for fire_task! function

### DIFF
--- a/src/scheduler.jl
+++ b/src/scheduler.jl
@@ -1,6 +1,6 @@
 module Sch
 
-import ..Dagger: Context, Thunk, Chunk, OSProc, order, free!, dependents, noffspring, istask, inputs, affinity, tochunk, _thunk_dict, @dbg, @logmsg, timespan_start, timespan_end
+import ..Dagger: Context, Thunk, Chunk, OSProc, order, free!, dependents, noffspring, istask, inputs, affinity, tochunk, _thunk_dict, @dbg, @logmsg, timespan_start, timespan_end, unrelease
 
 const OneToMany = Dict{Thunk, Set{Thunk}}
 struct ComputeState


### PR DESCRIPTION
The cache option is broken due to `unrelease` not being imported.  This PR fixes the issue.

Error from running the `cache.jl` test.
```
$ julia cache.jl 
cache: Error During Test
  Test threw an exception of type UndefVarError
  Expression: -s1 == collect(sum2)
  UndefVarError: unrelease not defined
  Stacktrace:
   [1] fire_task!(::Dagger.Context, ::Dagger.Thunk, ::Dagger.OSProc, ::Dagger.Sch.ComputeState, ::Channel{Any}, ::Function) at /Users/tomkwong/.julia/v0.6/Dagger/src/scheduler.jl:127
   [2] compute_dag(::Dagger.Context, ::Dagger.Thunk) at /Users/tomkwong/.julia/v0.6/Dagger/src/scheduler.jl:35
   [3] compute(::Dagger.Context, ::Dagger.Thunk) at /Users/tomkwong/.julia/v0.6/Dagger/src/compute.jl:26
   [4] collect(::Dagger.Thunk) at /Users/tomkwong/.julia/v0.6/Dagger/src/compute.jl:10
   [5] macro expansion at /Users/tomkwong/.julia/v0.6/Dagger/test/cache.jl:18 [inlined]
   [6] macro expansion at ./test.jl:860 [inlined]
   [7] anonymous at ./<missing>:?
cache: Error During Test
  Test threw an exception of type UndefVarError
  Expression: s1 == collect(sum1)
  UndefVarError: unrelease not defined
  Stacktrace:
   [1] fire_task!(::Dagger.Context, ::Dagger.Thunk, ::Dagger.OSProc, ::Dagger.Sch.ComputeState, ::Channel{Any}, ::Function) at /Users/tomkwong/.julia/v0.6/Dagger/src/scheduler.jl:127
   [2] compute_dag(::Dagger.Context, ::Dagger.Thunk) at /Users/tomkwong/.julia/v0.6/Dagger/src/scheduler.jl:35
   [3] compute(::Dagger.Context, ::Dagger.Thunk) at /Users/tomkwong/.julia/v0.6/Dagger/src/compute.jl:26
   [4] collect(::Dagger.Thunk) at /Users/tomkwong/.julia/v0.6/Dagger/src/compute.jl:10
   [5] macro expansion at /Users/tomkwong/.julia/v0.6/Dagger/test/cache.jl:19 [inlined]
   [6] macro expansion at ./test.jl:860 [inlined]
   [7] anonymous at ./<missing>:?
cache: Error During Test
  Test threw an exception of type UndefVarError
  Expression: -(collect(sum1)) == collect(sum2)
  UndefVarError: unrelease not defined
  Stacktrace:
   [1] fire_task!(::Dagger.Context, ::Dagger.Thunk, ::Dagger.OSProc, ::Dagger.Sch.ComputeState, ::Channel{Any}, ::Function) at /Users/tomkwong/.julia/v0.6/Dagger/src/scheduler.jl:127
   [2] compute_dag(::Dagger.Context, ::Dagger.Thunk) at /Users/tomkwong/.julia/v0.6/Dagger/src/scheduler.jl:35
   [3] compute(::Dagger.Context, ::Dagger.Thunk) at /Users/tomkwong/.julia/v0.6/Dagger/src/compute.jl:26
   [4] collect(::Dagger.Thunk) at /Users/tomkwong/.julia/v0.6/Dagger/src/compute.jl:10
   [5] macro expansion at /Users/tomkwong/.julia/v0.6/Dagger/test/cache.jl:20 [inlined]
   [6] macro expansion at ./test.jl:860 [inlined]
   [7] anonymous at ./<missing>:?
cache: Error During Test
  Test threw an exception of type UndefVarError
  Expression: s1 != collect(sum1)
  UndefVarError: unrelease not defined
  Stacktrace:
   [1] fire_task!(::Dagger.Context, ::Dagger.Thunk, ::Dagger.OSProc, ::Dagger.Sch.ComputeState, ::Channel{Any}, ::Function) at /Users/tomkwong/.julia/v0.6/Dagger/src/scheduler.jl:127
   [2] compute_dag(::Dagger.Context, ::Dagger.Thunk) at /Users/tomkwong/.julia/v0.6/Dagger/src/scheduler.jl:35
   [3] compute(::Dagger.Context, ::Dagger.Thunk) at /Users/tomkwong/.julia/v0.6/Dagger/src/compute.jl:26
   [4] collect(::Dagger.Thunk) at /Users/tomkwong/.julia/v0.6/Dagger/src/compute.jl:10
   [5] macro expansion at /Users/tomkwong/.julia/v0.6/Dagger/test/cache.jl:28 [inlined]
   [6] macro expansion at ./test.jl:860 [inlined]
   [7] anonymous at ./<missing>:?
cache: Error During Test
  Test threw an exception of type UndefVarError
  Expression: s2 != collect(sum2)
  UndefVarError: unrelease not defined
  Stacktrace:
   [1] fire_task!(::Dagger.Context, ::Dagger.Thunk, ::Dagger.OSProc, ::Dagger.Sch.ComputeState, ::Channel{Any}, ::Function) at /Users/tomkwong/.julia/v0.6/Dagger/src/scheduler.jl:127
   [2] compute_dag(::Dagger.Context, ::Dagger.Thunk) at /Users/tomkwong/.julia/v0.6/Dagger/src/scheduler.jl:35
   [3] compute(::Dagger.Context, ::Dagger.Thunk) at /Users/tomkwong/.julia/v0.6/Dagger/src/compute.jl:26
   [4] collect(::Dagger.Thunk) at /Users/tomkwong/.julia/v0.6/Dagger/src/compute.jl:10
   [5] macro expansion at /Users/tomkwong/.julia/v0.6/Dagger/test/cache.jl:29 [inlined]
   [6] macro expansion at ./test.jl:860 [inlined]
   [7] anonymous at ./<missing>:?
Test Summary: | Error  Total
cache         |     5      5
```