### PR TITLE
Fix memory leaks in eager API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Dagger"
 uuid = "d58978e5-989f-55fb-8d15-ea34adc7bf54"
-version = "0.11.5"
+version = "0.11.6"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/src/Dagger.jl
+++ b/src/Dagger.jl
@@ -2,6 +2,8 @@ module Dagger
 
 using Distributed, SharedArrays
 
+using MemPool
+
 import Base: collect, adjoint, reduce
 import Distributed: procs
 

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -1,5 +1,3 @@
-
-using MemPool
 using Serialization
 
 export domain, UnitDomain, project, alignfirst, ArrayDomain

--- a/src/sch/util.jl
+++ b/src/sch/util.jl
@@ -12,17 +12,17 @@ unwrap_nested_exception(err) = err
 "Prepares the scheduler to schedule `thunk`."
 function reschedule_inputs!(state, thunk, seen=Dict{Thunk,Bool}())
     haskey(seen, thunk) && return seen[thunk]
+    haskey(state.cache, thunk) && return false
     w = get!(()->Set{Thunk}(), state.waiting, thunk)
     scheduled = false
-    for input in thunk.inputs
+    for input in unwrap_weak.(thunk.inputs)
         if istask(input) || (input isa Chunk)
             push!(get!(()->Set{Thunk}(), state.waiting_data, input), thunk)
-            push!(get!(()->Set{Thunk}(), state.dependents, input), thunk)
         end
         istask(input) || continue
         if input in state.errored
             set_failed!(state, input, thunk)
-            break # TODO: Allow collecting all error'd inputs
+            scheduled = true
         end
         haskey(state.cache, input) && continue
         if (input in state.running) ||
@@ -34,10 +34,14 @@ function reschedule_inputs!(state, thunk, seen=Dict{Thunk,Bool}())
             error("Failed to reschedule $(input.id) for $(thunk.id)")
         end
     end
+    get!(()->Set{Thunk}(), state.waiting_data, thunk)
     if isempty(w) && !(thunk in state.errored)
         # Inputs are ready
         push!(state.ready, thunk)
         delete!(state.waiting, thunk)
+        if !get(state.errored, thunk, false)
+            push!(state.ready, thunk)
+        end
         return true
     else
         return scheduled
@@ -56,11 +60,13 @@ function set_failed!(state, origin, thunk=origin)
         end
         delete!(state.futures, thunk)
     end
-    for dep in state.dependents[thunk]
-        if haskey(state.waiting, dep)
-            pop!(state.waiting, dep)
+    if haskey(state.waiting_data, thunk)
+        for dep in state.waiting_data[thunk]
+            if haskey(state.waiting, dep)
+                pop!(state.waiting, dep)
+            end
+            set_failed!(state, origin, dep)
         end
-        set_failed!(state, origin, dep)
     end
 end
 
@@ -109,9 +115,6 @@ function print_sch_status(io::IO, state, thunk; offset=0, limit=5, max_inputs=3)
         if haskey(state.waiting_data, input) && thunk in state.waiting_data[input]
             status *= "w"
         end
-        if haskey(state.dependents, input) && thunk in state.dependents[input]
-            status *= "d"
-        end
         if haskey(state.futures, input)
             status *= "f($(length(state.futures[input])))"
         end
@@ -139,6 +142,6 @@ function fetch_report(task)
 end
 
 function signature(task::Thunk, state)
-    inputs = map(x->istask(x) ? state.cache[x] : x, task.inputs)
+    inputs = map(x->istask(x) ? state.cache[x] : x, unwrap_weak.(task.inputs))
     Tuple{typeof(task.f), map(x->x isa Chunk ? x.chunktype : typeof(x), inputs)...}
 end

--- a/src/thunk.jl
+++ b/src/thunk.jl
@@ -1,10 +1,7 @@
 export Thunk, delayed, delayedmap
 
