### PR TITLE
Thunk cost estimation, chunk caching, benchmark updates

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 Colors = "0.10, 0.11, 0.12"
-MemPool = "0.3.3"
+MemPool = "0.3.4"
 Requires = "1"
 StatsBase = "0.28, 0.29, 0.30, 0.31, 0.32, 0.33"
 julia = "1.0"

--- a/benchmarks/visualize.jl
+++ b/benchmarks/visualize.jl
@@ -1,27 +1,59 @@
-using JLD
+using JLD, Serialization
 using BenchmarkTools
 using TypedTables
 
-res = JLD.load(ARGS[1])
+res = if endswith(ARGS[1], ".jld")
+    JLD.load(ARGS[1])
+elseif endswith(ARGS[1], ".jls")
+    deserialize(ARGS[1])
+else
+    error("Unknown file type")
+end
 
-serial_results = res["results"]["Serial"]
-dagger_results = res["results"]["Dagger"]
+serial_results = filter(x->!occursin("dagger", x[1]), res["results"])
+@assert length(keys(serial_results)) > 0 "No serial results found"
+dagger_results = filter(x->occursin("dagger", x[1]), res["results"])
+@assert length(keys(dagger_results)) > 0 "No Dagger results found"
 
-scale_set = sort([key=>parse(Int, lstrip(last(split(key, ':')), ' ')) for key in keys(serial_results)]; by=x->x[2])
-serial_times = [minimum(serial_results[scale]).time/(10^9) for scale in first.(scale_set)]
-nw_set = sort([key=>parse(Int, lstrip(last(split(key, ':')), ' ')) for key in keys(dagger_results[first(first(scale_set))])]; by=x->x[2])
+scale_set = sort([key=>parse(Int, lstrip(last(split(key, ':')), ' ')) for key in keys(first(serial_results)[2])]; by=x->x[2])
+nw_set = sort([key=>parse(Int, lstrip(last(split(key, ':')), ' ')) for key in keys(first(dagger_results)[2][first(first(scale_set))])]; by=x->x[2])
+raw_table = NamedTuple[]
+for bset_key in keys(res["results"])
+    bset = res["results"][bset_key]
+    if typeof(bset[first(first(scale_set))]) <: BenchmarkGroup
+        procs = parse(Int, lstrip(last(split(first(first(bset[first(first(scale_set))])), ':')), ' '))
+        for nw in nw_set
+            for i in 1:length(scale_set)
+                set_times = [minimum(bset[scale][nw[1]]).time/(10^9) for scale in first.(scale_set)]
+                push!(raw_table, (name=bset_key, time=set_times[i], scale=last.(scale_set)[i], procs=nw[2]))
+            end
+        end
+    else
+        set_times = [minimum(bset[scale]).time/(10^9) for scale in first.(scale_set)]
+        procs = 8  # default for OpenBLAS
+        for i in 1:length(set_times)
+            push!(raw_table, (name=bset_key, time=set_times[i], scale=last.(scale_set)[i], procs=procs))
+        end
+    end
+end
+table = Table(raw_table)
 
-table = Table(name=[:Base for _ in 1:3], time=serial_times, scale=last.(scale_set), procs=[8 for _ in 1:3])
+btable = copy(table[map(x->!x, occursin.(Ref("dagger"), table.name))])
+dtable = copy(table[occursin.(Ref("dagger"), table.name)])
 
-btable = copy(table)
+#table = Table(name=[:Base for _ in 1:3], time=serial_times, scale=last.(scale_set), procs=[8 for _ in 1:3])
 
+#btable = copy(table)
+
+#=
 for (nw,nw_val) in nw_set
     dagger_times = [minimum(dagger_results[scale][nw]).time/(10^9) for scale in first.(scale_set)]
     t = Table(name=[:Dagger for _ in 1:3], time=dagger_times, scale=last.(scale_set), procs=[parse(Int,split(nw, ":")[2]) for _ in 1:3])
     append!(table, t)
 end
+=#
 
-dtable = table[table.name .== :Dagger]
+#dtable = table[table.name .== :Dagger]
 
 # Plotting
 
