### PR TITLE
Add fault tolerance to scheduler

### DIFF
--- a/src/fault-handler.jl
+++ b/src/fault-handler.jl
@@ -7,15 +7,6 @@ check_exited_exception(res::ProcessExitedException) = true
 check_exited_exception(res) = false
 
 function handle_fault(ctx, state, thunk, oldproc, chan, node_order)
-    #=
-    @debug "Pre-recovery State:"
-    @show state.ready
-    @show state.running
-    @show keys(state.cache)
-    @show state.waiting
-    @show state.waiting_data
-    =#
-
     # Find thunks whose results were cached on the dead worker
     deadlist = Thunk[thunk]
     thunk.cache = false
@@ -23,7 +14,6 @@ function handle_fault(ctx, state, thunk, oldproc, chan, node_order)
     for t in keys(state.cache)
         v = state.cache[t]
         if v isa Chunk && v.handle isa DRef && v.handle.owner == oldproc.pid
-            @debug "Found dead cached thunk to reschedule: $t"
             push!(deadlist, t)
             # Any inputs to dead cached thunks must be rescheduled
             function bfs!(deadlist, t)
@@ -36,8 +26,7 @@ function handle_fault(ctx, state, thunk, oldproc, chan, node_order)
             bfs!(deadlist, t)
         end
     end
-    #@debug "Deadlist: $deadlist"
-    # TODO: Find thunks who were actively running on the dead worker
+    # TODO: Find *all* thunks who were actively running on the dead worker
 
     # Empty cache of dead thunks
     for ct in keys(state.cache)
@@ -50,30 +39,22 @@ function handle_fault(ctx, state, thunk, oldproc, chan, node_order)
         waiting, waiting_data = state.waiting, state.waiting_data
         off = repeat(" ", offset)
         offi = repeat(" ", offset+1)
-        #@debug "$off Fixing $t"
         if !(t in keys(waiting))
-            #@debug "Not in waiting: $t"
             waiting[t] = Set{Thunk}()
         end
         if !isleaf
-            # If we aren't a leaf thunk, then we may still need to
-            # recover further into the DAG
-            #@debug "$off Begin fix inputs for $t: $(t.inputs)"
+            # If we aren't a leaf thunk, then we may still need to recover
+            # further into the DAG
             for input in t.inputs
-                #@debug "$offi istask input $input of $t: $(istask(input))"
                 istask(input) || continue
-                #@debug "$offi Add input to waiting for $t: $input"
-                #@show state.waiting
-                @assert haskey(waiting, t) "Error: $t not in waiting"
+                @assert haskey(waiting, t) "Error: $t not in state.waiting"
                 push!(waiting[t], input)
                 push!(waiting_data[input], t)
                 isleaf = !(input in deadlist)
                 fix_waitdicts!(state, deadlist, input; isleaf=isleaf, offset=offset+1)
             end
-            #@debug "$off End fix inputs for $t"
         end
         if isempty(waiting[t])
-            #@debug "Prune waiting: $t"
             delete!(waiting, t)
         end
     end
@@ -95,8 +76,6 @@ function handle_fault(ctx, state, thunk, oldproc, chan, node_order)
 
     # Remove dead thunks from state.running, and add state.running
     # deps back to state.waiting
-    # FIXME: If a thunk is actively running on a live node, it may
-    # fail during/after this recovery. Is that a problem?
     wasrunning = copy(state.running)
     empty!(state.running)
     while !isempty(wasrunning)
@@ -116,18 +95,9 @@ function handle_fault(ctx, state, thunk, oldproc, chan, node_order)
             end
             isempty(newtemp) || push!(state.running, newtemp)
         else
-            throw("Unexpected $temp")
+            throw("Unexpected type in recovery: $temp")
         end
     end
-
-    #=
-    @debug "Recovering State:"
-    @show state.ready
-    @show state.running
-    @show keys(state.cache)
-    @show state.waiting
-    @show state.waiting_data
-    =#
 
     # Reschedule inputs from deadlist
     newproc = OSProc(rand(workers()))
@@ -138,7 +108,6 @@ function handle_fault(ctx, state, thunk, oldproc, chan, node_order)
             push!(deadlist, dt)
             continue
         end
-        @debug "Re-scheduling $dt"
         fire_task!(ctx, dt, newproc, state, chan, node_order)
         break
     end

