### PR TITLE
Add dynamic scheduler control

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Dagger"
 uuid = "d58978e5-989f-55fb-8d15-ea34adc7bf54"
-version = "0.10.1"
+version = "0.10.2"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,6 +16,7 @@ makedocs(;
         "Processors" => "processors.md",
         "Scheduler Internals" => "scheduler-internals.md",
         "Logging and Graphing" => "logging.md",
+        "Dynamic Scheduler Control" => "dynamic.md",
     ]
 )
 

--- a/docs/src/dynamic.md
+++ b/docs/src/dynamic.md
@@ -1,0 +1,54 @@
+# Dynamic Scheduler Control
+
+Normally, Dagger executes static graphs defined with `delayed` and `@par`.
+However, it is possible for thunks to dynamically modify the graph at runtime,
+and to generally exert direct control over the scheduler's internal state. The
+`Dagger.sch_handle` function provides this functionality within a thunk:
+
+```julia
+function mythunk(x)
+    h = Dagger.sch_handle()
+    Dagger.halt!(h)
+    return x
+end
+```
+
+The above example prematurely halts a running scheduler at the next
+opportunity using `Dagger.halt!`:
+
+[`Dagger.halt!`](@ref)
+
+There are a variety of other built-in functions available for
+various uses:
+
+[`Dagger.get_dag_ids`](@ref)
+[`Dagger.add_thunk!`](@ref)
+
+When working with thunks acquired from `get_dag_ids` or `add_thunk!`,
+you will have `ThunkID` objects which refer to a thunk by ID. Scheduler
+control functions which work with thunks accept or return `ThunkID`s. For
+example, one can create a new thunkt and get its result with `Base.fetch`:
+
+```julia
+function mythunk(x)
+    h = Dagger.sch_handle()
+    id = Dagger.add_thunk!(h, x) do y
+        y + 1
+    end
+    return fetch(h, id)
+end
+```
+
+Alternatively, `Base.wait` can be used when one does not wish to retrieve the
+returned value of the thunk.
+
+Users with needs not covered by the built-in functions should use the
+`Dagger.exec!` function to pass a user-defined function, closure, or
+callable struct to the scheduler, along with a payload which will be
+provided to that function:
+
+[`Dagger.exec!`](@ref)
+
+Note that all functions called by `Dagger.exec!` take the scheduler's internal
+lock, so it's safe to manipulate the internal `ComputeState` object within the
+user-provided function.

--- a/src/Dagger.jl
+++ b/src/Dagger.jl
@@ -23,7 +23,7 @@ include("chunks.jl")
 
 # Task scheduling
 include("compute.jl")
-include("scheduler.jl")
+include("sch/Sch.jl"); using .Sch
 
 # Array computations
 include("array/darray.jl")

--- a/src/processor.jl
+++ b/src/processor.jl
@@ -188,10 +188,14 @@ iscompatible_arg(proc::ThreadProc, opts, x) = true
         end
         try
             fetch(task)
-        catch TaskFailedException
-            stk = Base.catch_stack(task)
-            err, frames = stk[1]
-            rethrow(CapturedException(err, frames))
+        catch err
+            @static if VERSION >= v"1.1"
+                stk = Base.catch_stack(task)
+                err, frames = stk[1]
+                rethrow(CapturedException(err, frames))
+            else
+                rethrow(task.result)
+            end
         end
     end
 else
@@ -205,10 +209,14 @@ else
         end
         try
             fetch(task)
-        catch TaskFailedException
-            stk = Base.catch_stack(task)
-            err, frames = stk[1]
-            rethrow(CapturedException(err, frames))
+        catch err
+            @static if VERSION >= v"1.1"
+                stk = Base.catch_stack(task)
+                err, frames = stk[1]
+                rethrow(CapturedException(err, frames))
+            else
+                rethrow(task.result)
+            end
         end
     end
 end

