### PR TITLE
Threading trick!

### DIFF
--- a/src/processor.jl
+++ b/src/processor.jl
@@ -17,10 +17,11 @@ mutable struct Context
     procs::Array{OSProc}
     log_sink::Any
     profile::Bool
+    options
 end
 
 function Context(xs)
-    Context(xs, NoOpLog(), false) # By default don't log events
+    Context(xs, NoOpLog(), false, nothing) # By default don't log events
 end
 Context(xs::Array{Int}) = Context(map(OSProc, xs))
 Context(;nthreads=Threads.nthreads()) = Context([workers() for i=1:nthreads] |> Iterators.flatten |> collect)

--- a/src/processor.jl
+++ b/src/processor.jl
@@ -23,7 +23,7 @@ function Context(xs)
     Context(xs, NoOpLog(), false) # By default don't log events
 end
 Context(xs::Array{Int}) = Context(map(OSProc, xs))
-Context() = Context(workers())
+Context(;nthreads=Threads.nthreads()) = Context([workers() for i=1:nthreads] |> Iterators.flatten |> collect)
 procs(c::Context) = c.procs
 
 """

--- a/src/scheduler.jl
+++ b/src/scheduler.jl
@@ -307,8 +307,12 @@ _move(ctx, to_proc::OSProc, x::Union{Chunk, Thunk}) = collect(ctx, x)
     result_meta = try
         use_threads = (ctx.options !== nothing && ctx.options.threads) ||
                       (options !== nothing && options.threads)
-        if @static VERSION >= v"1.3.0-DEV.573" ? use_threads : false
-            res = fetch(Threads.@spawn f(fetched...))
+        if use_threads
+            @static if VERSION >= v"1.3.0-DEV.573"
+                res = fetch(Threads.@spawn f(fetched...))
+            else
+                res = f(fetched...)
+            end
         else
             res = f(fetched...)
         end

--- a/src/scheduler.jl
+++ b/src/scheduler.jl
@@ -302,7 +302,11 @@ _move(ctx, to_proc::OSProc, x::Union{Chunk, Thunk}) = collect(ctx, x)
 
     @dbg timespan_start(ctx, :compute, thunk_id, proc)
     result_meta = try
-        res = fetch(Threads.@spawn f(fetched...))
+        @static if VERSION >= v"1.3.0-DEV.573"
+            res = fetch(Threads.@spawn f(fetched...))
+        else
+            res = f(fetched...)
+        end
         (proc, thunk_id, send_result ? res : tochunk(res, persist=persist, cache=persist ? true : cache)) #todo: add more metadata
     catch ex
         bt = catch_backtrace()

--- a/src/scheduler.jl
+++ b/src/scheduler.jl
@@ -302,7 +302,7 @@ _move(ctx, to_proc::OSProc, x::Union{Chunk, Thunk}) = collect(ctx, x)
 
     @dbg timespan_start(ctx, :compute, thunk_id, proc)
     result_meta = try
-        res = f(fetched...)
+        res = fetch(Threads.@spawn f(fetched...))
         (proc, thunk_id, send_result ? res : tochunk(res, persist=persist, cache=persist ? true : cache)) #todo: add more metadata
     catch ex
         bt = catch_backtrace()

--- a/test/scheduler.jl
+++ b/test/scheduler.jl
@@ -8,20 +8,41 @@ function checkwid(x...)
     @assert myid() == 1
     return 1
 end
+function checktid(x...)
+    @assert Threads.threadid() != 1
+    return 1
+end
 end
 
 @testset "Scheduler" begin
     @testset "Scheduler options: single worker" begin
+        options = SchedulerOptions(;single=1)
         a = delayed(checkwid)(1)
         b = delayed(checkwid)(2)
         c = delayed(checkwid)(a,b)
 
-        @test collect(Context(), c; options=SchedulerOptions(1)) == 1
+        @test collect(Context(), c; options=options) == 1
     end
     @testset "Thunk options: single worker" begin
-        options = ThunkOptions(1)
+        options = ThunkOptions(;single=1)
         a = delayed(checkwid; options=options)(1)
 
         @test collect(Context(), a) == 1
+    end
+    @static if VERSION >= v"1.3.0-DEV.573"
+        @testset "Scheduler options: threads" begin
+            options = SchedulerOptions(;threads=true)
+            a = delayed(checktid)(1)
+            b = delayed(checktid)(2)
+            c = delayed(checktid)(a,b)
+
+            @test collect(Context(), c; options=options) == 1
+        end
+        @testset "Thunk options: threads" begin
+            options = ThunkOptions(;threads=true)
+            a = delayed(checktid; options=options)(1)
+
+            @test collect(Context(), a) == 1
+        end
     end
 end

--- a/test/scheduler.jl
+++ b/test/scheduler.jl
@@ -9,7 +9,7 @@ function checkwid(x...)
     return 1
 end
 function checktid(x...)
-    @assert Threads.threadid() != 1
+    @assert Threads.threadid() != 1 || Threads.nthreads() == 1
     return 1
 end
 end
@@ -30,6 +30,9 @@ end
         @test collect(Context(), a) == 1
     end
     @static if VERSION >= v"1.3.0-DEV.573"
+        if Threads.nthreads() == 1
+            @warn "Threading tests running in serial"
+        end
         @testset "Scheduler options: threads" begin
             options = SchedulerOptions(;threads=true)
             a = delayed(checktid)(1)


### PR DESCRIPTION
1. Spawn `Threads.@spawn f(x...)` instead of `f(x...)` where `x` is the "fetched" data.
2. repeat every process as many times as nthreads() -- causing Dagger to oversubscribe each worker processors as many times as the threads. TOOD: actually get nthreads from each worker rather than using the value on the master process

By @shashi 

Will need to be adjusted so that pre-MT julia still works, and to make this an opt-in feature for now.