--- a/src/fault-handler.jl
+++ b/src/fault-handler.jl
@@ -1,0 +1,145 @@
+"Recursively checks if an exception was caused by a worker exiting."
+check_exited_exception(res::CapturedException) =
+    check_exited_exception(res.ex)
+check_exited_exception(res::RemoteException) =
+    check_exited_exception(res.captured)
+check_exited_exception(res::ProcessExitedException) = true
+check_exited_exception(res) = false
+
+function handle_fault(ctx, state, thunk, oldproc, chan, node_order)
+    #=
+    @debug "Pre-recovery State:"
+    @show state.ready
+    @show state.running
+    @show keys(state.cache)
+    @show state.waiting
+    @show state.waiting_data
+    =#
+
+    # Find thunks whose results were cached on the dead worker
+    deadlist = Thunk[thunk]
+    thunk.cache = false
+    thunk.cache_ref = nothing
+    for t in keys(state.cache)
+        v = state.cache[t]
+        if v isa Chunk && v.handle isa DRef && v.handle.owner == oldproc.pid
+            @debug "Found dead cached thunk to reschedule: $t"
+            push!(deadlist, t)
+            # Any inputs to dead cached thunks must be rescheduled
+            function bfs!(deadlist, t)
+                for input in t.inputs
+                    istask(input) || continue
+                    !(input in deadlist) && push!(deadlist, input)
+                    bfs!(deadlist, input)
+                end
+            end
+            bfs!(deadlist, t)
+        end
+    end
+    #@debug "Deadlist: $deadlist"
+    # TODO: Find thunks who were actively running on the dead worker
+
+    # Empty cache of dead thunks
+    for ct in keys(state.cache)
+        if ct in deadlist
+            delete!(state.cache, ct)
+        end
+    end
+
+    function fix_waitdicts!(state, deadlist, t::Thunk; isleaf=false, offset=0)
+        waiting, waiting_data = state.waiting, state.waiting_data
+        off = repeat(" ", offset)
+        offi = repeat(" ", offset+1)
+        #@debug "$off Fixing $t"
+        if !(t in keys(waiting))
+            #@debug "Not in waiting: $t"
+            waiting[t] = Set{Thunk}()
+        end
+        if !isleaf
+            # If we aren't a leaf thunk, then we may still need to
+            # recover further into the DAG
+            #@debug "$off Begin fix inputs for $t: $(t.inputs)"
+            for input in t.inputs
+                #@debug "$offi istask input $input of $t: $(istask(input))"
+                istask(input) || continue
+                #@debug "$offi Add input to waiting for $t: $input"
+                #@show state.waiting
+                @assert haskey(waiting, t) "Error: $t not in waiting"
+                push!(waiting[t], input)
+                push!(waiting_data[input], t)
+                isleaf = !(input in deadlist)
+                fix_waitdicts!(state, deadlist, input; isleaf=isleaf, offset=offset+1)
+            end
+            #@debug "$off End fix inputs for $t"
+        end
+        if isempty(waiting[t])
+            #@debug "Prune waiting: $t"
+            delete!(waiting, t)
+        end
+    end
+
+    # Add state.waiting deps back to state.waiting
+    for ot in keys(state.waiting)
+        fix_waitdicts!(state, deadlist, ot)
+    end
+
+    fix_waitdicts!(state, deadlist, thunk)
+
+    # Remove thunks from state.ready that have inputs on the deadlist
+    for idx in length(state.ready):-1:1
+        rt = state.ready[idx]
+        if any((input in deadlist) for input in rt.inputs)
+            deleteat!(state.ready, idx)
+        end
+    end
+
+    # Remove dead thunks from state.running, and add state.running
+    # deps back to state.waiting
+    # FIXME: If a thunk is actively running on a live node, it may
+    # fail during/after this recovery. Is that a problem?
+    wasrunning = copy(state.running)
+    empty!(state.running)
+    while !isempty(wasrunning)
+        temp = pop!(wasrunning)
+        if temp isa Thunk
+            if !(temp in deadlist)
+                push!(state.running, temp)
+            end
+            fix_waitdicts!(state, deadlist, temp)
+        elseif temp isa Vector
+            newtemp = []
+            for t in temp
+                fix_waitdicts!(state, deadlist, t)
+                if !(t in deadlist)
+                    push!(newtemp, t)
+                end
+            end
+            isempty(newtemp) || push!(state.running, newtemp)
+        else
+            throw("Unexpected $temp")
+        end
+    end
+
+    #=
+    @debug "Recovering State:"
+    @show state.ready
+    @show state.running
+    @show keys(state.cache)
+    @show state.waiting
+    @show state.waiting_data
+    =#
+
+    # Reschedule inputs from deadlist
+    newproc = OSProc(rand(workers()))
+    while length(deadlist) > 0
+        dt = popfirst!(deadlist)
+        if any((input in deadlist) for input in dt.inputs)
+            # We need to schedule our input thunks first
+            push!(deadlist, dt)
+            continue
+        end
+        @debug "Re-scheduling $dt"
+        fire_task!(ctx, dt, newproc, state, chan, node_order)
+        break
+    end
+end

