### PR TITLE
refactor: simplify map call

### DIFF
--- a/src/lib/util.jl
+++ b/src/lib/util.jl
@@ -90,7 +90,7 @@ macro unimplemented(expr)
     args = expr.args[2:end]
     sig = string(expr)
 
-    vars = map(x->getvarname(x), args)
+    vars = map(getvarname, args)
     typs = Expr(:vect, map(x -> :(typeof($x)), vars)...,)
 
 


### PR DESCRIPTION
A simple refactor based on the [style guide](https://docs.julialang.org/en/v1/manual/style-guide/#Do-not-write-x-f(x)-1).