### PR TITLE
Remove context from move

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Dagger"
 uuid = "d58978e5-989f-55fb-8d15-ea34adc7bf54"
-version = "0.9.2"
+version = "0.10.0"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -65,12 +65,12 @@ function unrelease(c::Chunk{<:Any,DRef})
 end
 unrelease(c::Chunk) = c
 
-collect_remote(chunk::Chunk) =
-    move(Context(), chunk.processor, OSProc(), poolget(chunk.handle))
+collect_remote(ctx, chunk::Chunk) =
+    move(ctx, chunk.processor, OSProc(), poolget(chunk.handle))
 function collect(ctx::Context, chunk::Chunk; options=nothing)
     # delegate fetching to handle by default.
     if chunk.handle isa DRef && !(chunk.processor isa OSProc)
-        return remotecall_fetch(collect_remote, chunk.handle.owner, chunk)
+        return remotecall_fetch(collect_remote, chunk.handle.owner, ctx, chunk)
     elseif chunk.handle isa FileRef
         return poolget(chunk.handle)
     else

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -66,7 +66,7 @@ end
 unrelease(c::Chunk) = c
 
 collect_remote(pids, chunk::Chunk) =
-    move(Context(pids), chunk.processor, OSProc(), poolget(chunk.handle))
+    move(chunk.processor, OSProc(), poolget(chunk.handle))
 function collect(ctx::Context, chunk::Chunk; options=nothing)
     # delegate fetching to handle by default.
     if chunk.handle isa DRef && !(chunk.processor isa OSProc)
@@ -75,14 +75,14 @@ function collect(ctx::Context, chunk::Chunk; options=nothing)
     elseif chunk.handle isa FileRef
         return poolget(chunk.handle)
     else
-        return move(ctx, chunk.processor, OSProc(), chunk.handle)
+        return move(chunk.processor, OSProc(), chunk.handle)
     end
 end
 collect(ctx::Context, ref::DRef; options=nothing) =
-    move(ctx, OSProc(ref.owner), OSProc(), ref)
+    move(OSProc(ref.owner), OSProc(), ref)
 collect(ctx::Context, ref::FileRef; options=nothing) =
     poolget(ref)
-move(ctx, from_proc::OSProc, to_proc::OSProc, ref::Union{DRef, FileRef}) =
+move(from_proc::OSProc, to_proc::OSProc, ref::Union{DRef, FileRef}) =
     poolget(ref)
 
 

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -65,13 +65,12 @@ function unrelease(c::Chunk{<:Any,DRef})
 end
 unrelease(c::Chunk) = c
 
-collect_remote(pids, chunk::Chunk) =
+collect_remote(chunk::Chunk) =
     move(chunk.processor, OSProc(), poolget(chunk.handle))
 function collect(ctx::Context, chunk::Chunk; options=nothing)
     # delegate fetching to handle by default.
     if chunk.handle isa DRef && !(chunk.processor isa OSProc)
-        pids = map(p -> p.pid, filter(p -> p isa OSProc, procs(ctx)))
-        return remotecall_fetch(collect_remote, chunk.handle.owner, pids, chunk)
+        return remotecall_fetch(collect_remote, chunk.handle.owner, chunk)
     elseif chunk.handle isa FileRef
         return poolget(chunk.handle)
     else

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -65,12 +65,13 @@ function unrelease(c::Chunk{<:Any,DRef})
 end
 unrelease(c::Chunk) = c
 
-collect_remote(ctx, chunk::Chunk) =
-    move(ctx, chunk.processor, OSProc(), poolget(chunk.handle))
+collect_remote(pids, chunk::Chunk) =
+    move(Context(pids), chunk.processor, OSProc(), poolget(chunk.handle))
 function collect(ctx::Context, chunk::Chunk; options=nothing)
     # delegate fetching to handle by default.
     if chunk.handle isa DRef && !(chunk.processor isa OSProc)