--- a/src/scheduler.jl
+++ b/src/scheduler.jl
@@ -5,6 +5,8 @@ import MemPool: DRef
 
 import ..Dagger: Context, Thunk, Chunk, OSProc, order, free!, dependents, noffspring, istask, inputs, affinity, tochunk, @dbg, @logmsg, timespan_start, timespan_end, unrelease, procs
 
+include("fault-handler.jl")
+
 const OneToMany = Dict{Thunk, Set{Thunk}}
 struct ComputeState
     dependents::OneToMany
@@ -70,163 +72,16 @@ function compute_dag(ctx, d::Thunk; options=ComputeOptions())
             continue
         end
 
-        function check_exited_exception(res::CapturedException)
-            check_exited_exception(res.ex)
-        end
-        function check_exited_exception(res::RemoteException)
-            check_exited_exception(res.captured)
-        end
-        check_exited_exception(res::ProcessExitedException) = true
-        check_exited_exception(res) = false
-
         proc, thunk_id, res = take!(chan)
-        #@debug "Took thunk $thunk_id"
         if isa(res, CapturedException) || isa(res, RemoteException)
             if check_exited_exception(res)
                 @warn "Worker $(proc.pid) died on thunk $thunk_id, rescheduling work"
-                # TODO: showerror(res)
-                thunk = state.thunk_dict[thunk_id]
 
                 # Remove dead worker from procs list
                 filter!(p->p.pid!=proc.pid, ctx.procs)
                 ps = procs(ctx)
 
