### PR TITLE
Add functionality to add and remove workers while scheduler is running

### DIFF
--- a/src/fault-handler.jl
+++ b/src/fault-handler.jl
@@ -124,6 +124,9 @@ function handle_fault(ctx, state, thunk, oldproc, chan, node_order)
 
     # Reschedule inputs from deadlist
     newproc = OSProc(rand(workers()))
+    if newproc ∉ procs(ctx)
+        addprocs!(ctx, [newproc])
+    end
     while length(deadlist) > 0
         dt = popfirst!(deadlist)
         if any((input in deadlist) for input in dt.inputs)

--- a/src/processor.jl
+++ b/src/processor.jl
@@ -284,13 +284,27 @@ Base.lock(f, ctx::Context) = lock(f, ctx.proc_lock)
 """
     addprocs!(ctx::Context, xs)
 
-Add new workers `xs` to an existing `Context ctx`. 
+Add new workers `xs` to `ctx`. 
 
-Workers will typically be assigned new tasks in the next scheduling iteration.
+Workers will typically be assigned new tasks in the next scheduling iteration if scheduling is ongoing.
 
-Workers can be either `Processors` or the underlying process ids as `Integer`s.
+Workers can be either `Processor`s or the underlying process ids as `Integer`s.
 """
 addprocs!(ctx::Context, xs::AbstractVector{<:Integer}) = addprocs!(ctx, map(OSProc, xs))
 addprocs!(ctx::Context, xs::AbstractVector{<:Processor}) = lock(ctx) do 
     append!(ctx.procs, xs)
 end
+"""
+    rmprocs!(ctx::Context, xs)
+
+Remove the specified workers `xs` from `ctx`.
+
+Workers will typically finish all their assigned tasks if scheduling is ongoing but will not be assigned new tasks after removal.
+
+Workers can be either `Processors` or the underlying process ids as `Integer`s.
+"""
+rmprocs!(ctx::Context, xs::AbstractVector{<:Integer}) = rmprocs!(ctx, map(OSProc, xs))
+rmprocs!(ctx::Context, xs::AbstractVector{<:Processor}) = lock(ctx) do 
+    filter!(p -> p ∉ xs, ctx.procs)
+end
+

--- a/src/scheduler.jl
+++ b/src/scheduler.jl
@@ -3,7 +3,7 @@ module Sch
 using Distributed
 import MemPool: DRef
 
-import ..Dagger: Context, Processor, Thunk, Chunk, OSProc, order, free!, dependents, noffspring, istask, inputs, affinity, tochunk, @dbg, @logmsg, timespan_start, timespan_end, unrelease, procs, move, choose_processor, execute!, rmprocs!
+import ..Dagger: Context, Processor, Thunk, Chunk, OSProc, order, free!, dependents, noffspring, istask, inputs, affinity, tochunk, @dbg, @logmsg, timespan_start, timespan_end, unrelease, procs, move, choose_processor, execute!, rmprocs!, addprocs!
 
 include("fault-handler.jl")
 
@@ -112,7 +112,7 @@ function compute_dag(ctx, d::Thunk; options=SchedulerOptions())
         end
 
         # Note: worker_state may be different things for different contexts. Don't touch it out here!
-        worker_state = assign_new_workers!(ctx ,ps, state, chan, node_order, worker_state)
+        worker_state = assign_new_workers!(ctx, ps, state, chan, node_order, worker_state)
 
         if isempty(state.running)
             # the block above fired only meta tasks

--- a/test/processors.jl
+++ b/test/processors.jl
@@ -76,4 +76,19 @@ end
             @everywhere pop!(Dagger.PROCESSOR_CALLBACKS)
         end
     end
+
+    @testset "Modify workers in Context" begin
+        ps = addprocs(4, exeflags="--project")
+        @everywhere ps using Dagger
+        
+        ctx = Context(ps[1:2])
+
+        Dagger.addprocs!(ctx, ps[3:end])
+        @test map(p -> p.pid, procs(ctx)) == ps
+
+        Dagger.rmprocs!(ctx, ps[3:end])
+        @test map(p -> p.pid, procs(ctx)) == ps[1:2]
+
+        wait(rmprocs(ps))
+    end
 end

--- a/test/scheduler.jl
+++ b/test/scheduler.jl
@@ -66,15 +66,15 @@ end
     end
     @everywhere (pop!(Dagger.PROCESSOR_CALLBACKS); empty!(Dagger.OSPROC_CACHE))
 
-    @testset "Add new workers" begin
-        # Test that we can add new workers to an ongoing task.
+    @testset "Modify workers in running job" begin
+        # Test that we can add/remove workers while scheduler is running.
         # As this requires asynchronity a Condition is used to stall the tasks to 
-        # ensure workers are actually added while the scheduler is working 
-        using Distributed
-  
+        # ensure workers are actually modified while the scheduler is working 
+
         setup = quote
            using Dagger, Distributed
            # Condition to guarantee that processing is not completed before we add new workers