-# TODO: Make this thread-safe
-let counter=0
-    global next_id
-    next_id() = (counter >= (1 << 30)) ? (counter = 1) : (counter += 1)
-end
+const ID_COUNTER = Threads.Atomic{Int}(1)
+next_id() = Threads.atomic_add!(ID_COUNTER, 1)
 
 """
     Thunk

--- a/src/thunk.jl
+++ b/src/thunk.jl
@@ -118,6 +118,7 @@ end
 
 delayedmap(f, xs...) = map(delayed(f), xs...)
 
+"A future holding the result of a `Thunk`."
 struct ThunkFuture
     future::Future
 end
@@ -138,14 +139,33 @@ function Base.fetch(t::ThunkFuture; proc=OSProc())
 end
 Base.put!(t::ThunkFuture, x; error=false) = put!(t.future, (error, x))
 
+"A weak reference to a `Thunk`."
+struct WeakThunk
+    x::WeakRef
+    WeakThunk(t::Thunk) = new(WeakRef(t))
+end
+istask(::WeakThunk) = true
+unwrap_weak(t::WeakThunk) = t.x.value
+unwrap_weak(t) = t
+Base.show(io::IO, t::WeakThunk) = (print(io, "~"); Base.show(io, t.x.value))
+Base.convert(::Type{WeakThunk}, t::Thunk) = WeakThunk(t)
+
 struct ThunkFailedException{E<:Exception} <: Exception
-    thunk::Thunk
-    origin::Thunk
+    thunk::WeakThunk
+    origin::WeakThunk
     ex::E
 end
+ThunkFailedException(thunk, origin, ex::E) where E =
+    ThunkFailedException{E}(convert(WeakThunk, thunk), convert(WeakThunk, origin), ex)
 function Base.showerror(io::IO, ex::ThunkFailedException)
-    println(io, "$(ex.thunk) (id $(ex.thunk.id)) failure",
-                ex.thunk !== ex.origin ? " due to a failure in $(ex.origin)" : "",
+    t = unwrap_weak(ex.thunk)
+    o = unwrap_weak(ex.origin)
+    t_str = t !== nothing ? "$t" : "?"
+    o_str = o !== nothing ? "$o" : "?"
+    t_id = t !== nothing ? t.id : '?'
+    o_id = o !== nothing ? o.id : '?'
+    println(io, "ThunkFailedException ($t failure",
+                (o !== nothing && t != o) ? " due to a failure in $o)" : ")",
                 ":")
     Base.showerror(io, ex.ex)
 end
@@ -158,7 +178,7 @@ scheduler, potentially ready to execute, executing, or finished executing. May
 be `fetch`'d or `wait`'d on at any time.
 """
 mutable struct EagerThunk
-    uid::Int
+    uid::UInt
     future::ThunkFuture
     ref::DRef
 end
@@ -171,7 +191,7 @@ end
 
 "When finalized, cleans-up the associated `EagerThunk`."
 mutable struct EagerThunkFinalizer
-    uid::Int
+    uid::UInt
     function EagerThunkFinalizer(uid)
         x = new(uid)
         finalizer(Sch.eager_cleanup, x)
@@ -293,7 +313,7 @@ Base.isequal(x::Thunk, y::Thunk) = x.id==y.id
 
 function Base.show(io::IO, z::Thunk)
     lvl = get(io, :lazy_level, 1)
-    print(io, "Thunk($(z.f), ")
+    print(io, "Thunk[$(z.id)]($(z.f), ")
     if lvl < 2
         show(IOContext(io, :lazy_level => lvl+1), z.inputs)
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,21 @@ include("util.jl")
 include("fakeproc.jl")
 
 include("thunk.jl")
+
+# FIXME: Unreliable, and some thunks still get retained
+# N.B. We need a few of these probably because of incremental WeakRef GC
+@everywhere GC.gc()
+@everywhere GC.gc()
+@everywhere GC.gc()
+@everywhere GC.gc()
+sleep(1)
+@test isempty(Dagger.Sch.EAGER_ID_MAP)
+state = Dagger.Sch.EAGER_STATE[]
+@test isempty(state.waiting)
+@test_broken length(keys(state.waiting_data)) == 1
+# Ensure that all cache entries have expired
+@test_broken isempty(state.cache)
+
 include("scheduler.jl")
 include("processors.jl")
 include("ui.jl")

