### PR TITLE
Add Thunk options

### DIFF
--- a/src/thunk.jl
+++ b/src/thunk.jl
@@ -17,6 +17,7 @@ mutable struct Thunk
                   # cache it
     cache_ref::Any
     affinity::Union{Nothing, Vector{Pair{OSProc, Int}}}
+    options::Any # stores scheduler-specific options
     function Thunk(f, xs...;
                    id::Int=next_id(),
                    get_result::Bool=false,
@@ -24,9 +25,10 @@ mutable struct Thunk
                    persist::Bool=false,
                    cache::Bool=false,
                    cache_ref=nothing,
-                   affinity=nothing
+                   affinity=nothing,
+                   options=nothing
                   )
-        new(f,xs,id,get_result,meta,persist, cache, cache_ref, affinity)
+        new(f,xs,id,get_result,meta,persist, cache, cache_ref, affinity, options)
     end
 end
 

--- a/test/scheduler.jl
+++ b/test/scheduler.jl
@@ -1,64 +1,27 @@
-
-#### test set 2 begin
-
-import Dagger.Sch: ComputeOptions
+import Dagger.Sch: SchedulerOptions, ThunkOptions
 
 function inc(x)
     x+1
 end
 @everywhere begin
 function checkwid(x...)
-    @assert myid() == 2
+    @assert myid() == 1
     return 1
 end
 end
 
 @testset "Scheduler" begin
-    #=
-    @testset "order" begin
-        @par begin
-            a = 1
-            b = inc(a)
-            c = inc(b)
-        end
-
-        deps = dependents(c)
-        @test deps == Dict(a => Set([b]), b => Set([c]), c=>Set())
-        @test noffspring(deps) == Dict(a=>2, b=>1, c=>0)
-        @test order([c], noffspring(deps)) == Dict(a => 3, b => 2, c => 1)
-    end
-    @testset begin
-        @par begin
-            a = 1
-            b = 2
-            c = inc(a)
-            d = b+c
-        end
-        deps = dependents(d)
-        @test noffspring(deps) == Dict(a => 2, b => 1, c => 1, d => 0)
-        @test order([d], noffspring(deps)) == Dict(d=>1, c=>3, b=>2, a=>4)
-    end
-    @testset "simple compute" begin
-        @par begin
-            a = 1
-            b = 2
-            c = inc(a)
-            d = b+c
-        end
-
-        deps = dependents(d)
-        @test noffspring(deps) == Dict(a => 2, b => 1, c => 1, d => 0)
-        @test order([d], noffspring(deps)) == Dict(d=>1, c=>3, b=>2, a=>4)
-
-        @test compute(Context(), d) == 4
-    end
-    =#
-    @testset "single worker" begin
+    @testset "Scheduler options: single worker" begin
         a = delayed(checkwid)(1)
         b = delayed(checkwid)(2)
         c = delayed(checkwid)(a,b)
 
-        @test collect(Context(), c; options=ComputeOptions(2)) == 1
+        @test collect(Context(), c; options=SchedulerOptions(1)) == 1
+    end
+    @testset "Thunk options: single worker" begin
+        options = ThunkOptions(1)
+        a = delayed(checkwid; options=options)(1)
+
+        @test collect(Context(), a) == 1
     end
 end
-


### PR DESCRIPTION
- Adds `options` kwarg and field to Thunk
- Adds ThunkOptions to Dagger.Sch
- Renames ComputeOptions to SchedulerOptions to improve clarity
- Added docstrings for both option structs
- Added Thunk options test, changed both options tests `single` to master

I also removed the old tests to address #99, if that's desired.