--- a/src/sch/dynamic.jl
+++ b/src/sch/dynamic.jl
@@ -1,0 +1,150 @@
+export SchedulerHaltedException
+export sch_handle, halt!, exec!, get_dag_ids, add_thunk!
+
+"Identifies a thunk by its ID."
+struct ThunkID
+    id::Int
+end
+
+"A handle to the scheduler, used by dynamic thunks."
+struct SchedulerHandle
+    thunk_id::ThunkID
+    out_chan::RemoteChannel
+    inp_chan::RemoteChannel
+end
+
+"Gets the scheduler handle for the currently-executing thunk."
+sch_handle() = task_local_storage(:sch_handle)::SchedulerHandle
+
+"Thrown when the scheduler halts before finishing processing the DAG."
+struct SchedulerHaltedException <: Exception end
+
+function safepoint(state)
+    if state.halt[]
+        # Force dynamic thunks and listeners to terminate
+        for (inp_chan,out_chan) in values(state.worker_chans)
+            close(inp_chan)
+            close(out_chan)
+        end
+        # Throw out of scheduler
+        throw(SchedulerHaltedException())
+    end
+end
+
+"Processes dynamic messages from worker-executing thunks."
+function dynamic_listener!(ctx, state)
+    task = current_task()
+    for tid in keys(state.worker_chans)
+        inp_chan, out_chan = state.worker_chans[tid]
+        @async begin
+            while isopen(inp_chan)
+                tid, f, data = try
+                    take!(inp_chan)
+                catch err
+                    if !(unwrap_nested_exception(err) isa Union{SchedulerHaltedException,
+                                                                ProcessExitedException,
+                                                                InvalidStateException})
+                        @error exception=(err,catch_backtrace())
+                    end
+                    break
+                end
+                res = try
+                    (false, lock(state.lock) do
+                        Base.invokelatest(f, ctx, state, task, tid, data)
+                    end)
+                catch err
+                    (true, RemoteException(CapturedException(err,catch_backtrace())))
+                end
+                try
+                    put!(out_chan, res)
+                catch err
+                    if !(unwrap_nested_exception(err) isa Union{SchedulerHaltedException,
+                                                                ProcessExitedException,
+                                                                InvalidStateException})
+                        @error exception=(err,catch_backtrace())
+                    end
+                end
+            end
+        end
+    end
+end
+
+## Worker-side methods for dynamic communication
+
+"Executes an arbitrary function within the scheduler, returning the result."
+function exec!(f, h::SchedulerHandle, args...)
+    put!(h.out_chan, (h.thunk_id.id, f, args))
+    failed, res = take!(h.inp_chan)
+    failed && throw(res)
+    res
+end
+
+"Commands the scheduler to halt execution immediately."
+halt!(h::SchedulerHandle) = exec!(_halt, h, nothing)
+function _halt(ctx, state, task, tid, _)
+    state.halt[] = true
+    Base.throwto(task, SchedulerHaltedException())
+end
+
+"Waits on a thunk to complete, and fetches its result."
+function Base.fetch(h::SchedulerHandle, id::ThunkID)
+    future = Future(1)
+    exec!(_fetch, h, future, id.id)
+    move(thunk_processor(), fetch(future))
+end
+function _fetch(ctx, state, task, tid, (future, id))
+    @assert tid != id "Cannot fetch own result"
+    thunk = state.thunk_dict[id]
+    ownthunk = state.thunk_dict[tid]
+    dominates(target, t) = (t == target) || any(_t->dominates(target, _t), filter(istask, t.inputs))
+    @assert !dominates(ownthunk, thunk) "Cannot fetch result of dominated thunk"
+    if thunk in state.finished
+        if haskey(state.cache, thunk)
+            put!(future, state.cache[thunk])
+        else
+            put!(future, nothing)
+        end
+    else
+        futures = get!(()->Future[], state.futures, thunk)
+        push!(futures, future)
+        schedule!(ctx, state)
+    end
+    nothing
+end
+
+# TODO: Optimize wait() to not serialize a Chunk
+"Waits on a thunk to complete."
+function Base.wait(h::SchedulerHandle, id::ThunkID)
+    future = Future(1)
+    exec!(_fetch, h, future, id.id)
+    wait(future)
+end
+
+"Returns all Thunks IDs as a Dict, mapping a Thunk to its downstream dependents."
+get_dag_ids(h::SchedulerHandle) =
+    exec!(_get_dag_ids, h, nothing)::Dict{ThunkID,Set{ThunkID}}
+function _get_dag_ids(ctx, state, task, tid, _)
+    deps = Dict{ThunkID,Set{ThunkID}}()
+    for (key,val) in state.dependents
+        deps[ThunkID(key.id)] = Set(map(t->ThunkID(t.id), collect(val)))
+    end
+    deps
+end
+
+"Adds a new Thunk to the DAG."
+add_thunk!(f, h::SchedulerHandle, args...; kwargs...) =
+    ThunkID(exec!(_add_thunk!, h, f, args, kwargs)::Int)
+function _add_thunk!(ctx, state, task, tid, (f, args, kwargs))
+    _args = map(arg->arg isa ThunkID ? state.thunk_dict[arg.id] : arg, args)
+    thunk = Thunk(f, _args...; kwargs...)
+    lock(state.lock) do
+        state.thunk_dict[thunk.id] = thunk
+        state.dependents[thunk] = Set{Thunk}()
+        reschedule_inputs!(state, thunk)
+        if isempty(state.waiting[thunk])
+            push!(state.ready, thunk)
+        end
+        schedule!(ctx, state)
+    end
+    return thunk.id
+end

