### PR TITLE
settable global eager SchedulerOptions

### DIFF
--- a/src/sch/eager.jl
+++ b/src/sch/eager.jl
@@ -22,7 +22,6 @@ otherwise the global eager scheduler options are set to
 function global_eager_scheduler_options(; kwargs...)
     if !isassigned(EAGER_SCH_OPTS) || !isempty(kwargs)
         EAGER_SCH_OPTS[] = SchedulerOptions(; kwargs...)
-        @show EAGER_SCH_OPTS[]
     end
     return EAGER_SCH_OPTS[]
 end

--- a/src/sch/eager.jl
+++ b/src/sch/eager.jl
@@ -19,7 +19,7 @@ otherwise the global eager scheduler options are set to
 # Returns
 - `SchedulerOptions`: The global options used for eager scheduling.
 """
-function global_eager_scheduler_options(; kwargs...)
+function eager_options(; kwargs...)
     if !isassigned(EAGER_SCH_OPTS) || !isempty(kwargs)
         EAGER_SCH_OPTS[] = SchedulerOptions(; kwargs...)
     end

--- a/src/sch/eager.jl
+++ b/src/sch/eager.jl
@@ -8,7 +8,7 @@ const EAGER_SCH_OPTS = Ref{SchedulerOptions}(SchedulerOptions(;allow_errors=true
 eager_context() = isassigned(EAGER_CONTEXT) ? EAGER_CONTEXT[] : nothing
 
 """
-    global_eager_scheduler_options(; kwargs...)
+    eager_options(; kwargs...)
 
 Set / retrieve the global eager scheduler options.
 If no `kwargs` are passed, the current `SchedulerOptions` is returned,
@@ -20,14 +20,14 @@ otherwise the global eager scheduler options are set to
 - `SchedulerOptions`: The global options used for eager scheduling.
 """
 function eager_options(; kwargs...)
-    if !isassigned(EAGER_SCH_OPTS) || !isempty(kwargs)
+    if !isempty(kwargs)
         EAGER_SCH_OPTS[] = SchedulerOptions(; kwargs...)
     end
     return EAGER_SCH_OPTS[]
 end
 
 """
-    global_eager_scheduler_options(options::SchedulerOptions)
+    eager_options(options::SchedulerOptions)
 
 Set the global `SchedulerOptions` used for eager scheduling.
 # Arguments