-                #=
-                @debug "Pre-recovery State:"
-                @show state.ready
-                @show state.running
-                @show keys(state.cache)
-                @show state.waiting
-                @show state.waiting_data
-                =#
-
-                # Find thunks whose results were cached on the dead worker
-                deadlist = Thunk[thunk]
-                thunk.cache = false
-                thunk.cache_ref = nothing
-                for t in keys(state.cache)
-                    v = state.cache[t]
-                    if v isa Chunk && v.handle isa DRef && v.handle.owner == proc.pid
-                        @warn "Found dead cached thunk to reschedule: $t"
-                        push!(deadlist, t)
-                        # Any inputs to dead cached thunks must be rescheduled
-                        function bfs!(deadlist, t)
-                            for input in t.inputs
-                                istask(input) || continue
-                                !(input in deadlist) && push!(deadlist, input)
-                                bfs!(deadlist, input)
-                            end
-                        end
-                        bfs!(deadlist, t)
-                    end
-                end
-                #@debug "Deadlist: $deadlist"
-                # TODO: Find thunks who were actively running on the dead worker
-
-                # Empty cache of dead thunks
-                for ct in keys(state.cache)
-                    if ct in deadlist
-                        delete!(state.cache, ct)
-                    end
-                end
-
-                function fix_waitdicts!(state, deadlist, t::Thunk; isleaf=false, offset=0)
-                    waiting, waiting_data = state.waiting, state.waiting_data
-                    off = repeat(" ", offset)
-                    offi = repeat(" ", offset+1)
-                    #@debug "$off Fixing $t"
-                    if !(t in keys(waiting))
-                        #@debug "Not in waiting: $t"
-                        waiting[t] = Set{Thunk}()
-                    end
-                    if !isleaf
-                        # If we aren't a leaf thunk, then we may still need to
-                        # recover further into the DAG
-                        #@debug "$off Begin fix inputs for $t: $(t.inputs)"
-                        for input in t.inputs
-                            #@debug "$offi istask input $input of $t: $(istask(input))"
-                            istask(input) || continue
-                            #@debug "$offi Add input to waiting for $t: $input"
-                            #@show state.waiting
-                            @assert haskey(waiting, t) "Error: $t not in waiting"
-                            push!(waiting[t], input)
-                            push!(waiting_data[input], t)
-                            isleaf = !(input in deadlist)
-                            fix_waitdicts!(state, deadlist, input; isleaf=isleaf, offset=offset+1)
-                        end
-                        #@debug "$off End fix inputs for $t"
-                    end
-                    if isempty(waiting[t])
-                        #@debug "Prune waiting: $t"
-                        delete!(waiting, t)
-                    end
-                end
-
-                # Add state.waiting deps back to state.waiting
-                for ot in keys(state.waiting)
-                    fix_waitdicts!(state, deadlist, ot)
-                end
-
-                fix_waitdicts!(state, deadlist, thunk)
-
-                # Remove thunks from state.ready that have inputs on the deadlist
-                for idx in length(state.ready):-1:1
-                    rt = state.ready[idx]
-                    if any((input in deadlist) for input in rt.inputs)
-                        deleteat!(state.ready, idx)
-                    end
-                end
-
-                # Remove dead thunks from state.running, and add state.running
-                # deps back to state.waiting
-                # FIXME: If a thunk is actively running on a live node, it may
-                # fail during/after this recovery. Is that a problem?
-                wasrunning = copy(state.running)
-                empty!(state.running)
-                while !isempty(wasrunning)
-                    temp = pop!(wasrunning)
-                    if temp isa Thunk
-                        if !(temp in deadlist)
-                            push!(state.running, temp)
-                        end
-                        fix_waitdicts!(state, deadlist, temp)
-                    elseif temp isa Vector
-                        newtemp = []
-                        for t in temp
-                            fix_waitdicts!(state, deadlist, t)
-                            if !(t in deadlist)
-                                push!(newtemp, t)
-                            end
-                        end
-                        isempty(newtemp) || push!(state.running, newtemp)
-                    else
-                        throw("Unexpected $temp")
-                    end
-                end
-
-                #=
-                @debug "Recovering State:"
-                @show state.ready
-                @show state.running
-                @show keys(state.cache)
-                @show state.waiting
-                @show state.waiting_data
-                =#
-
-                # Reschedule inputs from deadlist
-                newproc = OSProc(rand(workers()))
-                while length(deadlist) > 0
-                    dt = popfirst!(deadlist)
-                    if any((input in deadlist) for input in dt.inputs)
-                        # We need to schedule our input thunks first
-                        push!(deadlist, dt)
-                        continue
-                    end
-                    @warn "Re-scheduling $dt"
-                    fire_task!(ctx, dt, newproc, state, chan, node_order)
-                    break
-                end
-
+                handle_fault(ctx, state, state.thunk_dict[thunk_id], proc, chan, node_order)
                 continue
             else
                 throw(res)
@@ -236,21 +91,11 @@ function compute_dag(ctx, d::Thunk; options=ComputeOptions())
         @logmsg("WORKER $(proc.pid) - $node ($(node.f)) input:$(node.inputs)")
         state.cache[node] = res
 
-        #=
-        @debug "Normal State:"
-        @show state.ready
-        @show state.running
-        @show keys(state.cache)
-        @show state.waiting
-        @show state.waiting_data
-        =#
-
         @dbg timespan_start(ctx, :scheduler, thunk_id, master)
         immediate_next = finish_task!(state, node, node_order)
         if !isempty(state.ready)
             thunk = pop_with_affinity!(Context(ps), state.ready, proc, immediate_next)
             if thunk !== nothing
-                #@debug "End-firing $thunk"
                 fire_task!(ctx, thunk, proc, state, chan, node_order)
             end
         end

--- a/src/scheduler.jl
+++ b/src/scheduler.jl
@@ -1,6 +1,7 @@
 module Sch
 
 using Distributed
+import MemPool: DRef
 
 import ..Dagger: Context, Thunk, Chunk, OSProc, order, free!, dependents, noffspring, istask, inputs, affinity, tochunk, @dbg, @logmsg, timespan_start, timespan_end, unrelease, procs
 
@@ -54,7 +55,6 @@ function compute_dag(ctx, d::Thunk; options=ComputeOptions())
     @dbg timespan_end(ctx, :scheduler_init, 0, master)
 
     while !isempty(state.ready) || !isempty(state.running)
-
         if isempty(state.running) && !isempty(state.ready)
             for p in ps
                 isempty(state.ready) && break
@@ -70,19 +70,187 @@ function compute_dag(ctx, d::Thunk; options=ComputeOptions())
             continue
         end
 
