### PR TITLE
avoid stackoverflow in deserialize

### DIFF
--- a/test/array.jl
+++ b/test/array.jl
@@ -223,5 +223,5 @@ end
     B = SharedArray{Int}((1024,))
     C = Dagger.merge_sorted(Base.Order.Forward, A, B)
     @test length(C) === length(A) + length(B)
-    @test typeof(C) === SharedArray{Int,1}
+    @test typeof(C) === (Dagger.use_shared_array[] ? SharedArray{Int,1} : Array{Int64,1})
 end


### PR DESCRIPTION
Overriding deserialization of DArray introduced in #80 cause the below error:

```
xret = CapturedException(StackOverflowError(), Any[(deserialize(::SerializationState{IOStream}, ::Type{Dagger.DArray{Any,2,Base.#cat}}) at darray.jl:117, 100)])
DArray constructor: Error During Test
  Got an exception of type StackOverflowError outside of a @test
  StackOverflowError:
  Stacktrace:
   [1] deserialize(::SerializationState{IOStream}, ::Type{Dagger.DArray{Any,2,Base.#cat}}) at /home/tan/.julia/v0.6/Dagger/src/array/darray.jl:117 (repeats 20000 times)
```

Strangely the tests had passed then.

This is to avoid the stack overflow error. I did not find any other mechanism to invoke a specific method instance.

Also included a change in tests to have it pass when `Dagger.use_shared_array[] == false`.