### PR TITLE
Improve UI plan rendering

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "d58978e5-989f-55fb-8d15-ea34adc7bf54"
 version = "0.10.0"
 
 [deps]
+Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MemPool = "f9f48841-c794-520a-933b-121f7ba6ed94"

--- a/docs/src/logging.md
+++ b/docs/src/logging.md
@@ -38,4 +38,13 @@ you can call `Dagger.show_plan(logs, thunk)`, where `thunk` is the output
 
 !!! note
     `Dagger.get_logs!` clears out the event logs, so that old events don't mix
-with new ones from future DAGs.
+    with new ones from future DAGs.
+
+As a convenience, it's possible to set `ctx.log_file` to the path to an output
+file, and then calls to `compute(ctx, ...)`/`collect(ctx, ...)` will
+automatically write the graph in DOT format to that path. There is also a
+benefit to this approach over manual calls to `get_logs!` and `show_plan`: DAGs
+which aren't `Thunk`s (such as operations on the `Dagger.DArray`) will be
+properly rendered with input arguments (which normally aren't rendered because
+a `Thunk` is dynamically generated from such operations by Dagger before
+scheduling).

--- a/src/compute.jl
+++ b/src/compute.jl
@@ -29,7 +29,18 @@ function compute(ctx::Context, d::Thunk; options=nothing)
         PLUGINS[:scheduler] = get_type(PLUGIN_CONFIGS[:scheduler])
     end
     scheduler = PLUGINS[:scheduler]
-    (scheduler).compute_dag(ctx, d; options=options)
+    res = (scheduler).compute_dag(ctx, d; options=options)
+    if ctx.log_file !== nothing
+        if ctx.log_sink !== LocalEventLog
+            logs = get_logs!(ctx.log_sink)
+            open(ctx.log_file, "w") do io
+                Dagger.show_plan(io, logs, d)
+            end
+        else
+            @warn "Context log_sink not set to LocalEventLog, skipping"
+        end
+    end
+    res
 end
 
 function debug_compute(ctx::Context, args...; profile=false, options=nothing)

