### PR TITLE
Add at-spawn macro for eager scheduling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Dagger"
 uuid = "d58978e5-989f-55fb-8d15-ea34adc7bf54"
-version = "0.10.2"
+version = "0.11.0"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/src/sch/eager.jl
+++ b/src/sch/eager.jl
@@ -1,0 +1,59 @@
+const EAGER_INIT = Ref{Bool}(false)
+const EAGER_THUNK_CHAN = Channel(typemax(Int))
+const EAGER_THUNK_MAP = Dict{Int,Int}()
+const EAGER_CONTEXT = Ref{Context}()
+
+eager_context() = isassigned(EAGER_CONTEXT) ? EAGER_CONTEXT[] : nothing
+
+function init_eager()
+    EAGER_INIT[] && return
+    EAGER_INIT[] = true
+    if eager_context() === nothing
+        EAGER_CONTEXT[] = Context([myid(),workers()...])
+    end
+    ctx = EAGER_CONTEXT[]
+    @async try
+        sopts = SchedulerOptions(;allow_errors=true)
+        topts = ThunkOptions(;single=1)
+        Dagger.compute(ctx, Dagger.delayed(eager_thunk;options=topts)(); options=sopts)
+    catch err
+        iob = IOContext(IOBuffer(), :color=>true)
+        println(iob, "Error in eager scheduler:")
+        Base.showerror(iob, err)
+        Base.show_backtrace(iob, catch_backtrace())
+        println(iob)
+        seek(iob.io, 0)
+        write(stderr, iob)
+    finally
+        EAGER_INIT[] = false
+    end
+end
+
+"Sets the scheduler's cached pressure indicator for the specified worker."
+set_pressure!(h::SchedulerHandle, pid::Int, pressure::Int) =
+    exec!(_set_pressure!, h, pid, pressure)
+function _set_pressure!(ctx, state, task, tid, (pid, pressure))
+    state.worker_pressure[pid] = pressure
+end
+
+function eager_thunk()
+    h = sch_handle()
+    while isopen(EAGER_THUNK_CHAN)
+        set_pressure!(h, 1, 0) # HACK: Don't apply pressure from this thunk
+        try
+            future, uid, f, args, opts = take!(EAGER_THUNK_CHAN)
+            args = map(x->x isa Dagger.EagerThunk ? ThunkID(EAGER_THUNK_MAP[x.uid]) : x, args)
+            tid = add_thunk!(f, h, args...; opts...)
+            register_future!(h, tid, future)
+            EAGER_THUNK_MAP[uid] = tid.id
+        catch err
+            iob = IOContext(IOBuffer(), :color=>true)
+            println(iob, "Error in eager listener:")
+            Base.showerror(iob, err)
+            Base.show_backtrace(iob, catch_backtrace())
+            println(iob)
+            seek(iob.io, 0)
+            write(stderr, iob)
+        end
+    end
+end

--- a/src/sch/fault-handler.jl
+++ b/src/sch/fault-handler.jl
@@ -45,10 +45,8 @@ function handle_fault(ctx, state, thunk, oldproc)
         end
     end
 
-    function fix_waitdicts!(state, deadlist, t::Thunk; isleaf=false, offset=0)
+    function fix_waitdicts!(state, deadlist, t::Thunk; isleaf=false)
         waiting, waiting_data = state.waiting, state.waiting_data
-        off = repeat(" ", offset)
-        offi = repeat(" ", offset+1)
         if !(t in keys(waiting))
             waiting[t] = Set{Thunk}()
         end
@@ -61,7 +59,7 @@ function handle_fault(ctx, state, thunk, oldproc)
                 push!(waiting[t], input)
                 push!(waiting_data[input], t)
                 isleaf = !(input in deadlist)
-                fix_waitdicts!(state, deadlist, input; isleaf=isleaf, offset=offset+1)
+                fix_waitdicts!(state, deadlist, input; isleaf=isleaf)
             end
         end
         if isempty(waiting[t])

--- a/src/sch/util.jl
+++ b/src/sch/util.jl
@@ -8,16 +8,102 @@ unwrap_nested_exception(err::CapturedException) =
 unwrap_nested_exception(err::RemoteException) =
     unwrap_nested_exception(err.captured)
 unwrap_nested_exception(err) = err
-"Prepares the scheduler to schedule `thunk` by rescheduling all children."
+
+"Prepares the scheduler to schedule `thunk`."
 function reschedule_inputs!(state, thunk)
-    if !haskey(state.waiting, thunk)
-        state.waiting[thunk] = Set{Thunk}()
-    end
+    w = get!(()->Set{Thunk}(), state.waiting, thunk)
+    scheduled = false
     for input in thunk.inputs
         istask(input) || continue
