### PR TITLE
Allow StatsBase 0.33

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 MemPool = "0.3"
-StatsBase = "0.28, 0.29, 0.30, 0.31, 0.32"
+StatsBase = "0.28, 0.29, 0.30, 0.31, 0.32, 0.33"
 julia = "1.0"
 
 [extras]


### PR DESCRIPTION
This is what's causing ModelingToolkit test failures: https://travis-ci.com/github/SciML/ModelingToolkit.jl/builds/184324132#L460 . It would be good to get quick tag.

@shashi