### PR TITLE
Added worker pressure monitoring

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-MemPool = "0.3"
+MemPool = "0.3.2"
 StatsBase = "0.28, 0.29, 0.30, 0.31, 0.32, 0.33"
 julia = "1.0"
 

--- a/src/array/alloc.jl
+++ b/src/array/alloc.jl
@@ -61,7 +61,8 @@ Base.ones(p::Blocks, dims::Integer...) = ones(p, Float64, dims)
 Base.ones(p::Blocks, dims::Tuple) = ones(p, Float64, dims)
 
 function Base.zeros(p::Blocks, eltype::Type, dims)
-    AllocateArray(eltype, (_, x...) -> zeros(x...), ArrayDomain(map(x->1:x, dims)), p)
+    d = ArrayDomain(map(x->1:x, dims))
+    AllocateArray(eltype, (_, x...) -> zeros(x...), d, partition(p, d))
 end
 Base.zeros(p::Blocks, t::Type, dims::Integer...) = zeros(p, t, dims)
 Base.zeros(p::Blocks, dims::Integer...) = zeros(p, Float64, dims)

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -97,20 +97,6 @@ function affinity(r::FileRef)
     end
 end
 
-function Serialization.deserialize(io::AbstractSerializer, dt::Type{Chunk{T,H,P}}) where {T,H,P}
-    nf = fieldcount(dt)
-    c = ccall(:jl_new_struct_uninit, Any, (Any,), dt)
-    Serialization.deserialize_cycle(io, c)
-    for i in 1:nf
-        tag = Int32(read(io.io, UInt8)::UInt8)
-        if tag != Serialization.UNDEFREF_TAG
-            ccall(:jl_set_nth_field, Cvoid, (Any, Csize_t, Any), c, i-1, Serialization.handle_deserialize(io, tag))
-        end
-    end
-    myid() == 1 && nworkers() > 1 && finalizer(x->@async(free!(x)), c)
-    c
-end
-
 """
     tochunk(x, proc; persist=false, cache=false) -> Chunk
 

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -132,13 +132,10 @@ function free!(s::Chunk{X, DRef, P}; force=true, cache=false) where {X,P}
             catch err
                 isa(err, KeyError) || rethrow(err)
             end
-        else
-            pooldelete(s.handle) # remove immediately
         end
     end
 end
 free!(x; force=true,cache=false) = x # catch-all for non-chunks
-free!(x::DRef) = pooldelete(x)
 
 function savechunk(data, dir, f)
     sz = open(joinpath(dir, f), "w") do io

--- a/src/fault-handler.jl
+++ b/src/fault-handler.jl
@@ -26,7 +26,7 @@ of DAGs, it *may* cause a `KeyError` or other failures in the scheduler due to
 the complexity of getting the internal state back to a consistent and proper
 state.
 """
-function handle_fault(ctx, state, thunk, oldproc, chan, node_order)
+function handle_fault(ctx, state, thunk, oldproc, chan)
     # Find thunks whose results were cached on the dead worker and place them
     # on what's called a "deadlist". This structure will direct the recovery
     # of the scheduler's state.
@@ -134,7 +134,7 @@ function handle_fault(ctx, state, thunk, oldproc, chan, node_order)
             push!(deadlist, dt)
             continue
         end
-        fire_task!(ctx, dt, newproc, state, chan, node_order)
+        fire_task!(ctx, dt, newproc, state, chan)
         break
     end
 end

--- a/src/processor.jl
+++ b/src/processor.jl
@@ -124,6 +124,13 @@ function move_to_osproc(parent_proc, x)
 end
 
 """
+    capacity(proc::Processor=OSProc()) -> Int
+
+Returns the total processing capacity of `proc`.
+"""
+capacity(proc=OSProc()) = length(get_processors(proc))
+
+"""
     OSProc <: Processor
 
 Julia CPU (OS) process, identified by Distributed pid. Executes thunks when

--- a/src/processor.jl
+++ b/src/processor.jl
@@ -273,6 +273,7 @@ Context(procs::Vector{P}=Processor[OSProc(w) for w in workers()];
         profile=false, options=nothing) where {P<:Processor} =
     Context(procs, proc_lock, log_sink, log_file, profile, options)
 Context(xs::Vector{Int}) = Context(map(OSProc, xs))
+Context() = Context([OSProc(w) for w in workers()])
 procs(ctx::Context) = lock(ctx) do
     copy(ctx.procs)
 end

--- a/src/scheduler.jl
+++ b/src/scheduler.jl
@@ -155,7 +155,7 @@ function compute_dag(ctx, d::Thunk; options=SchedulerOptions())
         @dbg timespan_start(ctx, :scheduler, thunk_id, master)
         immediate_next = finish_task!(state, node)
         if !isempty(state.ready) && !shall_remove_proc(ctx, proc)
-            pop_and_fire!(Context(procs_to_use(ctx)), state, chan, proc; immediate_next=immediate_next)
+            pop_and_fire!(ctx, state, chan, proc; immediate_next=immediate_next)
         end
         @dbg timespan_end(ctx, :scheduler, thunk_id, master)
     end

--- a/test/array.jl
+++ b/test/array.jl
@@ -36,9 +36,11 @@ end
     r = collect(R)
     @test r[1:10] != r[11:20]
 end
-@testset "sum(ones(...))" begin
+@testset "sum" begin
     X = ones(Blocks(10, 10), 100, 100)
     @test sum(X) == 10000
+    Y = zeros(Blocks(10, 10), 100, 100)
+    @test sum(Y) == 0
 end
 
 @testset "distributing an array" begin

--- a/test/scheduler.jl
+++ b/test/scheduler.jl
@@ -21,19 +21,19 @@ end
         b = delayed(checkwid)(2)
         c = delayed(checkwid)(a,b)
 
-        @test collect(Context(), c; options=options) == 1
+        @test collect(Context([1,workers()...]), c; options=options) == 1
     end
     @testset "Thunk options: single worker" begin
         options = ThunkOptions(;single=1)
         a = delayed(checkwid; options=options)(1)
 
-        @test collect(Context(), a) == 1
+        @test collect(Context([1,workers()...]), a) == 1
     end
     @static if VERSION >= v"1.3.0-DEV.573"
         if Threads.nthreads() == 1
             @warn "Threading tests running in serial"
         end
-        @testset "Scheduler options: threads" begin
+        @testset "Scheduler options: proctypes" begin
             options = SchedulerOptions(;proctypes=[Dagger.ThreadProc])
             a = delayed(checktid)(1)
             b = delayed(checktid)(2)
@@ -41,7 +41,7 @@ end
 
             @test collect(Context(), c; options=options) == 1
         end
-        @testset "Thunk options: threads" begin
+        @testset "Thunk options: proctypes" begin
             options = ThunkOptions(;proctypes=[Dagger.ThreadProc])
             a = delayed(checktid; options=options)(1)
 


### PR DESCRIPTION
The intent of this PR is to inform the scheduler about the "pressure" on each worker, where pressure is some measure of the ability for a worker to compute a thunk in a timely manner. The scheduler is modified to take this pressure into account every time it tries to schedule a thunk, with the scheduler choosing to schedule ready thunks onto the workers with the least amount of relative pressure. We also allow more than just `Nprocs` thunks to be scheduled at a time; instead, we schedule all thunks marked ready. In the future, I intend to expand this approach to schedule full sub-graphs onto each worker to improve data locality.

Currently the tests are failing for various array operations. Whether we end up removing the array operations from this package or not (@shashi), I'd still like to hear if anyone has any ideas on why this is happening, and how to fix it.