--- a/src/compute.jl
+++ b/src/compute.jl
@@ -25,11 +25,10 @@ runs the scheduler with the specified options. Returns a Chunk which references
 the result.
 """
 function compute(ctx::Context, d::Thunk; options=nothing)
-    if !(:scheduler in keys(PLUGINS))
-        PLUGINS[:scheduler] = get_type(PLUGIN_CONFIGS[:scheduler])
+    scheduler = get!(PLUGINS, :scheduler) do
+        get_type(PLUGIN_CONFIGS[:scheduler])
     end
-    scheduler = PLUGINS[:scheduler]
-    res = (scheduler).compute_dag(ctx, d; options=options)
+    res = scheduler.compute_dag(ctx, d; options=options)
     if ctx.log_file !== nothing
         if ctx.log_sink !== LocalEventLog
             logs = get_logs!(ctx.log_sink)

--- a/src/ui/graph.jl
+++ b/src/ui/graph.jl
@@ -146,6 +146,7 @@ function write_dag(io, logs::Vector, t=nothing)
                 c = write_node(io, arg, c, name)
                 push!(nodes, name)
             end
+            arg_c += 1
         end
         argnodemap[id] = nodes
     end

--- a/src/ui/graph.jl
+++ b/src/ui/graph.jl
@@ -1,31 +1,12 @@
+import Colors
+
 export show_plan
 
 ### DAG-based graphing
 
-function write_node(io, t::Thunk, c)
-    f = isa(t.f, Function) ? "$(t.f)" : "fn"
-    println(io, "n_$(t.id) [label=\"$f - $(t.id)\"];")
-    c
-end
-
-dec(x) = Base.dec(x, 0, false)
-function write_node(io, t, c, id=dec(hash(t)))
-    l = replace(node_label(t), "\""=>"")
-    println(io, "n_$id", " [label=\"$l\"];")
-    c
-end
-function node_label(t)
-    iob = IOBuffer()
-    Base.show(iob, t)
-    String(take!(iob))
-end
-function node_label(x::T) where T<:AbstractArray
-    "$T\nShape: $(size(x))\nSize: $(pretty_size(sizeof(x)))"
-end
-
 global _part_labels = Dict()
 
-function write_node(io, t::Chunk, c)
+function write_node(ctx, io, t::Chunk, c)
     _part_labels[t]="part_$c"
     c+1
 end
@@ -47,7 +28,7 @@ function write_dag(io, t::Thunk)
     deps = dependents(t)
     c=1
     for k in keys(deps)
-        c = write_node(io, k, c)
+        c = write_node(nothing, io, k, c)
     end
     for (k, v) in deps
         for dep in v
@@ -87,88 +68,169 @@ function pretty_size(sz)
     end
 end
 
-function write_node(io, ts::Timespan, c)
-    f, res_type, res_sz = ts.timeline
-    f = isa(f, Function) ? "$f" : "fn"
-    t_comp = pretty_time(ts)
-    sz_comp = pretty_size(res_sz)
-    println(io, "n_$(ts.id) [label=\"$f - $(ts.id)\nCompute: $t_comp\nResult Type: $res_type\nResult Size: $sz_comp\"]")
+node_label(x) = repr(x)
+node_label(x::T) where T<:AbstractArray =
+    "$T\nShape: $(size(x))\nSize: $(pretty_size(sizeof(x)))"
+node_label(x::Chunk) = "Chunk on $(x.processor)"
+
+node_proc(x) = nothing
+node_proc(x::Chunk) = x.processor
+
+_proc_color(ctx, proc::Processor) = get!(ctx.proc_to_color, proc) do
+    _color = ctx.proc_colors[ctx.proc_color_idx[]]
+    ctx.proc_color_idx[] = clamp(ctx.proc_color_idx[]+1, 0, 128)
+    "#$(Colors.hex(_color))"
+end
+_proc_color(ctx, id::Int) = _proc_color(ctx, ctx.id_to_proc[id])
+_proc_color(ctx, ::Nothing) = "black"
+_proc_shape(ctx, proc::Processor) = get!(ctx.proc_to_shape, typeof(proc)) do
+    _shape = ctx.proc_shapes[ctx.proc_shape_idx[]]
+    ctx.proc_shape_idx[] = clamp(ctx.proc_shape_idx[]+1, 0, length(ctx.proc_shapes))
+    _shape
+end
+_proc_shape(ctx, ::Nothing) = "ellipse"
+
+function write_node(ctx, io, t::Thunk, c)
+    f = isa(t.f, Function) ? "$(t.f)" : "fn"
+    println(io, "n_$(t.id) [label=\"$f - $(t.id)\"];")
     c
 end
 
-function write_edge(io, ts_comm::Timespan, logs)
+dec(x) = Base.dec(x, 0, false)
+function write_node(ctx, io, t, c, id=dec(hash(t)))
+    l = replace(node_label(t), "\""=>"")
+    proc = node_proc(t)
+    color = _proc_color(ctx, proc)
+    shape = _proc_shape(ctx, proc)
+    println(io, "n_$id [label=\"$l\",color=\"$color\",shape=\"$shape\",penwidth=5];")
+    c
+end
+
+function write_node(ctx, io, ts::Timespan, c)
+    f, proc, res_type, res_sz = ts.timeline
+    f = isa(f, Function) ? "$f" : "fn"
+    t_comp = pretty_time(ts)
+    sz_comp = pretty_size(res_sz)
+    color = _proc_color(ctx, proc)
+    shape = _proc_shape(ctx, proc)
+    # TODO: t_log = log(ts.finish - ts.start) / 5
+    ctx.id_to_proc[ts.id] = proc
+    println(io, "n_$(ts.id) [label=\"$f\n$t_comp\",color=\"$color\",shape=\"$shape\",penwidth=5];")
+    # TODO: "\n Thunk $(ts.id)\nResult Type: $res_type\nResult Size: $sz_comp\",
+    c
+end
+
+function write_edge(ctx, io, ts_comm::Timespan, logs, inputname=nothing, inputarg=nothing)
     f, id = ts_comm.timeline
-    # FIXME: We should print these edges too
-    id === nothing && return
     t_comm = pretty_time(ts_comm)
-    print(io, "n_$id -> n_$(ts_comm.id[1]) [label=\"Comm: $t_comm")
+    if id > 0
+        print(io, "n_$id -> n_$(ts_comm.id[1]) [label=\"Comm: $t_comm")
+        color_src = _proc_color(ctx, id)
+    else
+        @assert inputname !== nothing
+        @assert inputarg !== nothing
+        print(io, "n_$inputname -> n_$(ts_comm.id[1]) [label=\"Comm: $t_comm")
+        proc = node_proc(inputarg)
+        color_src = _proc_color(ctx, proc)
+    end
+    color_dst = _proc_color(ctx, ts_comm.id[1])
     ts_idx = findfirst(x->x.category==:move &&
-                                ts_comm.id==x.id &&
-                                id==x.timeline[2], logs)
+                          ts_comm.id==x.id &&
+                          id==x.timeline[2], logs)
     if ts_idx !== nothing
         ts_move = logs[ts_idx]
         t_move = pretty_time(ts_move)
         print(io, "\nMove: $t_move")
     end
-    println(io, "\"];")
+    #= TODO: log_t = log((ts_comm.finish-ts_comm.start) +
+                (ts_move.finish-ts_move.start)) / 5=#
+    println(io, "\",color=\"$color_src;0.5:$color_dst\",penwidth=2];")
 end
 
-write_edge(io, from::String, to::String) = println(io, "n_$from -> n_$to")
+write_edge(ctx, io, from::String, to::String) = println(io, "n_$from -> n_$to;")
 
 getargs!(d, t) = nothing
 function getargs!(d, t::Thunk)
-    d[t.id] = [filter(!istask, [t.inputs...,])...,]
+    d[t.id] = [filter(x->!istask(x[2]), collect(enumerate(t.inputs)))...,]
     foreach(i->getargs!(d, i), t.inputs)
 end
 function write_dag(io, logs::Vector, t=nothing)
+    ctx = (proc_to_color = Dict{Processor,String}(),
+           proc_colors = Colors.distinguishable_colors(128),
+           proc_color_idx = Ref{Int}(1),
+           proc_to_shape = Dict{Type,String}(),
+           proc_shapes = ("ellipse","box","triangle"),
+           proc_shape_idx = Ref{Int}(1),
+           id_to_proc = Dict{Int,Processor}())
     argmap = Dict{Int,Vector}()
     getargs!(argmap, t)
     c = 1
+    # Compute nodes
     for ts in filter(x->x.category==:compute, logs)
-        c = write_node(io, ts, c)
+        c = write_node(ctx, io, ts, c)
     end
+    # Argument nodes
     argnodemap = Dict{Int,Vector{String}}()
     argids = IdDict{Any,String}()
     for id in keys(argmap)
         nodes = String[]
         arg_c = 1
-        for arg in argmap[id]
-            name = "$(id)_arg_$(arg_c)"
+        for (argidx,arg) in argmap[id]
+            name = "arg_$(argidx)_to_$(id)"
             if !isimmutable(arg)
                 if arg in keys(argids)
                     name = argids[arg]
                 else
                     argids[arg] = name
-                    c = write_node(io, arg, c, name)
+                    c = write_node(ctx, io, arg, c, name)
                 end
                 push!(nodes, name)
             else
-                c = write_node(io, arg, c, name)
+                c = write_node(ctx, io, arg, c, name)
                 push!(nodes, name)
+            end
+            # Arg-to-compute edges
+            for ts in filter(x->x.category==:comm &&
+                                x.id[1]==id &&
+                                x.timeline[2]==-argidx, logs)
+                write_edge(ctx, io, ts, logs, name, arg)
             end
             arg_c += 1
         end
         argnodemap[id] = nodes
     end
-    for ts in filter(x->x.category==:comm, logs)
-        write_edge(io, ts, logs)
+    # Comm+Move edges
+    for ts in filter(x->x.category==:comm && x.timeline[2]>0, logs)
+        write_edge(ctx, io, ts, logs)
     end
-    for id in keys(argnodemap)
-        for arg in argnodemap[id]
-            write_edge(io, arg, string(id))
-        end
+    #= FIXME: Legend (currently it's laid out horizontally)
+    println(io, """
+    subgraph  {
+        graph[style=dotted,newrank=true,rankdir=TB];
+        edge [style=invis];
+        Legend [shape=box];""")
+    cur = "Legend"
+    for id in keys(ctx.id_to_proc)
+        color = _proc_color(ctx, id)
+        shape = _proc_shape(ctx, ctx.id_to_proc[id])
+        name = "proc_$id"
+        println(io, "$name [color=\"$color\",shape=\"$shape\"];")
+        println(io, "$cur -> $name;")
+        cur = name
     end
+    println(io, "}")
+    =#
 end
 
 function show_plan(io::IO, t)
-    print(io, """digraph {
-    graph [layout=dot, rankdir=TB];""")
+    println(io, """strict digraph {
+    graph [layout=dot,rankdir=LR];""")
     write_dag(io, t)
     println(io, "}")
 end
 function show_plan(io::IO, logs::Vector{Timespan}, t::Thunk)
-    print(io, """digraph {
-    graph [layout=dot, rankdir=TB];""")
+    println(io, """strict digraph {
+    graph [layout=dot,rankdir=LR];""")
     write_dag(io, logs, t)
     println(io, "}")
 end

--- a/test/ui.jl
+++ b/test/ui.jl
@@ -44,4 +44,18 @@ end
     logs = Dagger.get_logs!(log)
     plan = Dagger.show_plan(logs, j)
 end
+
+@testset "Automatic Plan Rendering" begin
+    x = compute(rand(Blocks(2,2),4,4))
+    mktemp() do path, io
+        ctx = Context(;log_sink=Dagger.LocalEventLog(),log_file=path)
+        compute(ctx, x * x)
+        plan = String(read(io))
+        @test occursin("digraph {", plan)
+        @test occursin("Comm:", plan)
+        @test occursin("Move:", plan)
+        @test occursin("Compute:", plan)
+        @test endswith(plan, "}\n")
+    end
+end
 end

--- a/test/ui.jl
+++ b/test/ui.jl
@@ -19,7 +19,6 @@
     @test occursin("digraph {", plan)
     @test occursin("Comm:", plan)
     @test occursin("Move:", plan)
-    @test occursin("Compute:", plan)
     @test endswith(plan, "}\n")
 end
 
@@ -54,7 +53,6 @@ end
         @test occursin("digraph {", plan)
         @test occursin("Comm:", plan)
         @test occursin("Move:", plan)
-        @test occursin("Compute:", plan)
         @test endswith(plan, "}\n")
     end
 end


### PR DESCRIPTION
Will close #156 

Todo:

- [x] Make visualization quick and easy to do
- [x] Reduce information within nodes to make them smaller
- [x] Move node information to outside shape (note: I ended up removing some information for now)
- [x] Color nodes with unique color per processor
- [x] Color the edges with a gradient from source to destination
- [ ] ~Widen node borders for longer computations~
- [ ] ~Widen the edges for longer transfers~
- [x] Change node shape according to processor type
- [ ] ~Color and shape legend~
- [x] Dispatch for pretty-printing argument nodes (and hopefully coloring `Chunk` with the owning processor)
- [x] Show arg -> Thunk network timings