+        function check_exited_exception(res::CapturedException)
+            check_exited_exception(res.ex)
+        end
+        function check_exited_exception(res::RemoteException)
+            check_exited_exception(res.captured)
+        end
+        check_exited_exception(res::ProcessExitedException) = true
+        check_exited_exception(res) = false
+
         proc, thunk_id, res = take!(chan)
+        #@debug "Took thunk $thunk_id"
         if isa(res, CapturedException) || isa(res, RemoteException)
-            throw(res)
+            if check_exited_exception(res)
+                @warn "Worker $(proc.pid) died on thunk $thunk_id, rescheduling work"
+                # TODO: showerror(res)
+                thunk = state.thunk_dict[thunk_id]
+
+                # Remove dead worker from procs list
+                filter!(p->p.pid!=proc.pid, ctx.procs)
+                ps = procs(ctx)
+
+                #=
+                @debug "Pre-recovery State:"
+                @show state.ready
+                @show state.running
+                @show keys(state.cache)
+                @show state.waiting
+                @show state.waiting_data
+                =#
+
+                # Find thunks whose results were cached on the dead worker
+                deadlist = Thunk[thunk]
+                thunk.cache = false
+                thunk.cache_ref = nothing
+                for t in keys(state.cache)
+                    v = state.cache[t]
+                    if v isa Chunk && v.handle isa DRef && v.handle.owner == proc.pid
+                        @warn "Found dead cached thunk to reschedule: $t"
+                        push!(deadlist, t)
+                        # Any inputs to dead cached thunks must be rescheduled
+                        function bfs!(deadlist, t)
+                            for input in t.inputs
+                                istask(input) || continue
+                                !(input in deadlist) && push!(deadlist, input)
+                                bfs!(deadlist, input)
+                            end
+                        end
+                        bfs!(deadlist, t)
+                    end
+                end
+                #@debug "Deadlist: $deadlist"
+                # TODO: Find thunks who were actively running on the dead worker
+
+                # Empty cache of dead thunks
+                for ct in keys(state.cache)
+                    if ct in deadlist
+                        delete!(state.cache, ct)
+                    end
+                end
+
+                function fix_waitdicts!(state, deadlist, t::Thunk; isleaf=false, offset=0)
+                    waiting, waiting_data = state.waiting, state.waiting_data
+                    off = repeat(" ", offset)
+                    offi = repeat(" ", offset+1)
+                    #@debug "$off Fixing $t"
+                    if !(t in keys(waiting))
+                        #@debug "Not in waiting: $t"
+                        waiting[t] = Set{Thunk}()
+                    end
+                    if !isleaf
+                        # If we aren't a leaf thunk, then we may still need to
+                        # recover further into the DAG
+                        #@debug "$off Begin fix inputs for $t: $(t.inputs)"
+                        for input in t.inputs
+                            #@debug "$offi istask input $input of $t: $(istask(input))"
+                            istask(input) || continue
+                            #@debug "$offi Add input to waiting for $t: $input"
+                            #@show state.waiting
+                            @assert haskey(waiting, t) "Error: $t not in waiting"
+                            push!(waiting[t], input)
+                            push!(waiting_data[input], t)
+                            isleaf = !(input in deadlist)
+                            fix_waitdicts!(state, deadlist, input; isleaf=isleaf, offset=offset+1)
+                        end
+                        #@debug "$off End fix inputs for $t"
+                    end
+                    if isempty(waiting[t])
+                        #@debug "Prune waiting: $t"
+                        delete!(waiting, t)
+                    end
+                end
+
+                # Add state.waiting deps back to state.waiting
+                for ot in keys(state.waiting)
+                    fix_waitdicts!(state, deadlist, ot)
+                end
+
+                fix_waitdicts!(state, deadlist, thunk)
+
+                # Remove thunks from state.ready that have inputs on the deadlist
+                for idx in length(state.ready):-1:1
+                    rt = state.ready[idx]
+                    if any((input in deadlist) for input in rt.inputs)
+                        deleteat!(state.ready, idx)
+                    end
+                end
+
+                # Remove dead thunks from state.running, and add state.running
+                # deps back to state.waiting
+                # FIXME: If a thunk is actively running on a live node, it may
+                # fail during/after this recovery. Is that a problem?
+                wasrunning = copy(state.running)
+                empty!(state.running)
+                while !isempty(wasrunning)
+                    temp = pop!(wasrunning)
+                    if temp isa Thunk
+                        if !(temp in deadlist)
+                            push!(state.running, temp)
+                        end
+                        fix_waitdicts!(state, deadlist, temp)
+                    elseif temp isa Vector
+                        newtemp = []
+                        for t in temp
+                            fix_waitdicts!(state, deadlist, t)
+                            if !(t in deadlist)
+                                push!(newtemp, t)
+                            end
+                        end
+                        isempty(newtemp) || push!(state.running, newtemp)
+                    else
+                        throw("Unexpected $temp")
+                    end
+                end
+
+                #=
+                @debug "Recovering State:"
+                @show state.ready
+                @show state.running
+                @show keys(state.cache)
+                @show state.waiting
+                @show state.waiting_data
+                =#
+
+                # Reschedule inputs from deadlist
+                newproc = OSProc(rand(workers()))
+                while length(deadlist) > 0
+                    dt = popfirst!(deadlist)
+                    if any((input in deadlist) for input in dt.inputs)
+                        # We need to schedule our input thunks first
+                        push!(deadlist, dt)
+                        continue
+                    end
+                    @warn "Re-scheduling $dt"
+                    fire_task!(ctx, dt, newproc, state, chan, node_order)
+                    break
+                end
+
+                continue
+            else
+                throw(res)
+            end
         end
         node = state.thunk_dict[thunk_id]
         @logmsg("WORKER $(proc.pid) - $node ($(node.f)) input:$(node.inputs)")
         state.cache[node] = res