-        push!(state.waiting_data[input], thunk)
+        push!(get!(()->Set{Thunk}(), state.waiting_data, input), thunk)
+        push!(get!(()->Set{Thunk}(), state.dependents, input), thunk)
+        if input in state.errored
+            set_failed!(state, input, thunk)
+            break # TODO: Allow collecting all error'd inputs
+        end
         haskey(state.cache, input) && continue
-        push!(state.waiting[thunk], input)
-        reschedule_inputs!(state, input)
+        if (input in state.running) ||
+           (input in state.ready) ||
+           reschedule_inputs!(state, input)
+            push!(w, input)
+            scheduled = true
+        end
+    end
+    if isempty(w) && !(thunk in state.errored)
+        # Inputs are ready
+        push!(state.ready, thunk)
+        return true
+    else
+        return scheduled
+    end
+end
+
+"Marks `thunk` and all dependent thunks as failed."
+function set_failed!(state, origin, thunk=origin)
+    thunk in state.errored && return
+    push!(state.errored, thunk)
+    filter!(x->x!==thunk, state.ready)
+    state.cache[thunk] = ThunkFailedException(thunk, origin, state.cache[origin])
+    if haskey(state.futures, thunk)
+        for future in state.futures[thunk]
+            put!(future, state.cache[thunk]; error=true)
+        end
+        delete!(state.futures, thunk)
+    end
+    for dep in state.dependents[thunk]
+        if haskey(state.waiting, dep)
+            pop!(state.waiting, dep)
+        end
+        set_failed!(state, origin, dep)
+    end
+end
+
+"Internal utility, useful for debugging scheduler state."
+function print_sch_status(state, thunk)
+    iob = IOBuffer()
+    print_sch_status(iob, state, thunk)
+    seek(iob, 0)
+    write(stderr, iob)
+end
+function print_sch_status(io::IO, state, thunk; offset=0, limit=5)
+    function status_string(node)
+        status = ""
+        if node in state.errored
+            status *= "E"
+        end
+        if node in state.ready
+            status *= "r"
+        elseif node in state.running
+            status *= "R"
+        elseif haskey(state.cache, node)
+            status *= "C"
+        else
+            status *= "?"
+        end
+        status
+    end
+    offset == 0 && print(io, "($(status_string(thunk))) ")
+    println(io, "$(thunk.id): $(thunk.f)")
+    for input in thunk.inputs
+        input isa Thunk || continue
+        status = status_string(input)
+        if haskey(state.waiting, thunk) && input in state.waiting[thunk]
+            status *= "W"
+        end
+        if haskey(state.waiting_data, input) && thunk in state.waiting_data[input]
+            status *= "w"
+        end
+        if haskey(state.dependents, input) && thunk in state.dependents[input]
+            status *= "d"
+        end
+        if haskey(state.futures, input)
+            status *= "f$(length(state.futures[input]))"
+        end
+        print(io, repeat(' ', offset+2), "($status) ")
+        if limit > 0
+            print_sch_status(io, state, input; offset=offset+2, limit=limit-1)
+        else
+            println(io, "…")
+        end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ addprocs(3)
 using Test
 using Dagger
 
+include("util.jl")
 include("fakeproc.jl")
 
 include("thunk.jl")

--- a/test/thunk.jl
+++ b/test/thunk.jl
@@ -1,4 +1,6 @@
-import Dagger: @par
+import Dagger: @par, @spawn
+
+@everywhere checkwid() = myid()==1
 
 @testset "@par" begin
     @testset "per-call" begin
@@ -9,7 +11,6 @@ import Dagger: @par
         c = @par a * b
         @test collect(c) == 20
     end
-
     @testset "block" begin
         c = @par begin
             x = 2
@@ -21,5 +22,113 @@ import Dagger: @par
         @test a isa Dagger.Thunk
         @test c isa Dagger.Thunk
         @test collect(c) == 20