@@ -35,7 +35,7 @@ Set the global `SchedulerOptions` used for eager scheduling.
 # Returns
 - `SchedulerOptions`
 """
-function global_eager_scheduler_options(options::SchedulerOptions)
+function eager_options(options::SchedulerOptions)
     return EAGER_SCH_OPTS[] = options
 end
 
@@ -47,7 +47,7 @@ function init_eager()
     end
     ctx = EAGER_CONTEXT[]
     @async try
-        sopts = global_eager_scheduler_options()
+        sopts = eager_options()
         topts = ThunkOptions(;single=1)
         Dagger.compute(ctx, Dagger.delayed(eager_thunk;options=topts)(); options=sopts)
     catch err

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,10 +5,108 @@ using Test
 using Dagger
 using UUIDs
 
-include("util.jl")
-include("fakeproc.jl")
+#function test_set_eager_options()
+#    Dagger.Sch.eager_options(; single=1)
+#    eager_ctxt1 = @spawn _get_sch_ctxt(3)
+#    Dagger.Sch.eager_options(; single=0)
+#    sleep(1)
+#    eager_ctxt0 = @spawn _get_sch_ctxt(1)
+#    @test fetch(eager_ctxt1).options.single == 1
+#    @test fetch(eager_ctxt0).options.single == 0
+#end
+#@everywhere using Dagger
+#@everywhere _get_sch_ctxt(seconds) = (sleep(seconds); Dagger.Sch.eager_context())
+#@testset "Set eager options once" begin
+#    test_set_eager_options()
+#end
 
+####
+#### uncomment above, get errors below
+####
+
+##Set eager options once: Error During Test at /home/ubuntu/projects/Dagger.jl/test/runtests.jl:18
+##  Test threw exception
+##  Expression: (fetch(eager_ctxt1)).options.single == 1
+##  type Nothing has no field options
+##  Stacktrace:
+##   [1] getproperty(x::Nothing, f::Symbol)
+##     @ Base ./Base.jl:33
+##   [2] test_set_eager_options()
+##     @ Main ~/projects/Dagger.jl/test/runtests.jl:18
+##   [3] macro expansion
+##     @ ~/projects/Dagger.jl/test/runtests.jl:23 [inlined]
+##   [4] macro expansion
+##     @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
+##   [5] top-level scope
+##     @ ~/projects/Dagger.jl/test/runtests.jl:23
+##Set eager options once: Error During Test at /home/ubuntu/projects/Dagger.jl/test/runtests.jl:19
+##  Test threw exception
+##  Expression: (fetch(eager_ctxt0)).options.single == 0
+##  type Nothing has no field options
+##  Stacktrace:
+##   [1] getproperty(x::Nothing, f::Symbol)
+##     @ Base ./Base.jl:33
+##   [2] test_set_eager_options()
+##     @ Main ~/projects/Dagger.jl/test/runtests.jl:19
+##   [3] macro expansion
+##     @ ~/projects/Dagger.jl/test/runtests.jl:23 [inlined]
+##   [4] macro expansion
+##     @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
+##   [5] top-level scope
+##     @ ~/projects/Dagger.jl/test/runtests.jl:23
+##Test Summary:          | Error  Total
+##Set eager options once |     2      2
+
+include("util.jl")
+
+include("fakeproc.jl")
 include("thunk.jl")
+
+function test_set_eager_options()
+    Dagger.Sch.eager_options(; single=1)
+    eager_ctxt1 = @spawn _get_sch_ctxt(3)
+    Dagger.Sch.eager_options(; single=0)
+    sleep(1)
+    eager_ctxt0 = @spawn _get_sch_ctxt(1)
+    @test fetch(eager_ctxt1).options.single == 1
+    @test fetch(eager_ctxt0).options.single == 0
+end
+@everywhere using Dagger
+@everywhere _get_sch_ctxt(seconds) = (sleep(seconds); Dagger.Sch.eager_context())
+@testset "Set eager options once again" begin
+    test_set_eager_options()
+end
+#Set eager options once again: Test Failed at /home/ubuntu/projects/Dagger.jl/test/runtests.jl:68
+#  Expression: (fetch(eager_ctxt1)).options.single == 1
+#   Evaluated: 0 == 1
+#Stacktrace:
+# [1] test_set_eager_options()
+#   @ Main ~/projects/Dagger.jl/test/runtests.jl:68
+# [2] macro expansion
+#   @ ~/projects/Dagger.jl/test/runtests.jl:75 [inlined]
+# [3] macro expansion
+#   @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
+# [4] top-level scope
+#   @ ~/projects/Dagger.jl/test/runtests.jl:75
+#Set eager options once again: Error During Test at /home/ubuntu/projects/Dagger.jl/test/runtests.jl:69
+#  Test threw exception
+#  Expression: (fetch(eager_ctxt0)).options.single == 0
+#  type Nothing has no field options
+#  Stacktrace:
+#   [1] getproperty(x::Nothing, f::Symbol)
+#     @ Base ./Base.jl:33
+#   [2] test_set_eager_options()
+#     @ Main ~/projects/Dagger.jl/test/runtests.jl:69
+#   [3] macro expansion
+#     @ ~/projects/Dagger.jl/test/runtests.jl:75 [inlined]
+#   [4] macro expansion
+#     @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
+#   [5] top-level scope
+#     @ ~/projects/Dagger.jl/test/runtests.jl:75
+#Test Summary:                | Fail  Error  Total
+#Set eager options once again |    1      1      2
+
+
 
 #= FIXME: Unreliable, and some thunks still get retained
 # N.B. We need a few of these probably because of incremental WeakRef GC
@@ -25,19 +123,19 @@ state = Dagger.Sch.EAGER_STATE[]
 @test_broken isempty(state.cache)
 =#
 
-include("scheduler.jl")
-include("processors.jl")
-include("ui.jl")
-include("checkpoint.jl")
-include("scopes.jl")
-include("domain.jl")
-include("array.jl")
-include("cache.jl")
-include("table.jl")
-try # TODO: Fault tolerance is sometimes unreliable
-include("fault-tolerance.jl")
-catch
-end
-println(stderr, "tests done. cleaning up...")
-Dagger.cleanup()
-println(stderr, "all done.")
+#include("scheduler.jl")
+#include("processors.jl")
+#include("ui.jl")
+#include("checkpoint.jl")
+#include("scopes.jl")
+#include("domain.jl")
+#include("array.jl")
+#include("cache.jl")
+#include("table.jl")
+#try # TODO: Fault tolerance is sometimes unreliable
+#include("fault-tolerance.jl")
+#catch
+#end
+#println(stderr, "tests done. cleaning up...")
+#Dagger.cleanup()
+#println(stderr, "all done.")


### PR DESCRIPTION
There is currently no way to set `SchedulerOptions` for the eager scheduler. This makes the options a global ref and adds a setter/getter.