### PR TITLE
do not pass pid 1 as first pid to `check_same_host`

### DIFF
--- a/src/array/sort.jl
+++ b/src/array/sort.jl
@@ -120,9 +120,8 @@ end
 const use_shared_array = Ref(true)
 function _promote_array{T,S}(x::AbstractArray{T}, y::AbstractArray{S})
     Q = promote_type(T,S)
-    samehost = Distributed.check_same_host(procs())
     ok = (isa(x, Array) || isa(x, SharedArray)) && (isa(y, Array) || isa(y, SharedArray))
-    if use_shared_array[] && samehost && ok && isbits(Q)
+    if ok && isbits(Q) && use_shared_array[] && Distributed.check_same_host([workers()..., 1])
         return SharedArray{Q}(length(x)+length(y), pids=procs())
     else
         return similar(x, Q, length(x)+length(y))

--- a/test/array.jl
+++ b/test/array.jl
@@ -217,3 +217,11 @@ end
     gc()
     @test size(collect(D2)) == (40,40)
 end
+
+@testset "sharedarray" begin
+    A = SharedArray{Int}((1024,))
+    B = SharedArray{Int}((1024,))
+    C = Dagger.merge_sorted(Base.Order.Forward, A, B)
+    @test length(C) === length(A) + length(B)
+    @test typeof(C) === SharedArray{Int,1}
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,5 +5,7 @@ using Dagger
 
 include("domain.jl")
 include("array.jl")
+println(STDERR, "tests done. cleaning up...")
 Dagger.cleanup()
 #include("cache.jl")
+println(STDERR, "all done.")


### PR DESCRIPTION
Update for working around julialang issue https://github.com/JuliaLang/julia/issues/26699 when running across multiple machines.

Also reordered the `if` conditions to have the expensive part (`remotecall`) as the last one.