+
+        #=
+        @debug "Normal State:"
+        @show state.ready
+        @show state.running
+        @show keys(state.cache)
+        @show state.waiting
+        @show state.waiting_data
+        =#
 
         @dbg timespan_start(ctx, :scheduler, thunk_id, master)
         immediate_next = finish_task!(state, node, node_order)
         if !isempty(state.ready)
             thunk = pop_with_affinity!(Context(ps), state.ready, proc, immediate_next)
             if thunk !== nothing
+                #@debug "End-firing $thunk"
                 fire_task!(ctx, thunk, proc, state, chan, node_order)
             end
         end

--- a/test/fault-tolerance.jl
+++ b/test/fault-tolerance.jl
@@ -1,0 +1,60 @@
+@testset "Fault tolerance" begin
+    function setup_funcs()
+        @everywhere begin
+            $(Expr(:using, Expr(Symbol("."), :Dagger)))
+            function kill_eager(x)
+                _x = x+1
+                sleep(1)
+
+                _x == 2 && myid() != 1 && exit(1)
+
+                return _x
+            end
+            kill_eager(x...) = sum(x)
+
+            kill_lazy(x) = x+1
+            function kill_lazy(x...)
+                _x = sum(x)
+                sleep(1)
+
+                _x == 6 && myid() != 1 && exit(1)
+
+                return _x
+            end
+        end
+    end
+
+    setup_funcs()
+    for kill_func in (kill_eager, kill_lazy)
+        a = delayed(kill_func)(1)
+        b = delayed(kill_func)(a)
+        c = delayed(kill_func)(a)
+        d = delayed(kill_func)(b, c)
+        @test collect(d) == 6
+
+        addprocs(2)
+        using Dagger
+        setup_funcs()
+
+        a = delayed(kill_func)(1)
+        b = delayed(kill_func)(delayed(kill_func)(a))
+        c = delayed(kill_func)(a, b)
+        @test collect(c) == 6
+
+        addprocs(2)
+        using Dagger
+        setup_funcs()
+
+        a1 = delayed(kill_func)(1)
+        a2 = delayed(kill_func)(1)
+        a3 = delayed(kill_func)(1)
+        b1 = delayed(kill_func)(a1, a2)
+        b2 = delayed(kill_func)(a2, a3)
+        c = delayed(kill_func)(b1, b2)
+        @test collect(c) == 8
+
+        addprocs(2)
+        using Dagger
+        setup_funcs()
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using Dagger
 include("domain.jl")
 include("array.jl")
 include("scheduler.jl")
+include("fault-tolerance.jl")
 println(stderr, "tests done. cleaning up...")
 Dagger.cleanup()
 #include("cache.jl")


### PR DESCRIPTION
When a worker is killed due to OS signals (such as the Linux OOM
killer), a ProcessExitedException is likely to be thrown to the head
node. When such an exception is detected, we reschedule the failed thunk
on a new, non-dead worker (randomly for now).

Todo:
- [x] Reschedule dependent thunks that were cached on the dead worker
- [x] Recursively reschedule all dependent inputs of dead thunks if not cached on a live worker
- [x] Fix various `KeyError`s due to not getting `state` just right...
- [x] Add some tests