@@ -45,11 +77,11 @@ legend_names = String[]
 
 scales = unique(dtable.scale)
 
-colors = distinguishable_colors(lenght(scales), ColorSchemes.seaborn_deep.colors)
+colors = distinguishable_colors(length(scales), ColorSchemes.seaborn_deep.colors)
 
 for (i, scale) in enumerate(scales)
     stable = dtable[dtable.scale .== scale]
-    t1 = first(stable[stable.procs .== 1].time)
+    t1 = first(stable[stable.procs .== minimum(dtable.procs)].time)
     ss_efficiency = strong_scaling.(t1, stable.time, stable.procs)
     push!(line_plots, lines!(ssp, stable.procs, ss_efficiency, linewidth=3.0, color = colors[i]))
     push!(legend_names, "scale = $scale")
@@ -65,25 +97,32 @@ save("strong_scaling.png", fig)
 #    too little data
 
 fig = Figure(resolution = (1200, 800))
-weak_scaling(t1, tn) = t1/tn
+weak_scaling(t1, tn, p_prime, p) = t1/((p_prime/p)*tn)
 
-dtable = table[table.name .== :Dagger]
-wstable = filter(row->row.scale == row.procs, dtable)
-wstable = sort(wstable, by=r->r.scale)
-t1 = first(wstable).time
+t1 = first(dtable[map(row->(row.scale == 10) && (row.procs == 1), dtable)]).time
 
 fig = Figure(resolution = (1200, 800))
-perf = fig[1, 1] = Axis(fig, title = "Weak scaling")
-perf.xlabel = "nprocs"
-perf.ylabel = "Efficiency"
+perf = fig[1, 1] = Axis(fig, title = "Weak Scaling")
+perf.xlabel = "Number of processes"
+perf.ylabel = "Scaling efficiency"
 
-lines!(perf, wstable.procs, weak_scaling.(t1, wstable.time), linewidth=3.0)
+line_plots = Any[]
+legend_names = String[]
+
+wstable = similar(dtable, 0)
+for pair in [(10,1),(35,4),(85,8)]
+    append!(wstable, dtable[map(row->(row.scale == pair[1]) && (row.procs == pair[2]), rows(dtable))])
+end
+push!(line_plots, lines!(perf, wstable.procs, weak_scaling.(t1, wstable.time, wstable.procs .* 10, wstable.scale), linewidth=3.0))
+push!(legend_names, "cpu+dagger")
+
+legend = fig[1, 2] = Legend(fig, line_plots, legend_names)
 save("weak_scaling.png", fig)
 
 # 3. Comparision against Base
 
 fig = Figure(resolution = (1200, 800))
-perf = fig[1, 1] = Axis(fig, title = "DaggerArrays vs Base")
+perf = fig[1, 1] = Axis(fig, title = "Dagger vs Base")
 perf.xlabel = "Scaling factor"
 perf.ylabel = "time (s)"
 
@@ -92,7 +131,7 @@ legend_names = String[]
 
 procs = unique(dtable.procs)
 
-colors = distinguishable_colors(lenght(procs) + 1, ColorSchemes.seaborn_deep.colors)
+colors = distinguishable_colors(length(procs) + 1, ColorSchemes.seaborn_deep.colors)
 
 for (i, nproc) in enumerate(procs)
     stable = dtable[dtable.procs .== nproc]
@@ -109,23 +148,22 @@ save("raw_timings.png", fig)
 
 # 4. Speedup
 fig = Figure(resolution = (1200, 800))
-speedup = fig[1, 1] = Axis(fig, title = "DaggerArrays vs Base (8 threads)")
-speedup.xlabel = "Scaling factor"
-speedup.ylabel = "Speedup Base/Dagger"
+speedup = fig[1, 1] = Axis(fig, title = "Speedup vs. 1 processor")
+speedup.xlabel = "Number of processors"
+speedup.ylabel = "Speedup"
 
 line_plots = Any[]
 legend_names = String[]
 
 colors = distinguishable_colors(length(procs), ColorSchemes.seaborn_deep.colors)
 
-sort!(btable, by=r->r.scale)
+t1 = sort(dtable[dtable.scale .== 10]; by=r->r.procs)
 
