### PR TITLE
Optimize thunk placement for input affinity

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 Colors = "0.10, 0.11, 0.12"
-MemPool = "0.3.4"
+MemPool = "0.3.5"
 Requires = "1"
 StatsBase = "0.28, 0.29, 0.30, 0.31, 0.32, 0.33"
 julia = "1.0"

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -48,6 +48,7 @@ domain(c::Chunk) = c.domain
 chunktype(c::Chunk) = c.chunktype
 persist!(t::Chunk) = (t.persist=true; t)
 shouldpersist(p::Chunk) = t.persist
+processor(c::Chunk) = c.processor
 affinity(c::Chunk) = affinity(c.handle)
 
 function unrelease(c::Chunk{<:Any,DRef})
@@ -101,7 +102,7 @@ move(to_proc::Processor, x) =
     move(OSProc(), to_proc, x)
 
 ### ChunkIO
-affinity(r::DRef) = Pair{OSProc, UInt64}[OSProc(r.owner) => r.size]
+affinity(r::DRef) = OSProc(r.owner)=>r.size
 function affinity(r::FileRef)
     if haskey(MemPool.who_has_read, r.file)
         Pair{OSProc, UInt64}[OSProc(dref.owner) => r.size for dref in MemPool.who_has_read[r.file]]

--- a/src/processor.jl
+++ b/src/processor.jl
@@ -101,6 +101,7 @@ struct OSProc <: Processor
     end
 end
 const OSPROC_CACHE = Dict{Int,Vector{Processor}}()
+get_parent(proc::OSProc) = proc
 children(proc::OSProc) = OSPROC_CACHE[proc.pid]
 function get_proc_hierarchy()
     children = Processor[]

--- a/test/array.jl
+++ b/test/array.jl
@@ -209,11 +209,10 @@ using MemPool
 @testset "affinity" begin
     x = Dagger.tochunk([1:10;])
     aff = Dagger.affinity(x)
-    @test length(aff) == 1
-    @test aff[1][1] == Dagger.OSProc(myid())
-    @test aff[1][2] == sizeof(Int)*10
+    @test aff[1] == Dagger.OSProc(myid())
+    @test aff[2] == sizeof(Int)*10
     @test Dagger.tochunk(x) === x
-    f = MemPool.FileRef("/tmp/d", aff[1][2])
+    f = MemPool.FileRef("/tmp/d", aff[2])
     aff = Dagger.affinity(f)
     #@test length(aff) == 3
     @test (aff[1][1]).pid in procs()


### PR DESCRIPTION
The previous algorithm only accounted for how many thunks could fit on a single processor, without regard for where that thunk's inputs are coming from (thus causing lots of potentially unnecessary network transfers). The new algorithm is simply placed before the existing one, and tries to find the processor which contains the most amount of input data for a given thunk. If all processors containing that thunk's input data are at capacity, we simply fall back to the old algorithm.

@shashi this should make you happy :slightly_smiling_face: 

Todo:
- [ ] Amortize some costs when calculating chunk affinity and rejecting processors
- [ ] Benchmark better than master