--- a/src/sch/fault-handler.jl
+++ b/src/sch/fault-handler.jl
@@ -1,17 +1,4 @@
 """
-    check_exited_exception(res::Exception) -> Bool
-
-Recursively checks if an exception was caused by a worker exiting.
-"""
-check_exited_exception(res::CapturedException) =
-    check_exited_exception(res.ex)
-check_exited_exception(res::RemoteException) =
-    check_exited_exception(res.captured)
-check_exited_exception(res::ProcessExitedException) = true
-check_exited_exception(res::Base.IOError) = true
-check_exited_exception(res) = false
-
-"""
     handle_fault(...)
 
 An internal function to handle a worker dying or being killed by the OS.
@@ -26,7 +13,7 @@ of DAGs, it *may* cause a `KeyError` or other failures in the scheduler due to
 the complexity of getting the internal state back to a consistent and proper
 state.
 """
-function handle_fault(ctx, state, thunk, oldproc, chan)
+function handle_fault(ctx, state, thunk, oldproc)
     # Find thunks whose results were cached on the dead worker and place them
     # on what's called a "deadlist". This structure will direct the recovery
     # of the scheduler's state.
@@ -134,7 +121,7 @@ function handle_fault(ctx, state, thunk, oldproc, chan)
             push!(deadlist, dt)
             continue
         end
-        fire_task!(ctx, dt, newproc, state, chan)
+        fire_task!(ctx, dt, newproc, state)
         break
     end
 end

--- a/src/sch/util.jl
+++ b/src/sch/util.jl
@@ -1,0 +1,23 @@
+"""
+    unwrap_nested_exception(err::Exception) -> Bool
+
+Extracts the "core" exception from a nested exception."
+"""
+unwrap_nested_exception(err::CapturedException) =
+    unwrap_nested_exception(err.ex)
+unwrap_nested_exception(err::RemoteException) =
+    unwrap_nested_exception(err.captured)
+unwrap_nested_exception(err) = err
+"Prepares the scheduler to schedule `thunk` by rescheduling all children."
+function reschedule_inputs!(state, thunk)
+    if !haskey(state.waiting, thunk)
+        state.waiting[thunk] = Set{Thunk}()
+    end
+    for input in thunk.inputs
+        istask(input) || continue
+        push!(state.waiting_data[input], thunk)
+        haskey(state.cache, input) && continue
+        push!(state.waiting[thunk], input)
+        reschedule_inputs!(state, input)
+    end
+end

--- a/src/thunk.jl
+++ b/src/thunk.jl
@@ -28,7 +28,8 @@ mutable struct Thunk
                    affinity=nothing,
                    options=nothing
                   )
-        new(f,xs,id,get_result,meta,persist, cache, cache_ref, affinity, options)
+        new(f, xs, id, get_result, meta, persist, cache, cache_ref, affinity,
+            options)
     end
 end
 
@@ -152,4 +153,3 @@ inputs(x) = ()
 
 istask(x::Thunk) = true
 istask(x) = false
-

--- a/test/processors.jl
+++ b/test/processors.jl
@@ -83,7 +83,7 @@ end
         a = delayed(abc)(1)
         @test collect(a) == 2
     end
-  
+
     @testset "Processor TLS accessor" begin
         @everywhere function mythunk(x)
             typeof(Dagger.thunk_processor())


### PR DESCRIPTION
Allow thunks to dynamically control the scheduler

Todo:
- [x] `exec!`
- [x] `add_thunk!`
- [x] `get_dag_ids`
- [x] Change API to use `task_local_storage` for scheduler handle
- [x] Export dynamic API from Sch
- [x] Test `add_thunk!` and `wait`/`fetch!` better
- [x] Update docs for TLS API
- [ ] ~Expose scheduler control through `Context` somehow~ For a future PR
- [x] Simplify RPC interface to just use `exec!`
- [x] Change `set_return!` to `wait`/`fetch`, to allow one thunk to wait on another
- [x] Use special ThunkID instead of special Arg