### PR TITLE
Add configurable options to scheduler

### DIFF
--- a/src/array/darray.jl
+++ b/src/array/darray.jl
@@ -66,13 +66,13 @@ domain(x::AbstractArray) = ArrayDomain([1:l for l in size(x)])
 abstract type ArrayOp{T, N} <: AbstractArray{T, N} end
 Base.IndexStyle(::Type{<:ArrayOp}) = IndexCartesian()
 
-compute(ctx, x::ArrayOp) =
-    compute(ctx, cached_stage(ctx, x)::DArray)
+compute(ctx, x::ArrayOp; options=nothing) =
+    compute(ctx, cached_stage(ctx, x)::DArray; options=options)
 
-collect(ctx::Context, x::ArrayOp) =
-    collect(ctx, compute(ctx, x))
+collect(ctx::Context, x::ArrayOp; options=nothing) =
+    collect(ctx, compute(ctx, x); options=options)
 
-collect(x::ArrayOp) = collect(Context(), x)
+collect(x::ArrayOp; options=nothing) = collect(Context(), x; options=options)
 
 function Base.show(io::IO, ::MIME"text/plain", x::ArrayOp)
     write(io, string(typeof(x)))
@@ -148,8 +148,8 @@ domainchunks(d::DArray) = d.subdomains
 size(x::DArray) = size(domain(x))
 stage(ctx, c::DArray) = c
 
-function collect(ctx::Context, d::DArray; tree=false)
-    a = compute(ctx, d)
+function collect(ctx::Context, d::DArray; tree=false, options=nothing)
+    a = compute(ctx, d; options=options)
 
     if isempty(d.chunks)
         return Array{eltype(d)}(undef, size(d)...)
@@ -237,10 +237,10 @@ end
 A DArray object may contain a thunk in it, in which case
 we first turn it into a Thunk object and then compute it.
 """
-function compute(ctx, x::DArray; persist=true)
+function compute(ctx, x::DArray; persist=true, options=nothing)
     thunk = thunkize(ctx, x, persist=persist)
     if isa(thunk, Thunk)
-        compute(ctx, thunk)
+        compute(ctx, thunk; options=options)
     else
         x
     end

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -64,14 +64,14 @@ function unrelease(c::Chunk{T,DRef}) where T
 end
 unrelease(c::Chunk) = c
 
-function collect(ctx::Context, chunk::Chunk)
+function collect(ctx::Context, chunk::Chunk; kwargs...)
     # delegate fetching to handle by default.
     collect(ctx, chunk.handle)
 end
 
 
 ### ChunkIO
-function collect(ctx::Context, ref::Union{DRef, FileRef})
+function collect(ctx::Context, ref::Union{DRef, FileRef}; kwargs...)
     poolget(ref)
 end
 affinity(r::DRef) = Pair{OSProc, UInt64}[OSProc(r.owner) => r.size]

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -64,14 +64,14 @@ function unrelease(c::Chunk{T,DRef}) where T
 end
 unrelease(c::Chunk) = c
 
-function collect(ctx::Context, chunk::Chunk; kwargs...)
+function collect(ctx::Context, chunk::Chunk; options=nothing)
     # delegate fetching to handle by default.
     collect(ctx, chunk.handle)
 end
 
 
 ### ChunkIO
-function collect(ctx::Context, ref::Union{DRef, FileRef}; kwargs...)
+function collect(ctx::Context, ref::Union{DRef, FileRef}; options=nothing)
     poolget(ref)
 end
 affinity(r::DRef) = Pair{OSProc, UInt64}[OSProc(r.owner) => r.size]

--- a/src/compute.jl
+++ b/src/compute.jl
@@ -2,38 +2,38 @@ export stage, cached_stage, compute, debug_compute, free!, cleanup
 
 ###### Scheduler #######
 
-compute(x) = compute(Context(), x)
-compute(ctx, c::Chunk) = c
+compute(x; kwargs...) = compute(Context(), x; kwargs...)
+compute(ctx, c::Chunk; kwags...) = c
 
-collect(ctx::Context, c) = collect(ctx, compute(ctx, c))
-collect(d::Union{Chunk,Thunk}) = collect(Context(), d)
+collect(ctx::Context, c; kwargs...) = collect(ctx, compute(ctx, c); kwargs...)
+collect(d::Union{Chunk,Thunk}; kwargs...) = collect(Context(), d; kwargs...)
 
 abstract type Computation end
 
-compute(ctx, c::Computation) = compute(ctx, stage(ctx, c))
-collect(c::Computation) = collect(Context(), c)
+compute(ctx, c::Computation; kwargs...) = compute(ctx, stage(ctx, c); kwargs...)
+collect(c::Computation; kwargs...) = collect(Context(), c; kwargs...)
 
 """
