### PR TITLE
Set Julia 1.3 as minimum supported version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ Requires = "1"
 StatsBase = "0.28, 0.29, 0.30, 0.31, 0.32, 0.33"
 Tables = "1.5"
 TableOperations = "1"
-julia = "1.0"
+julia = "1.3"
 
 [extras]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - julia_version: 1.0
-  - julia_version: 1
+  - julia_version: 1.3
+  - julia_version: 1.6
   - julia_version: nightly
 
 platform:


### PR DESCRIPTION
Once a new LTS is officially announced, 1.3 will also be dropped in favor of that release (probably 1.6).