### PR TITLE
Import procs from Distributed and fix use of foldl

### DIFF
--- a/src/Dagger.jl
+++ b/src/Dagger.jl
@@ -3,6 +3,7 @@ module Dagger
 using Distributed, SharedArrays
 
 import Base: collect, adjoint, reduce
+import Distributed: procs
 
 using LinearAlgebra
 import LinearAlgebra: transpose

--- a/src/lib/logging.jl
+++ b/src/lib/logging.jl
@@ -196,7 +196,7 @@ function next_state(state::State, event::Event{:finish})
     state
 end
 next_state(state::State, events::AbstractArray) =
-    foldl(next_state, state, events)
+    foldl(next_state, events, init=state)
 
 # util
 


### PR DESCRIPTION
This seems to be sufficient to fix JuliaDB's `tracktime`. However, I'm not sure how to test this properly within Dagger.