+           # Note: c is used in expressions below
            c = Condition()
            function testfun(i)
                i < 4 && return myid()
@@ -83,39 +83,79 @@ end
            end
         end
 
+        @testset "Add new workers" begin
         ps = []
         try     
-            ps1 = addprocs(2, exeflags="--project");
-            push!(ps, ps1)
+                ps1 = addprocs(2, exeflags="--project");
+                push!(ps, ps1)
 
-            @everywhere $setup
-    
-            ts = delayed(vcat)((delayed(testfun)(i) for i in 1:10)...);
+                @everywhere vcat(ps1, myid()) $setup
+        
+                ts = delayed(vcat)((delayed(testfun)(i) for i in 1:10)...);
 
-            ctx = Context(ps1)
-            job = @async collect(ctx, ts);
-    
-            # Will not be added, so they should never appear in output
-            ps2 = addprocs(2, exeflags="--project");
-            push!(ps, ps2)
+                ctx = Context(ps1)
+                job = @async collect(ctx, ts);
 
-            ps3 = addprocs(2, exeflags="--project")
-            push!(ps, ps3)
-            @everywhere ps3 $setup
-            Dagger.addprocs!(ctx, ps3)
-    
-            while !istaskdone(job)
-                sleep(0.01)
-                if istaskstarted(job)
+                while !istaskstarted(job) 
+                    sleep(0.001)
+                end
+                
+                # Will not be added, so they should never appear in output
+                ps2 = addprocs(2, exeflags="--project");
+                push!(ps, ps2)
+
+                ps3 = addprocs(2, exeflags="--project")
+                push!(ps, ps3)
+                @everywhere ps3 $setup
+                Dagger.addprocs!(ctx, ps3)
+                @test length(procs(ctx)) == 4
+        
+                while !istaskdone(job)
                     @everywhere ps1 notify(c)
                     @everywhere ps3 notify(c)
                 end
-            end
-            @test fetch(job) isa Vector
-            @test fetch(job) |> unique |> sort == vcat(ps1, ps3)
+                @test fetch(job) isa Vector
+                @test fetch(job) |> unique |> sort == vcat(ps1, ps3)
 
-        finally
-            wait(rmprocs(ps))
+            finally
+                wait(rmprocs(ps))
+            end
+        end
+
+        @testset "Remove workers" begin
+        ps = []
+        try     
+                ps1 = addprocs(4, exeflags="--project");
+                push!(ps, ps1)
+
+                @everywhere vcat(ps1, myid()) $setup
+        
+                ts = delayed(vcat)((delayed(testfun)(i) for i in 1:16)...);
+
+                ctx = Context(ps1)
+                job = @async collect(ctx, ts);
+
+                while !istaskstarted(job) 
+                    sleep(0.001)
+                end
+
+                Dagger.rmprocs!(ctx, ps1[3:end])
+                @test length(procs(ctx)) == 2
+
+                while !istaskdone(job)
+                    @everywhere ps1 notify(c)
+                end
+                res = fetch(job)
+                @test res isa Vector
+                # First all four workers will report their IDs without hassle
+                # Then all four will be waiting for the Condition
+                # While they are waiting ps1[3:end] are removed, but when the Condition is notified they will finish their tasks before being removed
+                @test res[1:8] |> unique |> sort == ps1
+                @test res[9:end] |> unique |> sort == ps1[1:2]
+
+            finally
+                wait(rmprocs(ps))
+            end
         end
     end
 end


### PR DESCRIPTION
Fixes #145 

I went for the solution centered around procs as the merits of callbacks is not certain. Putting the launching of new workers in a separate method also allows for people to extend (by using a different context) if they really need to. Maybe this is a bit overengineered. It is a bit annoying to have to setdiff in each iteration but due to the possibility of rmprocs its hard to avoid it.

The option to provide a single worker through `options` makes it awkward to use `procs(ctx)` in the scheduling loop so for now `ps` is still being used. The option of single worker is also handled through a number of `ps === procs(ctx)` checks which is maybe not so nice. Why would anyone use it over creating a context with just one proc in it?

As per @jpsamaroo comments in #145, I didn’t make any callback when a worker is available and the only promise made in rmprocs! docstring is that no new tasks will be scheduled for the process. 

The faulthandler is currently a bit scary as it just plucks a random worker. Shouldn’t it pick one from the context? What if the picked worker is not setup with everywhere yet? This took me longer than I’d like to admit to figure out as the shall_remove_proc function did not play well with this at all: The whole thing just stalled when running the fault-tolerance tests since new workers where not in the context so no tasks were scheduled for them. :)

New Context constructor is to avoid semver breakage as the all args constructor is part of the public API.

I can add a section to the docs as well as soon as the implementation has converged. 

Shall I make addprocs! part of the public API? 
Should it be called addprocs to align with Distributed?
Same as above for rmprocs!.

I don’t love how complicated the testcases for this are. Any suggestions on how to simplify them?