-        return remotecall_fetch(collect_remote, chunk.handle.owner, ctx, chunk)
+        pids = map(p -> p.pid, filter(p -> p isa OSProc, procs(ctx)))
+        return remotecall_fetch(collect_remote, chunk.handle.owner, pids, chunk)
     elseif chunk.handle isa FileRef
         return poolget(chunk.handle)
     else

--- a/src/scheduler.jl
+++ b/src/scheduler.jl
@@ -343,7 +343,7 @@ end
     to_proc = choose_processor(from_proc, options, f, fetched)
     fetched = map(Iterators.zip(fetched,ids)) do (x, id)
         @dbg timespan_start(ctx, :move, (thunk_id, id), (f, id))
-        x = move(ctx, from_proc, to_proc, x)
+        x = move(from_proc, to_proc, x)
         @dbg timespan_end(ctx, :move, (thunk_id, id), (f, id))
         return x
     end

--- a/test/fakeproc.jl
+++ b/test/fakeproc.jl
@@ -17,10 +17,10 @@ fakesum(xs...) = FakeVal(sum(map(y->y.x, xs)))
 Dagger.iscompatible_func(proc::FakeProc, opts, f) = true
 Dagger.iscompatible_arg(proc::FakeProc, opts, x::Integer) = true
 Dagger.iscompatible_arg(proc::FakeProc, opts, x::FakeVal) = true
-Dagger.move(ctx, from_proc::OSProc, to_proc::FakeProc, x::Integer) = FakeVal(x)
-Dagger.move(ctx, from_proc::FakeProc, to_proc::OSProc, x::Vector) =
+Dagger.move(from_proc::OSProc, to_proc::FakeProc, x::Integer) = FakeVal(x)
+Dagger.move(from_proc::FakeProc, to_proc::OSProc, x::Vector) =
     map(y->y.x, x)
-Dagger.move(ctx, from_proc::FakeProc, to_proc::OSProc, x::FakeVal) =
+Dagger.move(from_proc::FakeProc, to_proc::OSProc, x::FakeVal) =
     x.x
 Dagger.execute!(proc::FakeProc, func, args...) = FakeVal(42+func(args...).x)
 

--- a/test/processors.jl
+++ b/test/processors.jl
@@ -12,8 +12,8 @@ struct PathProc <: Dagger.Processor
     owner::Int
 end
 Dagger.get_parent(proc::PathProc) = OSProc(proc.owner)
-Dagger.move(ctx, ::PathProc, ::OSProc, x::Float64) = x+1
-Dagger.move(ctx, ::OSProc, ::PathProc, x::Float64) = x+2
+Dagger.move(::PathProc, ::OSProc, x::Float64) = x+1
+Dagger.move(::OSProc, ::PathProc, x::Float64) = x+2
 Dagger.iscompatible(proc::PathProc, opts, f, args...) = true
 Dagger.execute!(proc::PathProc, func, args...) = func(args...)
 
@@ -54,7 +54,7 @@ end
         tp = ThreadProc(1, 1)
         op = get_parent(tp)
         value = rand()
-        moved_value = Dagger.move(ctx, tp, op, Dagger.move(ctx, op, tp, value))
+        moved_value = Dagger.move(tp, op, Dagger.move(op, tp, value))
         @test value === moved_value
     end
     @testset "Generic path move()" begin
@@ -63,7 +63,7 @@ end
         proc1 = first(filter(x->x isa PathProc, get_processors(OSProc(1))))
         proc2 = first(filter(x->x isa PathProc, get_processors(OSProc(2))))
         value = rand()
-        moved_value = Dagger.move(ctx, proc1, proc2, value)
+        moved_value = Dagger.move(proc1, proc2, value)
         @test moved_value == value+3
         @everywhere pop!(Dagger.PROCESSOR_CALLBACKS)
     end


### PR DESCRIPTION
Fixes #143 
Avoids creation of a new context

If there is a good reason to not pass the context (IC bandwidth?) then perhaps initialize it with myid?