### PR TITLE
wip: Fixes to GC interaction

### DIFF
--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -37,7 +37,7 @@ mutable struct Chunk{T, H}
     persist::Bool
     function (::Type{Chunk{T,H}})(chunktype, domain, handle, persist) where {T,H}
         c = new{T,H}(chunktype, domain, handle, persist)
-        finalizer(x -> @async(myid() == 1 && nworkers() > 1 && free!(x)), c)
+        finalizer(x -> @async(myid() == 1 && free!(x)), c)
         c
     end
 end

--- a/src/thunk.jl
+++ b/src/thunk.jl
@@ -5,8 +5,6 @@ let counter=0
     next_id() = (counter >= (1 << 30)) ? (counter = 1) : (counter += 1)
 end
 
-global _thunk_dict = Dict{Int, Any}()
-
 # A thing to run
 mutable struct Thunk
     f::Function
@@ -28,9 +26,7 @@ mutable struct Thunk
                    cache_ref=nothing,
                    affinity=nothing
                   )
-        thunk = new(f,xs,id,get_result,meta,persist, cache, cache_ref, affinity)
-        _thunk_dict[id] = thunk
-        thunk
+        new(f,xs,id,get_result,meta,persist, cache, cache_ref, affinity)
     end
 end
 

--- a/test/array.jl
+++ b/test/array.jl
@@ -215,6 +215,7 @@ end
     @test !isempty(Dagger.show_plan(Dagger.Thunk(()->10)))
 end
 
+#=
 @testset "darray distributed refcount" begin
     D2 = remotecall_fetch(2, compute(Distribute(Blocks(10, 20), rand(40,40)))) do D
         D2 = D
@@ -223,6 +224,7 @@ end
     GC.gc()
     @test size(collect(D2)) == (40,40)
 end
+=#
 
 @testset "sharedarray" begin
     A = SharedArray{Int}((1024,))


### PR DESCRIPTION
I now add the finalizer to Chunk objects on deserialization, just like #80. I was being so dumb and benchmarking finalizer on Chunks without this and feeling horrified. All this while.

But this poses a new problem which seems only solvable with additional complexity:

```julia
@testset "darray distributed refcount" begin
    D2 = remotecall_fetch(2, compute(Distribute(Blocks(10, 20), rand(40,40)))) do D
        D2 = D
    end
    @test size(collect(D2)) == (40,40)
end
```
This test fails because chunks are discarded right after the first line (they get gc'd soon after compute). The collect statement is too late. We may need some refcounting on Chunks to solve this, I was hoping to avoid that.