### PR TITLE
Set up Buildkite for tests and benchmarks

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,20 @@
+steps:
+  - command: julia --project -e 'using Pkg; Pkg.build(); Pkg.test()'
+    if: build.env("DAGGER_BENCHMARK") != "true"
+    agents:
+      os: linux
+      arch: x86_64
+    plugins:
+      - docker#v3.7.0:
+          image: julia:1
+  - command: echo TODO
+    if: build.env("DAGGER_BENCHMARK") == "true"
+    agents:
+      os: linux
+      arch: x86_64
+      serial: true
+    plugins:
+      - docker#v3.7.0:
+          image: julia:1.5.3
+    artifacts:
+      - benchmarks/TODO

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,13 @@
+name: Trigger benchmarks
+on: workflow_dispatch
+jobs:
+  benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl https://api.buildkite.com/v2/organizations/julialang/pipelines/dagger-dot-jl/builds \
+            --header "Authorization: Bearer $BUILDKITE_TOKEN" \
+            --data '{"commit": "HEAD", "branch": "master", "env": {"DAGGER_BENCHMARK": "true"}}' \
+          | jq -r .web_url
+        env:
+          BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}


### PR DESCRIPTION
WIP.

I set up a single BK agent on amdci3 with the tag `serial=true`, i.e. that machine does not run parallel jobs.
Benchmarks can be triggered manually via the GitHub Action.