### PR TITLE
Fix keyerror for eager api

### DIFF
--- a/src/thunk.jl
+++ b/src/thunk.jl
@@ -205,9 +205,12 @@ mutable struct EagerThunkFinalizer
     end
 end
 
+const EAGER_ID_COUNTER = Threads.Atomic{UInt64}(1)
+eager_next_id() = Threads.atomic_add!(EAGER_ID_COUNTER, one(UInt64))
+
 function _spawn(f, args...; kwargs...)
     Dagger.Sch.init_eager()
-    uid = rand(UInt)
+    uid = eager_next_id()
     future = ThunkFuture()
     finalizer_ref = poolset(EagerThunkFinalizer(uid))
     added_future = Future()


### PR DESCRIPTION
So since the UID was a rand() very rarely weird things like keyerrors would happen, especially in case when you're rerunning tests or using ```@btime```

Noticed by running these usecases and by looking at EAGER_ID_MAP and thunk_dict.

I'm 50% sure it fixes the occasional hangs as well, but I'll try to confirm it next week

fixes https://github.com/JuliaParallel/Dagger.jl/issues/267