-for (i, nproc) in enumerate(unique(dtable.procs))
-    nproc < 8 && continue
-    stable = dtable[dtable.procs .== nproc]
-    sort!(stable, by=r->r.scale)
-    push!(line_plots, lines!(speedup, stable.scale, btable.time ./ stable.time, linewidth=3.0, color = colors[i]))
-    push!(legend_names, "Dagger (nprocs = $nproc)")
+for (i, scale) in enumerate(unique(dtable.scale))
+    stable = dtable[dtable.scale .== scale]
+    sort!(stable, by=r->r.procs)
+    push!(line_plots, lines!(speedup, stable.procs, stable.time ./ t1.time, linewidth=3.0, color = colors[i]))
+    push!(legend_names, "Dagger (scale = $scale)")
 end
 
 legend = fig[1, 2] = Legend(fig, line_plots, legend_names)

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -65,8 +65,12 @@ function unrelease(c::Chunk{<:Any,DRef})
 end
 unrelease(c::Chunk) = c
 
+Base.:(==)(c1::Chunk, c2::Chunk) = c1.handle == c2.handle
+Base.hash(c::Chunk, x::UInt64) = hash(c.handle, x)
+
 collect_remote(chunk::Chunk) =
     move(chunk.processor, OSProc(), poolget(chunk.handle))
+
 function collect(ctx::Context, chunk::Chunk; options=nothing)
     # delegate fetching to handle by default.
     if chunk.handle isa DRef && !(chunk.processor isa OSProc)

--- a/src/processor.jl
+++ b/src/processor.jl
@@ -227,6 +227,9 @@ Context(procs::Vector{P}=Processor[OSProc(w) for w in workers()];
         profile=false, options=nothing) where {P<:Processor} =
     Context(procs, proc_lock, log_sink, log_file, profile, options)
 Context(xs::Vector{Int}; kwargs...) = Context(map(OSProc, xs); kwargs...)
+Context(ctx::Context, xs::Vector) = # make a copy
+    Context(xs; log_sink=ctx.log_sink, log_file=ctx.log_file,
+    profile=ctx.profile, options=ctx.options)
 procs(ctx::Context) = lock(ctx) do
     copy(ctx.procs)
 end

--- a/src/processor.jl
+++ b/src/processor.jl
@@ -168,7 +168,6 @@ iscompatible_arg(proc::ThreadProc, opts, x) = true
 else
     # TODO: Use Threads.@threads?
     function execute!(proc::ThreadProc, f, args...)
-        sch_handle = task_local_storage(:sch_handle)
         tls = get_tls()
         task = @async begin
             set_tls!(tls)

--- a/src/sch/Sch.jl
+++ b/src/sch/Sch.jl
@@ -374,7 +374,7 @@ function schedule!(ctx, state, procs=procs_to_use(ctx))
                 T = typeof(p)
                 extra_util = get(procutil, T, 1)
                 real_util = state.worker_pressure[gp][T]
-                cap = capacity(OSProc(gp), T)
+                cap = state.worker_capacity[gp][T]
                 if ((extra_util isa MaxUtilization) && (real_util > 0)) ||
                    ((extra_util isa Real) && (extra_util + real_util > cap))
                     continue

--- a/src/sch/Sch.jl
+++ b/src/sch/Sch.jl
@@ -245,8 +245,11 @@ function init_proc(state, p)
         state.worker_capacity[p.pid][OSProc] = 0
     end
     cap = remotecall(capacity, p.pid)
-    @async lock(state.lock) do
-        state.worker_capacity[p.pid] = fetch(cap)
+    @async begin
+        cap = fetch(cap)
+        lock(state.lock) do
+            state.worker_capacity[p.pid] = cap
+        end
     end
     # TODO: remotecall_fetch(_init_proc, p.pid, state.uid)
 