+    end
+end
+
+@testset "@spawn" begin
+    @test Dagger.Sch.eager_context() === nothing
+    @testset "per-call" begin
+        x = 2
+        a = @spawn x + x
+        @test a isa Dagger.EagerThunk
+        b = @spawn sum([x,1,2])
+        c = @spawn a * b
+        @test fetch(a) == 4
+        @test fetch(b) == 5
+        @test fetch(c) == 20
+    end
+    @test Dagger.Sch.eager_context() isa Context
+    @testset "waiting" begin
+        a = @spawn sleep(5)
+        @test !isready(a)
+        wait(a)
+        @test isready(a)
+    end
+    @testset "options" begin
+        s = 1
+        m = true
+        a = @spawn single=s checkwid()
+        b = @spawn meta=m ((_a)->_a isa Dagger.Chunk)(a)
+        @test fetch(a)
+        @test fetch(b)
+    end
+    @testset "errors" begin
+        @testset "independent" begin
+            a = @spawn error("Test")
+            wait(a)
+            @test isready(a)
+            @test_throws_unwrap Dagger.ThunkFailedException fetch(a)
+            b = @spawn 1+2
+            @test fetch(b) == 3
+        end
+        @testset "direct vs indirect" begin
+            a = @spawn error("Test")
+            b = @spawn a+1
+
+            ex = try
+                fetch(a)
+            catch err
+                err
+            end
+            ex = Dagger.Sch.unwrap_nested_exception(ex)
+            ex_str = sprint(io->Base.showerror(io,ex))
+            @test occursin(r"^Thunk.*failure:", ex_str)
+            @test occursin("Test", ex_str)
+            @test !occursin("due to a failure in", ex_str)
+
+            ex = try
+                fetch(b)
+            catch err
+                err
+            end
+            ex = Dagger.Sch.unwrap_nested_exception(ex)
+            ex_str = sprint(io->Base.showerror(io,ex))
+            @test occursin(r"^Thunk.*failure due to a failure in", ex_str)
+            @test occursin("Test", ex_str)
+        end
+        @testset "single dependent" begin
+            a = @spawn error("Test")
+            b = @spawn a+2
+            @test_throws_unwrap Dagger.ThunkFailedException fetch(a)
+        end
+        @testset "multi dependent" begin
+            a = @spawn error("Test")
+            b = @spawn a+2
+            c = @spawn a*2
+            @test_throws_unwrap Dagger.ThunkFailedException fetch(b)
+            @test_throws_unwrap Dagger.ThunkFailedException fetch(c)
+        end
+        @testset "dependent chain" begin
+            a = @spawn error("Test")
+            @test_throws_unwrap Dagger.ThunkFailedException fetch(a)
+            b = @spawn a+1
+            @test_throws_unwrap Dagger.ThunkFailedException fetch(b)
+            c = @spawn b+2
+            @test_throws_unwrap Dagger.ThunkFailedException fetch(c)
+        end
+        @testset "single input" begin
+            a = @spawn 1+1
+            b = @spawn (a->error("Test"))(a)
+            @test fetch(a) == 2
+            @test_throws_unwrap Dagger.ThunkFailedException fetch(b)
+        end
+        @testset "multi input" begin
+            a = @spawn 1+1
+            b = @spawn 2*2
+            c = @spawn ((a,b)->error("Test"))(a,b)
+            @test fetch(a) == 2
+            @test fetch(b) == 4
+            @test_throws_unwrap Dagger.ThunkFailedException fetch(c)
+        end
+        @testset "diamond" begin
+            a = @spawn 1+1
+            b = @spawn a+1
+            c = @spawn a*2
+            d = @spawn ((b,c)->error("Test"))(b,c)
+            @test fetch(a) == 2
+            @test fetch(b) == 3
+            @test fetch(c) == 4
+            @test_throws_unwrap Dagger.ThunkFailedException fetch(d)
+        end
     end
 end

--- a/test/util.jl
+++ b/test/util.jl
@@ -1,0 +1,10 @@
+macro test_throws_unwrap(terr, ex)
+    quote
+        rerr = try
+            $(esc(ex))
+        catch err
+            err
+        end
+        @test Dagger.Sch.unwrap_nested_exception(rerr) isa $terr
+    end
+end


### PR DESCRIPTION
The macro `Dagger.@spawn` is similar to `Dagger.@par`, however it schedules work "eagerly"; that is to say, the generated thunk(s) are immediately placed on an active scheduler. Dagger will now start up a scheduler instance in the background for such thunks, and will remain available for the full Julia session.

The intent is to mimic Base's `@async` and `Threads.@spawn`, allowing functionally-written code to be executed in a distributed manner without having to "thread" Dagger through a codebase.

Todo:
- [x] Make `@par` and `@spawn` non-recursive for non-`Expr(:block)` expressions
- [x] Make `@par` and `@spawn` thunk options configurable
- [ ] ~Consider allowing `@par` and `@spawn` to interact peacefully (handle blocking vs. non-blocking thunk inputs sensibly)~ For a future PR: #182 
- [x] Provide an accessor for the global `Context`
- [x] Allow thunks to error without affecting non-dependent thunks
- [x] Add custom error for thunks failing due to failed input(s)
- [x] More tests with errors
- [x] Docs