### PR TITLE
a fix for julia 1.1

### DIFF
--- a/src/array/sort.jl
+++ b/src/array/sort.jl
@@ -327,7 +327,7 @@ function Base.sort(v::ArrayOp;
     nchunks = nchunks === nothing ? length(v1.chunks) : nchunks
     cs = dsort_chunks(v1.chunks, nchunks, nsamples,
                       order=ord, merge=(x,y)->merge_sorted(ord, x,y))
-    map(persist!, cs)
+    foreach(persist!, cs)
     t=delayed((xs...)->[xs...]; meta=true)(cs...)
     # `compute(t)` only computes references to materialized version of `cs`
     # we don't want the scheduler to think that `cs`s' job is done

--- a/src/scheduler.jl
+++ b/src/scheduler.jl
@@ -59,7 +59,7 @@ function compute_dag(ctx, d::Thunk)
 
         proc, thunk_id, res = take!(chan)
         if isa(res, CapturedException) || isa(res, RemoteException)
-            rethrow(res)
+            throw(res)
         end
         node = state.thunk_dict[thunk_id]
         @logmsg("WORKER $(proc.pid) - $node ($(node.f)) input:$(node.inputs)")


### PR DESCRIPTION
`rethrow` is no longer allowed outside a catch block. Also another small change I had.