### PR TITLE
Remove Logging from REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,3 @@ julia 0.6
 MemPool 0.0.11
 Compat 0.19
 StatsBase
-Logging


### PR DESCRIPTION
It looks like it isn't used anymore and I noticed that it can cause some trouble now that we also have a stdlib with the same name.