--- a/test/scheduler.jl
+++ b/test/scheduler.jl
@@ -1,4 +1,4 @@
-import Dagger.Sch: SchedulerOptions, ThunkOptions, SchedulerHaltedException, ComputeState, sch_handle
+import Dagger.Sch: SchedulerOptions, ThunkOptions, SchedulerHaltedException, ComputeState, ThunkID, sch_handle
 
 @everywhere begin
 using Dagger
@@ -46,7 +46,7 @@ end
 function dynamic_get_dag(x...)
     h = sch_handle()
     ids = Dagger.Sch.get_dag_ids(h)
-    return (h.thunk_id, ids)
+    return ids
 end
 function dynamic_add_thunk(x)
     h = sch_handle()
@@ -333,19 +333,22 @@ end
         b = delayed(x->x+2)(a)
         c = delayed(x->x-1)(a)
         d = delayed(dynamic_get_dag)(b, c)
-        (d_id, ids) = collect(Context(), d)
+        ids = collect(Context(), d)
         @test ids isa Dict
         @test length(keys(ids)) == 4
+
+        a_id = ThunkID(a.id)
+        b_id = ThunkID(b.id)
+        c_id = ThunkID(c.id)
+        d_id = ThunkID(d.id)
+
         @test haskey(ids, d_id)
-        d_deps = ids[d_id]
-        @test length(d_deps) == 0
-        a_id = Dagger.Sch.ThunkID(d_id.id - 3) # relies on thunk ID monotonicity
-        a_deps = ids[a_id]
-        @test length(a_deps) == 2
-        i1, i2 =  pop!(a_deps), pop!(a_deps)
-        @test haskey(ids, i1)
-        @test haskey(ids, i2)
-        @test ids[pop!(ids[i1])] == ids[pop!(ids[i2])]
+        @test length(ids[d_id]) == 0 # no one waiting on our result
+        @test length(ids[a_id]) == 0 # b and c finished, our result is unneeded
+        @test length(ids[b_id]) == 1 # d is still executing
+        @test length(ids[c_id]) == 1 # d is still executing
+        @test pop!(ids[b_id]) == d_id
+        @test pop!(ids[c_id]) == d_id
     end
     @testset "Add Thunk" begin
         a = delayed(dynamic_add_thunk)(1)
@@ -387,6 +390,6 @@ function testevicted(x)
     x
 end
 end
-@testset "Caching" begin
+@testset "Chunk Caching" begin
     compute(delayed(testevicted)(delayed(testpresent)(c1,c2)))
 end

--- a/test/thunk.jl
+++ b/test/thunk.jl
@@ -81,7 +81,7 @@ end
             end
             ex = Dagger.Sch.unwrap_nested_exception(ex)
             ex_str = sprint(io->Base.showerror(io,ex))
-            @test occursin(r"^Thunk.*failure:", ex_str)
+            @test occursin(r"^ThunkFailedException \(Thunk.*failure\):", ex_str)
             @test occursin("Test", ex_str)
             @test !occursin("due to a failure in", ex_str)
 
@@ -92,7 +92,7 @@ end
             end
             ex = Dagger.Sch.unwrap_nested_exception(ex)
             ex_str = sprint(io->Base.showerror(io,ex))
-            @test occursin(r"^Thunk.*failure due to a failure in", ex_str)
+            @test occursin(r"Thunk.*failure due to a failure in", ex_str)
             @test occursin("Test", ex_str)
         end
         @testset "single dependent" begin


### PR DESCRIPTION
We need to ensure that we allow eager-allocated `Thunk`s to become unreferenced by the scheduler when they're no longer needed, so that they and their inputs can be subject to GC.

This also fixes a memory leak caused by the dynamic listener not terminating with its associated scheduler, resulting in a leak of the entire `ComputeState`.