--- a/src/sch/Sch.jl
+++ b/src/sch/Sch.jl
@@ -868,12 +868,12 @@ function do_task(to_proc, extra_util, thunk_id, f, data, send_result, persist, c
         if ((extra_util isa MaxUtilization) && (real_util[] > 0)) ||
            ((extra_util isa Real) && (extra_util + real_util[] > cap))
             # Fully subscribed, wait and re-check
-            @debug "($(myid())) $f Waiting for free $(typeof(to_proc)): $extra_util | $(real_util[])/$cap"
+            @debug "($(myid())) $f ($thunk_id) Waiting for free $(typeof(to_proc)): $extra_util | $(real_util[])/$cap"
             unlock(ACTIVE_TASKS_LOCK)
             wait(TASK_SYNC)
         else
             # Under-subscribed, calculate extra utilization and execute thunk
-            @debug "($(myid())) Using available $to_proc: $extra_util | $(real_util[])/$cap"
+            @debug "($(myid())) ($thunk_id) Using available $to_proc: $extra_util | $(real_util[])/$cap"
             extra_util = if extra_util isa MaxUtilization
                 count(c->typeof(c)===typeof(to_proc), children(from_proc))
             else
@@ -911,7 +911,7 @@ function do_task(to_proc, extra_util, thunk_id, f, data, send_result, persist, c
     lock(ACTIVE_TASKS_LOCK) do
         real_util[] -= extra_util
     end
-    @debug "($(myid())) Releasing $(typeof(to_proc)): $extra_util | $(real_util[])/$cap"
+    @debug "($(myid())) ($thunk_id) Releasing $(typeof(to_proc)): $extra_util | $(real_util[])/$cap"
     notify(TASK_SYNC)
     metadata = (
         pressure=real_util[],

--- a/src/sch/Sch.jl
+++ b/src/sch/Sch.jl
@@ -4,7 +4,7 @@ using Distributed
 import MemPool: DRef
 
 import ..Dagger
-import ..Dagger: Context, Processor, Thunk, ThunkFuture, ThunkFailedException, Chunk, OSProc, order, free!, dependents, noffspring, istask, inputs, affinity, tochunk, @dbg, @logmsg, timespan_start, timespan_end, unrelease, procs, move, capacity, chunktype, choose_processor, default_enabled, get_processors, execute!, rmprocs!, addprocs!, thunk_processor
+import ..Dagger: Context, Processor, Thunk, ThunkFuture, ThunkFailedException, Chunk, OSProc, order, free!, dependents, noffspring, istask, inputs, affinity, tochunk, @dbg, @logmsg, timespan_start, timespan_end, unrelease, procs, move, capacity, chunktype, default_enabled, get_processors, execute!, rmprocs!, addprocs!, thunk_processor
 
 const OneToMany = Dict{Thunk, Set{Thunk}}
 

--- a/src/sch/fault-handler.jl
+++ b/src/sch/fault-handler.jl
@@ -2,9 +2,10 @@
     handle_fault(...)
 
 An internal function to handle a worker dying or being killed by the OS.
-Attempts to determine which `Thunk`s require rescheduling based on a
-"deadlist", and then corrects the scheduler's internal `ComputeState` struct
-to recover from the fault.
+Attempts to determine which `Thunk`s were running on (or had their results
+cached on) the dead worker, and stores them in a "deadlist". It uses this
+deadlist to correct the scheduler's internal `ComputeState` struct to recover
+from the fault.
 
 Note: The logic for this functionality is not currently perfectly robust to
 all failure modes, and is only really intended as a last-ditch attempt to
@@ -13,64 +14,31 @@ of DAGs, it *may* cause a `KeyError` or other failures in the scheduler due to
 the complexity of getting the internal state back to a consistent and proper
 state.
 """
-function handle_fault(ctx, state, oldproc)
-    # Find thunks whose results were cached on the dead worker and place them
-    # on what's called a "deadlist". This structure will direct the recovery
-    # of the scheduler's state.
+function handle_fault(ctx, state, deadproc)
+    @assert !isempty(procs(ctx)) "No workers left for fault handling!"
+
     deadlist = Thunk[]
+
+    # Evict cache entries that were stored on the worker
     for t in keys(state.cache)
         v = state.cache[t]
-        if v isa Chunk && v.handle isa DRef && v.handle.owner == oldproc.pid
+        if v isa Chunk && v.handle isa DRef && v.handle.owner == deadproc.pid
             push!(deadlist, t)
-            # Any inputs to dead cached thunks must be rescheduled
-            function bfs!(deadlist, t)
-                for input in t.inputs
-                    istask(input) || continue
-                    !(input in deadlist) && push!(deadlist, input)
-                    bfs!(deadlist, input)
-                end
-            end
-            bfs!(deadlist, t)
+            pop!(state.cache, t)
         end
     end
-    # TODO: Find *all* thunks who were actively running on the dead worker
-    # TODO: Set thunk.cache to nothing
-
-    # Empty cache of dead thunks
-    for ct in keys(state.cache)
-        if ct in deadlist
-            delete!(state.cache, ct)
+    # Remove thunks that were running on the worker
+    for t in collect(keys(state.running_on))
+        pid = state.running_on[t].pid
+        if pid == deadproc.pid
+            push!(deadlist, t)
+            delete!(state.running_on, t)
         end
     end
-
-    function fix_waitdicts!(state, deadlist, t::Thunk; isleaf=false)
-        waiting, waiting_data = state.waiting, state.waiting_data
-        if !(t in keys(waiting))
-            waiting[t] = Set{Thunk}()
-        end
-        if !isleaf
-            # If we aren't a leaf thunk, then we may still need to recover
-            # further into the DAG
-            for input in t.inputs
-                istask(input) || continue
-                @assert haskey(waiting, t) "Error: $t not in state.waiting"
-                push!(waiting[t], input)
-                push!(waiting_data[input], t)
-                isleaf = !(input in deadlist)
-                fix_waitdicts!(state, deadlist, input; isleaf=isleaf)
-            end
-        end
-        if isempty(waiting[t])
-            delete!(waiting, t)
-        end
+    # Clear thunk.cache_ref
+    for t in deadlist
+        t.cache_ref = nothing
     end
-
-    # Add state.waiting deps back to state.waiting
-    for ot in keys(state.waiting)
-        fix_waitdicts!(state, deadlist, ot)
-    end
-
-    #fix_waitdicts!(state, deadlist, thunk)
 
     # Remove thunks from state.ready that have inputs on the deadlist
     for idx in length(state.ready):-1:1
@@ -80,40 +48,10 @@ function handle_fault(ctx, state, oldproc)
         end
     end
 
-    # Remove dead thunks from state.running, and add state.running
-    # deps back to state.waiting
-    wasrunning = copy(state.running)
-    empty!(state.running)
-    while !isempty(wasrunning)
-        temp = pop!(wasrunning)
-        if temp isa Thunk
-            if !(temp in deadlist)
-                push!(state.running, temp)
-            end
-            fix_waitdicts!(state, deadlist, temp)
-        elseif temp isa Vector
-            newtemp = []
-            for t in temp
-                fix_waitdicts!(state, deadlist, t)
-                if !(t in deadlist)
-                    push!(newtemp, t)
-                end
-            end
-            isempty(newtemp) || push!(state.running, newtemp)
-        else
-            throw("Unexpected type in recovery: $temp")
-        end
-    end
-
     # Reschedule inputs from deadlist
-    @assert !isempty(procs(ctx)) "No workers left for fault handling!"
-    while length(deadlist) > 0
-        dt = popfirst!(deadlist)
-        if any((input in deadlist) for input in dt.inputs)
-            # We need to schedule our input thunks first
-            continue
-        end
-        push!(state.ready, dt)
+    seen = Dict{Thunk,Bool}()
+    for t in deadlist
+        reschedule_inputs!(state, t, seen)
     end
     schedule!(ctx, state)
 end

--- a/src/sch/unix.jl
+++ b/src/sch/unix.jl
@@ -13,7 +13,7 @@ struct TimeSpec
     tv_nsec :: UInt64
 end
 
-maketime(ts) = ts.tv_sec * 1e9 + ts.tv_nsec
+maketime(ts) = ts.tv_sec * UInt(1e9) + ts.tv_nsec
 
 # From bits/times.h on a Linux system
 # Check if those are the same on BSD

--- a/src/sch/unix.jl
+++ b/src/sch/unix.jl
@@ -1,0 +1,77 @@
+##
+# This file is a part of Dagger.jl. License is MIT
+#
+# Based upon https://github.com/google/benchmark, which is licensed under Apache v2:
+# https://github.com/google/benchmark/blob/master/LICENSE
+#
+# In compliance with the Apache v2 license, here are the original copyright notices:
+# Copyright 2015 Google Inc. All rights reserved.
+##
+
+struct TimeSpec
+    tv_sec  :: UInt64 # time_t
+    tv_nsec :: UInt64
+end
+
+maketime(ts) = ts.tv_sec * 1e9 + ts.tv_nsec
+
+# From bits/times.h on a Linux system
+# Check if those are the same on BSD
+if Sys.islinux()
+    const CLOCK_MONOTONIC          = Cint(1)
+    const CLOCK_PROCESS_CPUTIME_ID = Cint(2)
+    const CLOCK_THREAD_CPUTIME_ID  = Cint(3)
+elseif Sys.KERNEL == :FreeBSD # atleast on FreeBSD 11.1
+    const CLOCK_MONOTONIC          = Cint(4)
+    const CLOCK_PROCESS_CPUTIME_ID = Cint(14)
+elseif Compat.Sys.isapple() # Version 10.12 required
+    const CLOCK_MONOTONIC          = Cint(6)
+    const CLOCK_PROCESS_CPUTIME_ID = Cint(12)
+else
+    error("""
+          BenchmarkTools doesn't currently support your operating system.
+          Please file an issue, your kernel is $(Sys.KERNEL)
+          """)
+end
+
+@inline function clock_gettime(cid)
+    ts = Ref{TimeSpec}()
+    ccall(:clock_gettime, Cint, (Cint, Ref{TimeSpec}), cid, ts)
+    return ts[]
+end
+
+@inline function realtime()
+    maketime(clock_gettime(CLOCK_MONOTONIC))
+end
+
+@inline function cputime()
+    maketime(clock_gettime(CLOCK_PROCESS_CPUTIME_ID))
+end
+
+@inline function cputhreadtime()
+    maketime(clock_gettime(CLOCK_THREAD_CPUTIME_ID))
+end
+
+struct Measurement
+    realtime::TimeSpec
+    cputime::TimeSpec
+    function Measurement()
+        rtime = clock_gettime(CLOCK_MONOTONIC)
+        ctime = clock_gettime(CLOCK_PROCESS_CPUTIME_ID)
+        return new(rtime, ctime)
+    end
+end
+
+struct MeasurementDelta
+    realtime::Float64
+    cpuratio::Float64
+    function MeasurementDelta(t1::Measurement, t0::Measurement)
+        rt0 = maketime(t0.realtime)
+        ct0 = maketime(t0.cputime)
+        rt1 = maketime(t1.realtime)
+        ct1 = maketime(t1.cputime)
+        realtime = rt1 - rt0
+        cputime = ct1 - ct0
+        return new(realtime, cputime/realtime)
+    end
+end

--- a/src/sch/util.jl
+++ b/src/sch/util.jl
@@ -14,9 +14,11 @@ function reschedule_inputs!(state, thunk)
     w = get!(()->Set{Thunk}(), state.waiting, thunk)
     scheduled = false
     for input in thunk.inputs
+        if istask(input) || (input isa Chunk)
+            push!(get!(()->Set{Thunk}(), state.waiting_data, input), thunk)
+            push!(get!(()->Set{Thunk}(), state.dependents, input), thunk)
+        end
         istask(input) || continue
-        push!(get!(()->Set{Thunk}(), state.waiting_data, input), thunk)
-        push!(get!(()->Set{Thunk}(), state.dependents, input), thunk)
         if input in state.errored
             set_failed!(state, input, thunk)
             break # TODO: Allow collecting all error'd inputs

--- a/src/sch/util.jl
+++ b/src/sch/util.jl
@@ -107,3 +107,17 @@ function print_sch_status(io::IO, state, thunk; offset=0, limit=5)
         end
     end
 end
+
+function fetch_report(task)
+    try
+        fetch(task)
+    catch err
+        @static if VERSION >= v"1.1"
+            stk = Base.catch_stack(task)
+            err, frames = stk[1]
+            rethrow(CapturedException(err, frames))
+        else
+            rethrow(task.result)
+        end
+    end
+end

--- a/src/sch/util.jl
+++ b/src/sch/util.jl
@@ -121,3 +121,8 @@ function fetch_report(task)
         end
     end
 end
+
+function signature(task::Thunk, state)
+    inputs = map(x->istask(x) ? state.cache[x] : x, task.inputs)
+    Tuple{typeof(task.f), map(x->x isa Chunk ? x.chunktype : typeof(x), inputs)...}
+end

--- a/src/ui/gantt-server.jl
+++ b/src/ui/gantt-server.jl
@@ -1,12 +1,11 @@
 using .Mux
 
-function serve_gantt(svg_path, prof_path; port=8000)
+function serve_gantt(svg_path, prof_path; port=8000, delay=5)
     # Setup Mux app
     @app gantt_app = (
         Mux.defaults,
         page(req->begin
             data = String(read(svg_path))
-            prof = String(read(prof_path))
             html = """
             <html>
             <head>
@@ -16,8 +15,31 @@ function serve_gantt(svg_path, prof_path; port=8000)
             <meta http-equiv="refresh" content="$delay">
             </head>
             <body>
+            <a href="/profile">Go to profile data</a>
             $data
-            <br/>
+            </body>
+            </html>
+            """
+            hdrs = Dict(
+                Symbol("Content-Type")=>"text/html",
+                Symbol("Cache-Control")=>"no-store",
+            )
+            Dict(
+                :body=>html,
+                :headers=>hdrs,
+            )
+        end),
+        page("/profile", req->begin
+            prof = String(read(prof_path))
+            html = """
+            <html>
+            <head>
+            <title>
+            Dagger: Scheduler Profile Flamegraph
+            </title>
+            <meta http-equiv="refresh" content="$delay">
+            </head>
+            <body>
             $prof
             </body>
             </html>
@@ -35,5 +57,11 @@ function serve_gantt(svg_path, prof_path; port=8000)
     )
 
     # Start serving app
-    Threads.@spawn serve(gantt_app, port)
+    Threads.@spawn begin
+        try
+            serve(gantt_app, port)
+        catch err
+            @error exception=(err,catch_backtrace())
+        end
+    end
 end

--- a/src/ui/gantt.jl
+++ b/src/ui/gantt.jl
@@ -188,13 +188,11 @@ function show_gantt(ctx; delay=2, port=8000, width=1000, height=640, window_leng
             draw_gantt(ctx, svg_path, prof_path; delay=delay, width=width,
                        height=height, window_length=window_length)
         catch err
-            Base.showerror(stderr, err)
-            Base.show_backtrace(stderr, catch_backtrace())
-            println(stderr)
+            @error exception=(err,catch_backtrace())
         end
     end
 
     if live
-        serve_gantt(svg_path, prof_path; port=port)
+        serve_gantt(svg_path, prof_path; port=port, delay=delay)
     end
 end

--- a/test/processors.jl
+++ b/test/processors.jl
@@ -37,9 +37,9 @@ end
     end
     @testset "Processor exhaustion" begin
         opts = ThunkOptions(proclist=[OptOutProc])
-        @test_throws_unwrap AssertionError collect(delayed(sum; options=opts)([1,2,3]))
+        @test_throws_unwrap Dagger.Sch.SchedulingException reason="No processors available, try making proclist more liberal" collect(delayed(sum; options=opts)([1,2,3]))
         opts = ThunkOptions(proclist=(proc)->false)
-        @test_throws_unwrap AssertionError collect(delayed(sum; options=opts)([1,2,3]))
+        @test_throws_unwrap Dagger.Sch.SchedulingException reason="No processors available, try making proclist more liberal" collect(delayed(sum; options=opts)([1,2,3]))
         opts = ThunkOptions(proclist=nothing)
         @test collect(delayed(sum; options=opts)([1,2,3])) == 6
     end

--- a/test/scheduler.jl
+++ b/test/scheduler.jl
@@ -371,3 +371,22 @@ end
         end
     end
 end
+
+c1 = Dagger.tochunk(1)
+c2 = Dagger.tochunk(2)
+@everywhere begin
+function testpresent(x,y)
+    @assert haskey(Dagger.Sch.CHUNK_CACHE, $c1)
+    @assert haskey(Dagger.Sch.CHUNK_CACHE, $c2)
+    x+y
+end
+function testevicted(x)
+    sleep(1)
+    @assert !haskey(Dagger.Sch.CHUNK_CACHE, $c1)
+    @assert !haskey(Dagger.Sch.CHUNK_CACHE, $c2)
+    x
+end
+end
+@testset "Caching" begin
+    compute(delayed(testevicted)(delayed(testpresent)(c1,c2)))
+end

--- a/test/scheduler.jl
+++ b/test/scheduler.jl
@@ -353,12 +353,7 @@ end
         @test res == 2
         @testset "self as input" begin
             a = delayed(dynamic_add_thunk_self_dominated)(1)
-            try
-                collect(Context(), a)
-                @test false
-            catch err
-                @test Dagger.Sch.unwrap_nested_exception(err) isa AssertionError
-            end
+            @test_throws_unwrap Dagger.Sch.DynamicThunkException reason="Cannot fetch result of dominated thunk" collect(Context(), a)
         end
     end
     @testset "Fetch/Wait" begin
@@ -368,21 +363,11 @@ end
         end
         @testset "self" begin
             a = delayed(dynamic_fetch_self)(1)
-            try
-                collect(Context(), a)
-                @test false
-            catch err
-                @test Dagger.Sch.unwrap_nested_exception(err) isa AssertionError
-            end
+            @test_throws_unwrap Dagger.Sch.DynamicThunkException reason="Cannot fetch own result" collect(Context(), a)
         end
         @testset "dominated" begin
             a = delayed(identity)(delayed(dynamic_fetch_dominated)(1))
-            try
-                collect(Context(), a)
-                @test false
-            catch err
-                @test Dagger.Sch.unwrap_nested_exception(err) isa AssertionError
-            end
+            @test_throws_unwrap Dagger.Sch.DynamicThunkException reason="Cannot fetch result of dominated thunk" collect(Context(), a)
         end
     end
 end

--- a/test/util.jl
+++ b/test/util.jl
@@ -1,10 +1,25 @@
-macro test_throws_unwrap(terr, ex)
+macro test_throws_unwrap(terr, args...)
+    _test_throws_unwrap(terr, args...)
+end
+function _test_throws_unwrap(terr, ex; to_match=[])
+    @gensym rerr
+    match_expr = Expr(:block)
+    for m in to_match
+        @assert m.head == :(=)
+        push!(match_expr.args, :(@test $rerr.$(m.args[1]) == $(m.args[2])))
+    end
     quote
-        rerr = try
+        $rerr = try
             $(esc(ex))
         catch err
-            err
+            Dagger.Sch.unwrap_nested_exception(err)
         end
-        @test Dagger.Sch.unwrap_nested_exception(rerr) isa $terr
+        @test $rerr isa $terr
+        $match_expr
     end
+end
+function _test_throws_unwrap(terr, args...)
+    ex = last(args)
+    to_match = args[1:end-1]
+    _test_throws_unwrap(terr, ex; to_match=to_match)
 end


### PR DESCRIPTION
This PR adds runtime estimation of thunk costs (per signature) to get as close to max utilization as possible (without impacting total runtime). It also adds chunk data caches to workers, which will be freed by the scheduler once they're no longer needed.

~Depends on https://github.com/JuliaData/MemPool.jl/pull/49~ Not doing this for now, wrong API for performance reasons.

Closes #205

Todo:
- [x] Parameterize function cost cache on argument types
- [x] Cache Chunk arguments per-process
- [x] Also key chunk cache on processor
- [x] Track Chunk usage and evict from caches ASAP
- [x] Test caching behavior
- [ ] ~Scale thunk cost by number of running thunks on same processor~ Something for later, possibly
- [ ] ~Add lots more benchmarks from https://blog.dask.org/2017/07/03/scaling~ https://github.com/JuliaParallel/Dagger.jl/issues/220
- [x] Confirm we benchmark better than master