### PR TITLE
Fix dynamic_fib

### DIFF
--- a/src/sch/eager.jl
+++ b/src/sch/eager.jl
@@ -35,6 +35,7 @@ function adjust_pressure!(h::SchedulerHandle, proctype::Type, pressure)
     uid = Dagger.get_tls().sch_uid
     lock(ACTIVE_TASKS_LOCK) do
         ACTIVE_TASKS[uid][proctype][] += pressure
+        notify(TASK_SYNC)
     end
     exec!(_adjust_pressure!, h, myid(), proctype, pressure)
 end

--- a/test/thunk.jl
+++ b/test/thunk.jl
@@ -5,7 +5,8 @@ import Dagger: @par, @spawn, spawn
     function dynamic_fib(n)
         n <= 1 && return n
         t = Dagger.spawn(dynamic_fib, n-1)
-        return (fetch(t)::Int) + dynamic_fib(n-2)
+        y = dynamic_fib(n-2)
+        return (fetch(t)::Int) + y
     end
 end
 
@@ -147,6 +148,6 @@ end
         @test fetch(a) == 3
 
         # Mild stress-test
-        @test fetch(dynamic_fib(10)) == 55
+        @test dynamic_fib(10) == 55
     end
 end


### PR DESCRIPTION
Parallel dynamic fib requires calling `dynamic_fib(n-2)` before `fetch`. Otherwise, all recursions are done serially.

Maybe it was me who sent this code to @jpsamaroo :)
