### PR TITLE
Set up reverse CI for testing JuliaDB against Dagger

### DIFF
--- a/.github/workflows/reverse_CI_JuliaDB.yml
+++ b/.github/workflows/reverse_CI_JuliaDB.yml
@@ -1,0 +1,32 @@
+name: reverse_CI_JuliaDB
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+    tags: '*'
+jobs:
+  reverse_CI_JuliaDB:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.0'
+          - '1'
+          - 'nightly'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - run: julia -e 'import Pkg; pkg_dagger = Pkg.PackageSpec(path = pwd()); pkg_juliadb = Pkg.PackageSpec(url = "https://github.com/JuliaData/JuliaDB.jl.git"); pkgs = Pkg.Types.PackageSpec[pkg_dagger, pkg_juliadb]; Pkg.develop(pkgs)'
+      - run: julia -e 'import Pkg; Pkg.status()'
+      - run: julia -e 'import Pkg; Pkg.test("JuliaDB")'


### PR DESCRIPTION
Fixes #132 

This PR creates the `reverse_CI_JuliaDB` CI job, which tests Dagger against the latest JuliaDB `master`.

cc: @jpsamaroo 