-Compute a Thunk - creates the DAG, assigns ranks to
-nodes for tie breaking and runs the scheduler.
+Compute a Thunk - creates the DAG, assigns ranks to nodes for tie breaking and
+runs the scheduler with the specified options.
 """
-function compute(ctx, d::Thunk)
+function compute(ctx, d::Thunk; kwargs...)
     if !(:scheduler in keys(PLUGINS))
         PLUGINS[:scheduler] = get_type(PLUGIN_CONFIGS[:scheduler])
     end
     scheduler = PLUGINS[:scheduler]
-    (scheduler).compute_dag(ctx, d)
+    (scheduler).compute_dag(ctx, d; kwargs...)
 end
 
-function debug_compute(ctx::Context, args...; profile=false)
-    @time res = compute(ctx, args...)
+function debug_compute(ctx::Context, args...; profile=false, kwargs...)
+    @time res = compute(ctx, args...; kwargs...)
     get_logs!(ctx.log_sink), res
 end
 
-function debug_compute(arg; profile=false)
+function debug_compute(arg; profile=false, kwargs...)
     ctx = Context()
     dbgctx = Context(procs(ctx), LocalEventLog(), profile)
-    debug_compute(dbgctx, arg)
+    debug_compute(dbgctx, arg; kwargs...)
 end
 
 Base.@deprecate gather(ctx, x) collect(ctx, x)

--- a/src/compute.jl
+++ b/src/compute.jl
@@ -3,9 +3,9 @@ export stage, cached_stage, compute, debug_compute, free!, cleanup
 ###### Scheduler #######
 
 compute(x; kwargs...) = compute(Context(), x; kwargs...)
-compute(ctx, c::Chunk; kwags...) = c
+compute(ctx, c::Chunk; kwargs...) = c
 
-collect(ctx::Context, c; kwargs...) = collect(ctx, compute(ctx, c); kwargs...)
+collect(ctx::Context, t::Thunk; kwargs...) = collect(ctx, compute(ctx, t; kwargs...); kwargs...)
 collect(d::Union{Chunk,Thunk}; kwargs...) = collect(Context(), d; kwargs...)
 
 abstract type Computation end

--- a/src/scheduler.jl
+++ b/src/scheduler.jl
@@ -19,7 +19,7 @@ end
 function cleanup(ctx)
 end
 
-function compute_dag(ctx, d::Thunk)
+function compute_dag(ctx, d::Thunk; kwargs...)
     master = OSProc(myid())
     @dbg timespan_start(ctx, :scheduler_init, 0, master)
 

--- a/src/scheduler.jl
+++ b/src/scheduler.jl
@@ -16,16 +16,24 @@ struct ComputeState
     thunk_dict::Dict{Int, Any}
 end
 
+struct ComputeOptions
+    single::Int
+end
+ComputeOptions() = ComputeOptions(0)
+
 function cleanup(ctx)
 end
 
-function compute_dag(ctx, d::Thunk; single=nothing)
+function compute_dag(ctx, d::Thunk; options=ComputeOptions())
+    if options === nothing
+        options = ComputeOptions()
+    end
     master = OSProc(myid())
     @dbg timespan_start(ctx, :scheduler_init, 0, master)
 
-    if single !== nothing
-        @assert single in vcat(1, workers()) "Sch option 'single' must specify an active worker id"
-        ps = OSProc[OSProc(single)]
+    if options.single !== 0
+        @assert options.single in vcat(1, workers()) "Sch option 'single' must specify an active worker id"
+        ps = OSProc[OSProc(options.single)]
     else
         ps = procs(ctx)
     end

--- a/src/scheduler.jl
+++ b/src/scheduler.jl
@@ -19,11 +19,16 @@ end
 function cleanup(ctx)
 end
 
-function compute_dag(ctx, d::Thunk; kwargs...)
+function compute_dag(ctx, d::Thunk; single=nothing)
     master = OSProc(myid())
     @dbg timespan_start(ctx, :scheduler_init, 0, master)
 
-    ps = procs(ctx)
+    if single !== nothing
+        @assert single in vcat(1, workers()) "Sch option 'single' must specify an active worker id"
+        ps = OSProc[OSProc(single)]
+    else
+        ps = procs(ctx)
+    end
     chan = Channel{Any}(32)
     deps = dependents(d)
     ord = order(d, noffspring(deps))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ using Dagger
 
 include("domain.jl")
 include("array.jl")
+include("scheduler.jl")
 println(stderr, "tests done. cleaning up...")
 Dagger.cleanup()
 #include("cache.jl")

--- a/test/scheduler.jl
+++ b/test/scheduler.jl
@@ -4,8 +4,15 @@
 function inc(x)
     x+1
 end
+@everywhere begin
+function checkwid(x...)
+    @assert myid() == 2
+    return 1
+end
+end
 
 @testset "Scheduler" begin
+    #=
     @testset "order" begin
         @par begin
             a = 1
@@ -42,6 +49,14 @@ end
         @test order([d], noffspring(deps)) == Dict(d=>1, c=>3, b=>2, a=>4)
 
         @test compute(Context(), d) == 4
+    end
+    =#
+    @testset "single worker" begin
+        a = delayed(checkwid)(1)
+        b = delayed(checkwid)(2)
+        c = delayed(checkwid)(a,b)
+
+        @test collect(Context(), c; single=2) == 1
     end
 end
 

--- a/test/scheduler.jl
+++ b/test/scheduler.jl
@@ -1,6 +1,8 @@
 
 #### test set 2 begin
 
+import Dagger.Sch: ComputeOptions
+
 function inc(x)
     x+1
 end
@@ -56,7 +58,7 @@ end
         b = delayed(checkwid)(2)
         c = delayed(checkwid)(a,b)
 
-        @test collect(Context(), c; single=2) == 1
+        @test collect(Context(), c; options=ComputeOptions(2)) == 1
     end
 end
 


### PR DESCRIPTION
This PR allows the scheduler to take options as keyword args. To start with, I'm adding an option called "single" which forces all work onto a single worker (master or a specific worker) by worker id.