### PR TITLE
[DTable] Leftjoin

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,6 +23,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 Colors = "0.10, 0.11, 0.12"
+DataAPI = "1.8"
 MemPool = "0.3.5"
 Requires = "1"
 SentinelArrays = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.13.7"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
+DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MemPool = "f9f48841-c794-520a-933b-121f7ba6ed94"

--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 Colors = "0.10, 0.11, 0.12"
-DataAPI = "1.8"
+DataAPI = "1"
 MemPool = "0.3.5"
 Requires = "1"
 SentinelArrays = "1"

--- a/docs/src/api/functions.md
+++ b/docs/src/api/functions.md
@@ -24,10 +24,16 @@ treereduce
 ```@docs
 tabletype
 tabletype!
+trim
+trim!
 map
-reduce
 filter
+reduce
 groupby
+leftjoin
+innerjoin
+keys
+getindex
 ```
 
 ## Array Functions

--- a/docs/src/dtable.md
+++ b/docs/src/dtable.md
@@ -304,22 +304,22 @@ It can be done by using the following keyword arguments:
 - `r_unique`: To indicate the right table only contains unique keys.
 - `lookup`: To provide a dict-like structure that will allow for quicker matching of inner rows. The structure needs to contain keys in form of a `Tuple` of the matched columns and values in form of type `Vector{UInt}` containing the related row indices.
 
-The join operations are designed in a way that allows calling specialized join methods for table types that define them.
-A good example is joining a `DTable` (with underlying table type `DataFrame`) with a `DataFrame`.
-This join will use the specialized join methods defined within the `DataFrames.jl` package.
-Please note that the usage of any of the keyword arguments described above will result in the usage of join methods
+Currently there is a special case available where joining a `DTable` (with `DataFrame` as the underlying table type) with a `DataFrame` will use
+the join functions coming from the `DataFrames.jl` package for the per chunk joins.
+In the future this behavior will be expanded to any type that implements its own join methods, but for now is limited to `DataFrame` only.
+
+Please note that the usage of any of the keyword arguments described above will always result in the usage of generic join methods
 defined in `Dagger` regardless of the availability of specialized methods.
-Joining two `DTable`s will fall back to those implementations as well.
 
 ```julia
-julia> pp = (d) -> for x in Tables.rows(d) println("$(x.a), $(x.b), $(x.c)") end;
+julia> using Tables; pp = d -> for x in Tables.rows(d) println("$(x.a), $(x.b), $(x.c)") end;
 
 julia> d1 = (a=collect(1:6), b=collect(1:6));
 
 julia> d2 = (a=collect(2:5), c=collect(-2:-1:-5));
 
 julia> dt = DTable(d1, 2)
-DTable with 5 partitions
+DTable with 3 partitions
 Tabletype: NamedTuple
 
 julia> pp(leftjoin(dt, d2, on=:a))
@@ -328,11 +328,7 @@ julia> pp(leftjoin(dt, d2, on=:a))
 3, 3, -3
 4, 4, -4
 5, 5, -5
-6, 6, -6
-7, 7, -7
-8, 8, -8
-9, 9, -9
-10, 10, missing
+6, 6, missing
 
 julia> pp(innerjoin(dt, d2, on=:a))
 2, 2, -2

--- a/docs/src/dtable.md
+++ b/docs/src/dtable.md
@@ -286,3 +286,27 @@ Key: b
    1 │ b         3
    2 │ b         4
 ```
+
+# Joins
+
+There are two join methods available currently: `leftjoin` and `innerjoin`.
+The interface is aiming to be compatible with the `DataFrames.jl` join interface, but for now it only supports
+the `on` keyword argument with symbol input. More keyword arguments known from `DataFrames` may be introduced in the future.
+
+It's possible to perform it on a `DTable` and any `Tables.jl` compatible table type.
+Joining two `DTable`s is possible as well, but it's not yet an optimized operation (treats the second `DTable` as any other table).
+
+There are several options to make your joins faster by providing additional information about the tables.
+It can be done by using the following keyword arguments:
+
+- `l_sorted`: To indicate the left table is sorted - only useful if the `r_sorted` is set to `true` as well.
+- `r_sorted`: To indicate the right table is sorted.
+- `r_unique`: To indicate the right table only contains unique keys.
+- `lookup`: You can pass a dict-like structure here that will allow for quicker matching of inner rows. The structure needs to contain keys in form of a `Tuple` and values in form of type `Vector{UInt}` containing the related row indices.
+
+The join operations are designed in a way that allows calling specialized join methods for table types that define them.
+A good example is joining a `DTable` (with underlying table type `DataFrame`) with a `DataFrame`.
+This join will use the specialized join methods defined within the `DataFrames.jl` package.
+Please note that the usage of any of the keyword arguments described above will result in the usage of join methods
+defined in `Dagger` regardless of the availability of specialized methods.
+

--- a/docs/src/dtable.md
+++ b/docs/src/dtable.md
@@ -294,7 +294,7 @@ The interface is aiming to be compatible with the `DataFrames.jl` join interface
 the `on` keyword argument with symbol input. More keyword arguments known from `DataFrames` may be introduced in the future.
 
 It's possible to perform a join on a `DTable` and any `Tables.jl` compatible table type.
-Joining two `DTable`s is possible as well, but it's not yet an optimized operation (treats the second `DTable` as any other table).
+Joining two `DTable`s is also supported and it will leverage the fact that the second `DTable` is partitioned during the joining process.
 
 There are several options to make your joins faster by providing additional information about the tables.
 It can be done by using the following keyword arguments:
@@ -309,6 +309,7 @@ A good example is joining a `DTable` (with underlying table type `DataFrame`) wi
 This join will use the specialized join methods defined within the `DataFrames.jl` package.
 Please note that the usage of any of the keyword arguments described above will result in the usage of join methods
 defined in `Dagger` regardless of the availability of specialized methods.
+Joining two `DTable`s will fall back to those implementations as well.
 
 ```julia
 julia> pp = (d) -> for x in Tables.rows(d) println("$(x.a), $(x.b), $(x.c)") end;

--- a/src/Dagger.jl
+++ b/src/Dagger.jl
@@ -59,6 +59,7 @@ include("table/gdtable.jl")
 include("table/tables.jl")
 include("table/operations.jl")
 include("table/groupby.jl")
+include("table/join.jl")
 
 include("lib/logging-extras.jl")
 

--- a/src/Dagger.jl
+++ b/src/Dagger.jl
@@ -59,6 +59,7 @@ include("table/gdtable.jl")
 include("table/tables.jl")
 include("table/operations.jl")
 include("table/groupby.jl")
+include("table/join_interface.jl")
 include("table/join.jl")
 
 include("lib/logging-extras.jl")

--- a/src/table/dtable.jl
+++ b/src/table/dtable.jl
@@ -4,7 +4,7 @@ import SentinelArrays
 
 import Base: fetch, show, length
 
-export DTable, tabletype, tabletype!, trim, trim!
+export DTable, tabletype, tabletype!, trim, trim!, leftjoin, innerjoin
 
 const VTYPE = Vector{Union{Dagger.Chunk,Dagger.EagerThunk}}
 
@@ -20,7 +20,7 @@ the underlying partitions was applied to it (currently only `filter`).
 mutable struct DTable
     chunks::VTYPE
     tabletype
-    schema::Union{Nothing, Tables.Schema}
+    schema::Union{Nothing,Tables.Schema}
     DTable(chunks::VTYPE, tabletype) = new(chunks, tabletype, nothing)
 end
 

--- a/src/table/dtable.jl
+++ b/src/table/dtable.jl
@@ -207,3 +207,5 @@ function _columnnames_svector(d::DTable)
 end
 
 @inline nchunks(d::DTable) = length(d.chunks)
+
+merge_chunks(sink, chunks) = sink(TableOperations.joinpartitions(Tables.partitioner(_retrieve, chunks)))

--- a/src/table/groupby.jl
+++ b/src/table/groupby.jl
@@ -121,7 +121,7 @@ function _groupby(
     merge::Bool,
     chunksize::Int)
 
-    grouping_function = cols === nothing ? row_function : nothing 
+    grouping_function = cols === nothing ? row_function : nothing
 
     spawner = (_dchunks, _row_function) -> Vector{EagerThunk}([Dagger.@spawn distinct_partitions(c, _row_function) for c in _dchunks])
 
@@ -154,9 +154,6 @@ function _distinct_partitions_iterate(chunk, f, keyval::T) where T
 
     Vector{Pair{T, Chunk}}([x => Dagger.tochunk(Tables.columntable(acc[x])) for x in collect(keys(acc))])
 end
-
-
-merge_chunks(sink, chunks) = sink(TableOperations.joinpartitions(Tables.partitioner(_retrieve, chunks)))
 
 rowcount(chunk) = length(Tables.rows(chunk))
 

--- a/src/table/join.jl
+++ b/src/table/join.jl
@@ -1,17 +1,31 @@
-r = (id=10,)
 
-d1=  DTable((id=1:10,a=1.0:10.0), 5)
-d2 = (id=1:10, b=11:20)
 
-function leftjoin(d1::DTable, d2)
-    col = :id
+function leftjoin(d1, d2)
+    sink = Tables.materializer(d1)
+    cols = [:id]
     rowmap = row -> (Tables.getcolumn(row, :id),)
-    match = Vector{Bool}(undef, length(Tables.rows(d1)))
-    for o in Tables.rows(d1)
+    
+    bvec = Vector{Union{Int, Missing}}()
+    schema = Tables.schema(d2)
+    
+    names = filter(x -> x ∉ cols, schema.names)
+    collectors = []
+    for n in names
+        push!(collectors, Vector{Union{Any, Missing}}())
+    end
 
+    for o in Tables.rows(d1)
+        ro = rowmap(o)
+        ri = missing
         for i in Tables.rows(d2)
-        
-            continue
+            if ro == rowmap(i)
+                ri = i
+                break
+            end
+        end
+        for (idx,n) in enumerate(names)
+            push!(collectors[idx], ri === missing ? missing : Tables.getcolumn(ri, n))
         end
     end
+    sink((;Tables.columntable(d1)..., [n => collectors[idx] for (idx, n) in enumerate(names)]...))
 end

--- a/src/table/join.jl
+++ b/src/table/join.jl
@@ -46,16 +46,20 @@ function _leftjoin(l, r, l_ind::NTuple{N1,Int}, r_ind::NTuple{N1,Int}, r_new_ind
     end
 
     @inbounds for o in Tables.rows(l)
+        test = false
         for i in Tables.rows(r)
-            if compare_rows(o, i, l_ind, r_ind)
-                for j in 1:length(r_new_ind)
+            test = compare_rows(o, i, l_ind, r_ind)
+            if test
+                for j in 1:N2
                     push!(collectors[j], Tables.getcolumn(i, r_new_ind[j]))
                 end
                 break
             end
         end
-        @inbounds for j in 1:N2
-            push!(collectors[j], missing)
+        if !test
+            @inbounds for j in 1:N2
+                push!(collectors[j], missing)
+            end
         end
     end
 

--- a/src/table/join.jl
+++ b/src/table/join.jl
@@ -46,9 +46,9 @@ function _leftjoin(l, r, l_ind::NTuple{N1,Int}, r_ind::NTuple{N1,Int}, r_new_ind
     end
 
     @inbounds for o in Tables.rows(l)
-        test = false
+        cmp = false
         for i in Tables.rows(r)
-            test = compare_rows(o, i, l_ind, r_ind)
+            cmp = compare_rows(o, i, l_ind, r_ind)
             if test
                 for j in 1:N2
                     push!(collectors[j], Tables.getcolumn(i, r_new_ind[j]))
@@ -56,7 +56,7 @@ function _leftjoin(l, r, l_ind::NTuple{N1,Int}, r_ind::NTuple{N1,Int}, r_new_ind
                 break
             end
         end
-        if !test
+        if !cmp
             @inbounds for j in 1:N2
                 push!(collectors[j], missing)
             end

--- a/src/table/join.jl
+++ b/src/table/join.jl
@@ -1,31 +1,74 @@
+function _resolve_indices(d1, d2, on)
+    isnothing(on) && error("yeet")
+    if on isa Symbol
+        l_cols = [on]
+        r_cols = [on]
+    elseif on isa Vector{Symbol}
+        l_cols = on
+        r_cols = on
+    elseif on isa Vector{Pair{Symbol, Symbol}}
+        l_cols = getindex.(on, 1)
+        r_cols = getindex.(on, 2)
+    end
+    d1_names = collect(Tables.schema(d1).names)
+    d2_names = collect(Tables.schema(d2).names)
+    _l = length(l_cols)
+    l_cols_indices = NTuple{_l, Int}(indexin(l_cols, d1_names))
+    r_cols_indices = NTuple{_l, Int}(indexin(r_cols, d2_names))
+    l_cols_indices, r_cols_indices
+end
+
+function leftjoin(d1::DTable, d2; on=nothing, d2_mode=:full)
+    l_cols_indices, r_cols_indices = _resolve_indices(d1, d2, on)
+    _a = setdiff(1:length(Tables.columnnames(d2)), r_cols_indices)
+    r_new_ind = NTuple{length(_a), Int}(_a)
+    v = [Dagger.@spawn _leftjoin(c, d2, l_cols_indices, r_cols_indices,r_new_ind) for c in d1.chunks]
+    DTable(v, d1.tabletype)
+end
 
 
-function leftjoin(d1, d2)
-    sink = Tables.materializer(d1)
-    cols = [:id]
-    rowmap = row -> (Tables.getcolumn(row, :id),)
-    
-    bvec = Vector{Union{Int, Missing}}()
-    schema = Tables.schema(d2)
-    
-    names = filter(x -> x ∉ cols, schema.names)
-    collectors = []
-    for n in names
-        push!(collectors, Vector{Union{Any, Missing}}())
+
+# per partition, full r table joining
+function _leftjoin(l, r, l_ind::NTuple{N1,Int}, r_ind::NTuple{N1,Int}, r_new_ind::NTuple{N2,Int}) where {N1, N2}
+    sink = Tables.materializer(l)
+    collectors = Vector{Vector}()
+    sizehint!(collectors, length(r_new_ind))
+
+    rschema = Tables.schema(r)
+    rnames = rschema.names
+    llength = length(Tables.rows(l))
+
+    @inbounds for i in r_new_ind
+        t = isnothing(rschema.types) ? Any : rschema.types[i]
+        p = Vector{Union{t, Missing}}()
+        sizehint!(p, llength)
+        push!(collectors, p)
     end
 
-    for o in Tables.rows(d1)
-        ro = rowmap(o)
-        ri = missing
-        for i in Tables.rows(d2)
-            if ro == rowmap(i)
-                ri = i
+    @inbounds for o in Tables.rows(l)
+        for i in Tables.rows(r)
+            if compare_rows(o, i, l_ind, r_ind)
+                for j in 1:length(r_new_ind)
+                    push!(collectors[j], Tables.getcolumn(i, r_new_ind[j]))
+                end
                 break
             end
         end
-        for (idx,n) in enumerate(names)
-            push!(collectors[idx], ri === missing ? missing : Tables.getcolumn(ri, n))
+        @inbounds for j in 1:N2
+            push!(collectors[j], missing)
         end
     end
-    sink((;Tables.columntable(d1)..., [n => collectors[idx] for (idx, n) in enumerate(names)]...))
+
+    left_cols = Tables.columntable(l)
+    new_cols = [rnames[col_idx] => collectors[i] for (i, col_idx) in enumerate(r_new_ind)]
+    sink((;left_cols..., new_cols...))
+end
+
+function compare_rows(o, i, l_ind::NTuple{N, Int}, r_ind::NTuple{N, Int}) where {N}
+    test = true
+    @inbounds for x in 1:N
+        test &= Tables.getcolumn(o, l_ind[x]) == Tables.getcolumn(i, r_ind[x])
+        test || break
+    end
+    test
 end

--- a/src/table/join.jl
+++ b/src/table/join.jl
@@ -1,0 +1,17 @@
+r = (id=10,)
+
+d1=  DTable((id=1:10,a=1.0:10.0), 5)
+d2 = (id=1:10, b=11:20)
+
+function leftjoin(d1::DTable, d2)
+    col = :id
+    rowmap = row -> (Tables.getcolumn(row, :id),)
+    match = Vector{Bool}(undef, length(Tables.rows(d1)))
+    for o in Tables.rows(d1)
+
+        for i in Tables.rows(d2)
+        
+            continue
+        end
+    end
+end

--- a/src/table/join.jl
+++ b/src/table/join.jl
@@ -245,10 +245,13 @@ function build_joined_table(
 
     rcols = Tables.columns(r)
     for i in other_r
-        c = Tables.getcolumn(rcols, i)
-        vectype = jointype == :innerjoin ? eltype(c) : Union{eltype(c),Missing}
+        t = Tables.schema(rcols).types[i]
+        vectype = jointype == :innerjoin ? t : Union{t,Missing}
         newc = Vector{vectype}(undef, fulllength)
-        copyto!(newc, view(c, inner_r))
+        if length(inner_r) > 0 # skip fetching and copying if there's no records matched
+            c = Tables.getcolumn(rcols, i)
+            copyto!(newc, view(c, inner_r))
+        end
         cols[colcounter] = newc
         colcounter += 1
     end

--- a/src/table/join.jl
+++ b/src/table/join.jl
@@ -34,7 +34,12 @@ function resolve_colnames(l, r, on)
     final_nameset, other_l, other_r, cmp_l, cmp_r
 end
 
+"""
+    match_inner_indices(l, r, l_ind::NTuple{N,Int}, r_ind::NTuple{N,Int})
 
+Returns two vectors containing indices of matched rows.
+Standard non-optimized use case.
+"""
 function match_inner_indices(l, r, l_ind::NTuple{N,Int}, r_ind::NTuple{N,Int}) where {N}
     l_length = length(Tables.rows(l))
     vl = Vector{UInt}()
@@ -52,7 +57,16 @@ function match_inner_indices(l, r, l_ind::NTuple{N,Int}, r_ind::NTuple{N,Int}) w
     vl, vr
 end
 
+"""
+    match_inner_indices_lookup(l, lookup, l_ind::NTuple{N,Int})
 
+Returns two vectors containing indices of matched rows.
+Uses `lookup` to find the matching indices.
+
+`lookup` needs to be a dict-like structure that contains keys in
+form of a `Tuple` of all matching columns and values in form
+of type `Vector{UInt}` containing the related row indices.
+"""
 function match_inner_indices_lookup(l, lookup, l_ind::NTuple{N,Int}) where {N}
     l_length = length(Tables.rows(l))
     vl = Vector{UInt}()
@@ -72,7 +86,12 @@ function match_inner_indices_lookup(l, lookup, l_ind::NTuple{N,Int}) where {N}
     vl, vr
 end
 
+"""
+    match_inner_indices_lsorted_rsorted(l, r, cmp_l::NTuple{N,Int}, cmp_r::NTuple{N,Int}, runique::Bool)
 
+Returns two vectors containing indices of matched rows.
+Optimized pass for the left table sorted, right table sorted and optionally right table only containing unique keys.
+"""
 function match_inner_indices_lsorted_rsorted(l, r, cmp_l::NTuple{N,Int}, cmp_r::NTuple{N,Int}, runique::Bool) where {N}
     l_length = length(Tables.rows(l))
     vl = Vector{UInt}()
@@ -128,7 +147,12 @@ function match_inner_indices_lsorted_rsorted(l, r, cmp_l::NTuple{N,Int}, cmp_r::
     vl, vr
 end
 
+"""
+    match_inner_indices_runique(l, r, cmp_l::NTuple{N,Int}, cmp_r::NTuple{N,Int})
 
+Returns two vectors containing indices of matched rows.
+Optimized pass for joins with the right table containing unique keys only.
+"""
 function match_inner_indices_runique(l, r, cmp_l::NTuple{N,Int}, cmp_r::NTuple{N,Int}) where {N}
     l_length = length(Tables.rows(l))
     vl = Vector{UInt}()
@@ -148,7 +172,12 @@ function match_inner_indices_runique(l, r, cmp_l::NTuple{N,Int}, cmp_r::NTuple{N
     vl, vr
 end
 
+"""
+    match_inner_indices_rsorted(l, r, cmp_l::NTuple{N,Int}, cmp_r::NTuple{N,Int})
 
+Returns two vectors containing indices of matched rows.
+Optimized pass for joins with a sorted right table.
+"""
 function match_inner_indices_rsorted(l, r, cmp_l::NTuple{N,Int}, cmp_r::NTuple{N,Int}) where {N}
     l_length = length(Tables.rows(l))
     vl = Vector{UInt}()
@@ -171,13 +200,24 @@ function match_inner_indices_rsorted(l, r, cmp_l::NTuple{N,Int}, cmp_r::NTuple{N
     vl, vr
 end
 
+"""
+    find_outer_indices(d, inner_indices)
 
+Finds the unmatched indices from the table.
+"""
 function find_outer_indices(d, inner_indices)
     s = Set(one(UInt):length(Tables.rows(d)))
     setdiff!(s, inner_indices)
 end
 
+"""
+    build_joined_table(jointype, names, l, r, inner_l, inner_r, outer_l, other_r)
 
+Takes the indices of matching rows (`inner*`) and the ones that weren't matched (`outer_l`) from the `l` table
+and builds the result based on that.
+
+Uses all the columns from the left column and the `other_r` columns from the right table.
+"""
 function build_joined_table(
         jointype::Symbol,
         names::Tuple,

--- a/src/table/join.jl
+++ b/src/table/join.jl
@@ -131,7 +131,7 @@ function match_inner_indices_lsorted_rsorted(l, r, cmp_l::NTuple{N,Int}, cmp_r::
             else
                 inner_riter = iterate(ri, rstate)
                 while inner_riter !== nothing
-                    ((i_iind, i_iel), i_rstate) = inner_riter
+                    (i_iind, i_iel), i_rstate = inner_riter
                     if compare_rows_eq(oel, i_iel, cmp_l, cmp_r)
                         push!(vl, oind)
                         push!(vr, i_iind)
@@ -269,11 +269,15 @@ end
 
 
 @inline function compare_rows_lt(o, i, cmp_l::NTuple{N,Int}, cmp_r::NTuple{N,Int}) where {N}
-    test = false
     @inbounds for x = 1:N
-        test |= Tables.getcolumn(o, cmp_l[x]) < Tables.getcolumn(i, cmp_r[x])
-        test && break
+        l = Tables.getcolumn(o, cmp_l[x])
+        r = Tables.getcolumn(i, cmp_r[x])
+        if l > r
+            return false
+        elseif l < r
+            return true
+        end
     end
-    test
+    false
 end
 

--- a/src/table/join.jl
+++ b/src/table/join.jl
@@ -22,7 +22,8 @@ function leftjoin(d1::DTable, d2; on=nothing, d2_mode=:full)
     l_cols_indices, r_cols_indices = _resolve_indices(d1, d2, on)
     _a = setdiff(1:length(Tables.columnnames(d2)), r_cols_indices)
     r_new_ind = NTuple{length(_a), Int}(_a)
-    v = [Dagger.@spawn _leftjoin(c, d2, l_cols_indices, r_cols_indices,r_new_ind) for c in d1.chunks]
+    v = [Dagger.@spawn newjoinflow(c, d2, l_cols_indices, r_cols_indices,r_new_ind) for c in d1.chunks]
+    # v = [Dagger.@spawn _leftjoin_nonunique_r(c, d2, l_cols_indices, r_cols_indices,r_new_ind) for c in d1.chunks]
     DTable(v, d1.tabletype)
 end
 
@@ -34,7 +35,7 @@ function _leftjoin(l, r, l_ind::NTuple{N1,Int}, r_ind::NTuple{N1,Int}, r_new_ind
     collectors = Vector{Vector}()
     sizehint!(collectors, length(r_new_ind))
 
-    rschema = Tables.schema(r)
+    rschema = Tables.schema(Tables.rows(r))
     rnames = rschema.names
     llength = length(Tables.rows(l))
 
@@ -49,7 +50,7 @@ function _leftjoin(l, r, l_ind::NTuple{N1,Int}, r_ind::NTuple{N1,Int}, r_new_ind
         cmp = false
         for i in Tables.rows(r)
             cmp = compare_rows(o, i, l_ind, r_ind)
-            if test
+            if cmp
                 for j in 1:N2
                     push!(collectors[j], Tables.getcolumn(i, r_new_ind[j]))
                 end
@@ -68,6 +69,128 @@ function _leftjoin(l, r, l_ind::NTuple{N1,Int}, r_ind::NTuple{N1,Int}, r_new_ind
     sink((;left_cols..., new_cols...))
 end
 
+function _leftjoin_nonunique_r(l, r, l_ind::NTuple{N1,Int}, r_ind::NTuple{N1,Int}, r_new_ind::NTuple{N2,Int}) where {N1, N2}
+    sink = Tables.materializer(l)
+    collectors = Vector{Vector}()
+    sizehint!(collectors, length(r_new_ind))
+
+    rschema = Tables.schema(Tables.rows(r))
+    rnames = rschema.names
+    llength = length(Tables.rows(l))
+
+    repeat_previous = BitVector()
+    sizehint!(repeat_previous, llength)
+
+    @inbounds for i in r_new_ind
+        t = isnothing(rschema.types) ? Any : rschema.types[i]
+        p = Vector{Union{t, Missing}}()
+        sizehint!(p, llength)
+        push!(collectors, p)
+    end
+
+    @inbounds for o in Tables.rows(l)
+        cmp = false
+        already_matched = false
+
+        for i in Tables.rows(r)
+            cmp = compare_rows(o, i, l_ind, r_ind)
+            if cmp
+                for j in 1:N2
+                    push!(collectors[j], Tables.getcolumn(i, r_new_ind[j]))
+                end
+                if already_matched
+                    push!(repeat_previous, true)
+                else
+                    push!(repeat_previous, false)
+                    already_matched = true
+                end
+            end
+        end
+        if !already_matched
+            push!(repeat_previous, false)
+            @inbounds for j in 1:N2
+                push!(collectors[j], missing)
+            end
+        end
+    end
+
+    function expand_column(col, repeat_previous)
+        newcol = Vector{eltype(col)}()
+        sizehint!(newcol, length(repeat_previous))
+        ind = 0
+        for b in repeat_previous
+            if !b ind += 1 end
+            push!(newcol, col[ind])
+        end
+        newcol
+    end
+
+    left_cols = Tables.columntable(l)
+    new_cols = [rnames[col_idx] => collectors[i] for (i, col_idx) in enumerate(r_new_ind)]
+    sink((;[k => expand_column(left_cols[k], repeat_previous) for k in Tables.columnnames(left_cols)]..., new_cols...))
+end
+
+function newjoinflow(l, r, l_ind::NTuple{N1,Int}, r_ind::NTuple{N1,Int}, r_new_ind::NTuple{N2,Int}) where {N1, N2}
+    vl, vr = inner_indices(l,r,l_ind, r_ind, r_new_ind)
+    vl2 = left_unmatched(l, vl)
+    build_result_table_based_on_indices(l,r, vl, vr, vl2, l_ind, r_ind, r_new_ind)
+end
+
+function inner_indices(l, r, l_ind::NTuple{N1,Int}, r_ind::NTuple{N1,Int}, r_new_ind::NTuple{N2,Int}) where {N1, N2}
+    
+    llength = length(Tables.rows(l))
+    vl = Vector{Int}()
+    sizehint!(vl, llength)
+    vr = Vector{Int}()
+    sizehint!(vr, llength)
+    for (oind, oel) in enumerate(Tables.rows(l))
+        for (iind, iel) in enumerate(Tables.rows(r))
+            cmp = compare_rows(oel, iel, l_ind, r_ind)
+            if cmp
+                push!(vl, oind)
+                push!(vr, iind)
+            end
+        end
+    end
+    vl, vr
+end
+
+function left_unmatched(l, vl)
+    s = Set(vl)
+    llenght=length(Tables.rows(l))
+    filter(x->x∉s, 1:llenght)
+end
+
+function build_result_table_based_on_indices(l, r, vl, vr, vl2, l_ind::NTuple{N1,Int}, r_ind::NTuple{N1,Int}, r_new_ind::NTuple{N2,Int}) where {N1, N2}
+    fulllength = length(vl) + length(vl2)
+    rcolnames = Tables.columnnames(Tables.columns(r))
+    lcolnames = Tables.columnnames(Tables.columns(l))
+    rrcolnames = getindex.(Ref(rcolnames), (2,))
+    allcolnames = vcat(lcolnames..., rrcolnames...)
+
+
+    cols = Vector{AbstractVector}(undef, N1+N2)
+
+    colcounter = 1
+    for c in Tables.columns(l)
+        newc = Vector{eltype(c)}(undef, fulllength)
+        copyto!(newc, view(c, vl))
+        copyto!(newc, length(vl) + 1, view(c, vl2))
+        cols[colcounter] = newc
+        colcounter += 1
+    end
+    for (i,c) in enumerate(Tables.columns(r))
+        i ∉ r_new_ind && continue
+        newc = Vector{Union{eltype(c), Missing}}(missing, fulllength)
+        copyto!(newc, view(c, vr))
+        cols[colcounter] = newc
+        colcounter += 1
+    end
+    sink = Tables.materializer(l)
+    # this sink allocates, but not sure if that's the best idea, because the columns are already copied at this point
+    sink([key => col for (key, col) in zip(allcolnames, cols)])
+end
+
 function compare_rows(o, i, l_ind::NTuple{N, Int}, r_ind::NTuple{N, Int}) where {N}
     test = true
     @inbounds for x in 1:N
@@ -76,3 +199,4 @@ function compare_rows(o, i, l_ind::NTuple{N, Int}, r_ind::NTuple{N, Int}) where 
     end
     test
 end
+

--- a/src/table/join.jl
+++ b/src/table/join.jl
@@ -50,15 +50,12 @@ function match_inner_indices(l, r, l_ind::NTuple{N,Int}, r_ind::NTuple{N,Int}) w
 end
 
 
-
-
 function match_inner_indices_lsorted_rsorted(l, r, cmp_l::NTuple{N,Int}, cmp_r::NTuple{N,Int}, runique::Bool) where {N}
     l_length = length(Tables.rows(l))
     vl = Vector{UInt}()
     vr = Vector{UInt}()
     sizehint!(vl, l_length) # these vectors will be at least this long
     sizehint!(vr, l_length)
-
 
     ri = enumerate(Tables.rows(r))
     li = enumerate(Tables.rows(l))
@@ -191,7 +188,7 @@ function build_joined_table(
 
     rcols = Tables.columns(r)
     for i in other_r
-        c = rcols[i]
+        c = Tables.getcolumn(rcols, i)
         vectype = jointype == :innerjoin ? eltype(c) : Union{eltype(c),Missing}
         newc = Vector{vectype}(undef, fulllength)
         copyto!(newc, view(c, inner_r))

--- a/src/table/join.jl
+++ b/src/table/join.jl
@@ -1,3 +1,19 @@
+import DataAPI: leftjoin, innerjoin
+
+function leftjoin(d1::DTable, d2; on=nothing)
+    f = (_d1, _d2, _on) -> leftjoin(_d1, _d2, on=_on)
+    v = [Dagger.@spawn f(c, d2, on) for c in d1.chunks]
+    DTable(v, d1.tabletype)
+end
+
+
+function innerjoin(d1::DTable, d2; on=nothing)
+    f = (_d1, _d2, _on) -> innerjoin(_d1, _d2, on=_on)
+    v = [Dagger.@spawn f(c, d2, on) for c in d1.chunks]
+    DTable(v, d1.tabletype)
+end
+
+
 function _resolve_indices(d1, d2, on)
     isnothing(on) && error("yeet")
     if on isa Symbol
@@ -6,138 +22,39 @@ function _resolve_indices(d1, d2, on)
     elseif on isa Vector{Symbol}
         l_cols = on
         r_cols = on
-    elseif on isa Vector{Pair{Symbol, Symbol}}
+    elseif on isa Vector{Pair{Symbol,Symbol}}
         l_cols = getindex.(on, 1)
         r_cols = getindex.(on, 2)
     end
-    d1_names = collect(Tables.schema(d1).names)
-    d2_names = collect(Tables.schema(d2).names)
+    d1_names = collect(Tables.schema(Tables.columns(d1)).names)
+    d2_names = collect(Tables.schema(Tables.columns(d2)).names)
     _l = length(l_cols)
-    l_cols_indices = NTuple{_l, Int}(indexin(l_cols, d1_names))
-    r_cols_indices = NTuple{_l, Int}(indexin(r_cols, d2_names))
+    l_cols_indices = NTuple{_l,Int}(indexin(l_cols, d1_names))
+    r_cols_indices = NTuple{_l,Int}(indexin(r_cols, d2_names))
     l_cols_indices, r_cols_indices
 end
 
-function leftjoin(d1::DTable, d2; on=nothing, d2_mode=:full)
-    l_cols_indices, r_cols_indices = _resolve_indices(d1, d2, on)
-    _a = setdiff(1:length(Tables.columnnames(d2)), r_cols_indices)
-    r_new_ind = NTuple{length(_a), Int}(_a)
-    v = [Dagger.@spawn newjoinflow(c, d2, l_cols_indices, r_cols_indices,r_new_ind) for c in d1.chunks]
-    # v = [Dagger.@spawn _leftjoin_nonunique_r(c, d2, l_cols_indices, r_cols_indices,r_new_ind) for c in d1.chunks]
-    DTable(v, d1.tabletype)
-end
 
-
-
-# per partition, full r table joining
-function _leftjoin(l, r, l_ind::NTuple{N1,Int}, r_ind::NTuple{N1,Int}, r_new_ind::NTuple{N2,Int}) where {N1, N2}
-    sink = Tables.materializer(l)
-    collectors = Vector{Vector}()
-    sizehint!(collectors, length(r_new_ind))
-
-    rschema = Tables.schema(Tables.rows(r))
-    rnames = rschema.names
-    llength = length(Tables.rows(l))
-
-    @inbounds for i in r_new_ind
-        t = isnothing(rschema.types) ? Any : rschema.types[i]
-        p = Vector{Union{t, Missing}}()
-        sizehint!(p, llength)
-        push!(collectors, p)
-    end
-
-    @inbounds for o in Tables.rows(l)
-        cmp = false
-        for i in Tables.rows(r)
-            cmp = compare_rows(o, i, l_ind, r_ind)
-            if cmp
-                for j in 1:N2
-                    push!(collectors[j], Tables.getcolumn(i, r_new_ind[j]))
-                end
-                break
-            end
-        end
-        if !cmp
-            @inbounds for j in 1:N2
-                push!(collectors[j], missing)
-            end
-        end
-    end
-
-    left_cols = Tables.columntable(l)
-    new_cols = [rnames[col_idx] => collectors[i] for (i, col_idx) in enumerate(r_new_ind)]
-    sink((;left_cols..., new_cols...))
-end
-
-function _leftjoin_nonunique_r(l, r, l_ind::NTuple{N1,Int}, r_ind::NTuple{N1,Int}, r_new_ind::NTuple{N2,Int}) where {N1, N2}
-    sink = Tables.materializer(l)
-    collectors = Vector{Vector}()
-    sizehint!(collectors, length(r_new_ind))
-
-    rschema = Tables.schema(Tables.rows(r))
-    rnames = rschema.names
-    llength = length(Tables.rows(l))
-
-    repeat_previous = BitVector()
-    sizehint!(repeat_previous, llength)
-
-    @inbounds for i in r_new_ind
-        t = isnothing(rschema.types) ? Any : rschema.types[i]
-        p = Vector{Union{t, Missing}}()
-        sizehint!(p, llength)
-        push!(collectors, p)
-    end
-
-    @inbounds for o in Tables.rows(l)
-        cmp = false
-        already_matched = false
-
-        for i in Tables.rows(r)
-            cmp = compare_rows(o, i, l_ind, r_ind)
-            if cmp
-                for j in 1:N2
-                    push!(collectors[j], Tables.getcolumn(i, r_new_ind[j]))
-                end
-                if already_matched
-                    push!(repeat_previous, true)
-                else
-                    push!(repeat_previous, false)
-                    already_matched = true
-                end
-            end
-        end
-        if !already_matched
-            push!(repeat_previous, false)
-            @inbounds for j in 1:N2
-                push!(collectors[j], missing)
-            end
-        end
-    end
-
-    function expand_column(col, repeat_previous)
-        newcol = Vector{eltype(col)}()
-        sizehint!(newcol, length(repeat_previous))
-        ind = 0
-        for b in repeat_previous
-            if !b ind += 1 end
-            push!(newcol, col[ind])
-        end
-        newcol
-    end
-
-    left_cols = Tables.columntable(l)
-    new_cols = [rnames[col_idx] => collectors[i] for (i, col_idx) in enumerate(r_new_ind)]
-    sink((;[k => expand_column(left_cols[k], repeat_previous) for k in Tables.columnnames(left_cols)]..., new_cols...))
-end
-
-function newjoinflow(l, r, l_ind::NTuple{N1,Int}, r_ind::NTuple{N1,Int}, r_new_ind::NTuple{N2,Int}) where {N1, N2}
-    vl, vr = inner_indices(l,r,l_ind, r_ind, r_new_ind)
+function leftjoin(l, r; on=nothing)
+    l_ind, r_ind = _resolve_indices(l, r, on)
+    _a = setdiff(1:length(Tables.columnnames(r)), r_ind)
+    r_new_ind = NTuple{length(_a),Int}(_a)
+    vl, vr = inner_indices(l, r, l_ind, r_ind, r_new_ind)
     vl2 = left_unmatched(l, vl)
-    build_result_table_based_on_indices(l,r, vl, vr, vl2, l_ind, r_ind, r_new_ind)
+    build_result_table_based_on_indices(l, r, vl, vr, vl2, l_ind, r_ind, r_new_ind)
 end
 
-function inner_indices(l, r, l_ind::NTuple{N1,Int}, r_ind::NTuple{N1,Int}, r_new_ind::NTuple{N2,Int}) where {N1, N2}
-    
+
+function innerjoin(l, r; on=nothing)
+    l_ind, r_ind = _resolve_indices(l, r, on)
+    _a = setdiff(1:length(Tables.columnnames(r)), r_ind)
+    r_new_ind = NTuple{length(_a),Int}(_a)
+    vl, vr = inner_indices(l, r, l_ind, r_ind, r_new_ind)
+    vl2 = [] 
+    build_result_table_based_on_indices(l, r, vl, vr, vl2, l_ind, r_ind, r_new_ind)
+end
+
+function inner_indices(l, r, l_ind::NTuple{N1,Int}, r_ind::NTuple{N1,Int}, r_new_ind::NTuple{N2,Int}) where {N1,N2}
     llength = length(Tables.rows(l))
     vl = Vector{Int}()
     sizehint!(vl, llength)
@@ -157,11 +74,11 @@ end
 
 function left_unmatched(l, vl)
     s = Set(vl)
-    llenght=length(Tables.rows(l))
-    filter(x->x∉s, 1:llenght)
+    llenght = length(Tables.rows(l))
+    filter(x -> x ∉ s, 1:llenght)
 end
 
-function build_result_table_based_on_indices(l, r, vl, vr, vl2, l_ind::NTuple{N1,Int}, r_ind::NTuple{N1,Int}, r_new_ind::NTuple{N2,Int}) where {N1, N2}
+function build_result_table_based_on_indices(l, r, vl, vr, vl2, l_ind::NTuple{N1,Int}, r_ind::NTuple{N1,Int}, r_new_ind::NTuple{N2,Int}) where {N1,N2}
     fulllength = length(vl) + length(vl2)
     rcolnames = Tables.columnnames(Tables.columns(r))
     lcolnames = Tables.columnnames(Tables.columns(l))
@@ -169,7 +86,7 @@ function build_result_table_based_on_indices(l, r, vl, vr, vl2, l_ind::NTuple{N1
     allcolnames = vcat(lcolnames..., rrcolnames...)
 
 
-    cols = Vector{AbstractVector}(undef, N1+N2)
+    cols = Vector{AbstractVector}(undef, N1 + N2)
 
     colcounter = 1
     for c in Tables.columns(l)
@@ -179,19 +96,18 @@ function build_result_table_based_on_indices(l, r, vl, vr, vl2, l_ind::NTuple{N1
         cols[colcounter] = newc
         colcounter += 1
     end
-    for (i,c) in enumerate(Tables.columns(r))
+    for (i, c) in enumerate(Tables.columns(r))
         i ∉ r_new_ind && continue
-        newc = Vector{Union{eltype(c), Missing}}(missing, fulllength)
+        newc = Vector{Union{eltype(c),Missing}}(missing, fulllength)
         copyto!(newc, view(c, vr))
         cols[colcounter] = newc
         colcounter += 1
     end
     sink = Tables.materializer(l)
-    # this sink allocates, but not sure if that's the best idea, because the columns are already copied at this point
-    sink([key => col for (key, col) in zip(allcolnames, cols)])
+    sink((;zip(allcolnames, cols)...))
 end
 
-function compare_rows(o, i, l_ind::NTuple{N, Int}, r_ind::NTuple{N, Int}) where {N}
+@inline function compare_rows(o, i, l_ind::NTuple{N,Int}, r_ind::NTuple{N,Int}) where {N}
     test = true
     @inbounds for x in 1:N
         test &= Tables.getcolumn(o, l_ind[x]) == Tables.getcolumn(i, r_ind[x])

--- a/src/table/join_interface.jl
+++ b/src/table/join_interface.jl
@@ -196,7 +196,7 @@ end
 """
     use_dataframe_join(d1type, d2type)
 
-Determines whether to use the DataAPI join function, which leads to usage of DataFrames join function.
+Determines whether to use the DataAPI join function, which leads to usage of DataFrames join function if both types are `DataFrame`.
 Remove this function and it's usage once a generic Tables.jl compatible join function becomes available.
 Porting the Dagger join functions to TableOperations is an option to achieve that.
 """

--- a/src/table/join_interface.jl
+++ b/src/table/join_interface.jl
@@ -87,7 +87,7 @@ function _join(
     names, _, other_r, cmp_l, cmp_r = resolve_colnames(l, r, on)
 
     inner_l, inner_r = if lookup !== nothing
-        match_inner_indices_lookup(l, lookup, cmp_l)
+        match_inner_indices_lookup(l, lookup, cmp_l) # uses the `lookup` to find indices
     elseif r_sorted && l_sorted
         match_inner_indices_lsorted_rsorted(l, r, cmp_l, cmp_r, r_unique) # loop through r once
     elseif r_unique

--- a/src/table/join_interface.jl
+++ b/src/table/join_interface.jl
@@ -25,7 +25,7 @@ and a `d2` of `DataFrame` type.
 - `l_sorted`: To indicate the left table is sorted - only useful if the `r_sorted` is set to `true` as well.
 - `r_sorted`: To indicate the right table is sorted.
 - `r_unique`: To indicate the right table only contains unique keys.
-- `lookup`: You can pass a dict-like structure here that will allow for quicker matching of inner rows. The structure needs to contain keys in form of a `Tuple` and values in form of type `Vector{UInt}` containing the related row indices.
+- `lookup`: To provide a dict-like structure that will allow for quicker matching of inner rows. The structure needs to contain keys in form of a `Tuple` and values in form of type `Vector{UInt}` containing the related row indices.
 """
 function leftjoin(d1::DTable, d2; kwargs...)
     f = if any(k in JOINKWARGS for k in keys(kwargs))

--- a/src/table/join_interface.jl
+++ b/src/table/join_interface.jl
@@ -37,6 +37,11 @@ function leftjoin(d1::DTable, d2; kwargs...)
     DTable(v, d1.tabletype)
 end
 
+function leftjoin(d1::GDTable, d2; kwargs...)
+    d = leftjoin(d1.dtable, d2; kwargs...)
+    GDTable(d, d1.cols, d1.index)
+end
+
 leftjoin(l, r; on=nothing) = _leftjoin(l, r; on=on)
 _leftjoin(l, r; kwargs...) = _join(:leftjoin, l, r; kwargs...)
 
@@ -68,6 +73,11 @@ function innerjoin(d1::DTable, d2; kwargs...)
     end
     v = [Dagger.@spawn f(c, d2, kwargs) for c in d1.chunks]
     DTable(v, d1.tabletype)
+end
+
+function innerjoin(d1::GDTable, d2; kwargs...)
+    d = innerjoin(d1.dtable, d2; kwargs...)
+    GDTable(d, d1.cols, d1.index)
 end
 
 innerjoin(l, r; on=nothing) = _innerjoin(l, r; on=on)

--- a/src/table/join_interface.jl
+++ b/src/table/join_interface.jl
@@ -1,29 +1,52 @@
 import DataAPI: leftjoin, innerjoin
 
+const JOINKWARGS = Set([
+    :l_sorted,
+    :r_sorted,
+    :r_unique,
+    :build_lookup,
+    :lookup_table,])
 
-function leftjoin(d1::DTable, d2; on = nothing)
-    f = (_d1, _d2, _on) -> leftjoin(_d1, _d2, on = _on)
-    v = [Dagger.@spawn f(c, d2, on) for c in d1.chunks]
+
+function leftjoin(d1::DTable, d2; kwargs...)
+    f = (_d1, _d2, kwargs) -> leftjoin(_d1, _d2; kwargs...)
+    if any(k in JOINKWARGS for k in keys(kwargs))
+        f = (_d1, _d2, kwargs) -> _leftjoin(_d1, _d2; kwargs...)
+    end
+
+    v = [Dagger.@spawn f(c, d2, kwargs) for c in d1.chunks]
     DTable(v, d1.tabletype)
 end
 
-function leftjoin(l, r; on = nothing)
-    names, _, other_r, cmp_l, cmp_r = resolve_colnames(l, r, on)
-    inner_l, inner_r = match_inner_indices(l, r, cmp_l, cmp_r)
-    outer_l = find_outer_indices(l, inner_l)
-    build_joined_table(:leftjoin, names, l, r, inner_l, inner_r, outer_l, other_r)
-end
+leftjoin(l, r; on = nothing) = _leftjoin(l, r; on = on)
+_leftjoin(l, r; kwargs...) = _join(:leftjoin, l, r; kwargs...)
 
 
-function innerjoin(d1::DTable, d2; on = nothing)
-    f = (_d1, _d2, _on) -> innerjoin(_d1, _d2, on = _on)
-    v = [Dagger.@spawn f(c, d2, on) for c in d1.chunks]
+function innerjoin(d1::DTable, d2; kwargs...)
+    f = (_d1, _d2, kwargs) -> innerjoin(_d1, _d2; kwargs...)
+    if any(k in JOINKWARGS for k in keys(kwargs))
+        f = (_d1, _d2, kwargs) -> _innerjoin(_d1, _d2; kwargs...)
+    end
+    v = [Dagger.@spawn f(c, d2, kwargs) for c in d1.chunks]
     DTable(v, d1.tabletype)
 end
 
-function innerjoin(l, r; on = nothing)
+innerjoin(l, r; on = nothing) = _innerjoin(l, r; on = on)
+_innerjoin(l, r; kwargs...) = _join(:innerjoin, l, r; kwargs...)
+
+
+function _join(
+        type::Symbol,
+        l, r;
+        on = nothing,
+        l_sorted = false,
+        r_sorted = false,
+        r_unique = false,
+        build_lookup = false,
+        lookup_table = nothing
+    )
     names, _, other_r, cmp_l, cmp_r = resolve_colnames(l, r, on)
     inner_l, inner_r = match_inner_indices(l, r, cmp_l, cmp_r)
-    outer_l = Set{UInt}()
-    build_joined_table(:innerjoin, names, l, r, inner_l, inner_r, outer_l, other_r)
+    outer_l = type == :innerjoin ? Set{UInt}() : find_outer_indices(l, inner_l)
+    build_joined_table(type, names, l, r, inner_l, inner_r, outer_l, other_r)
 end

--- a/src/table/join_interface.jl
+++ b/src/table/join_interface.jl
@@ -1,19 +1,32 @@
 import DataAPI: leftjoin, innerjoin
 
 const JOINKWARGS = Set([
-        :l_sorted,
-        :r_sorted,
-        :r_unique,
-        :build_lookup,
-        :lookup_table,
-    ])
+    :l_sorted,
+    :r_sorted,
+    :r_unique,
+    :lookup,
+])
 
-# so the function selection goes as follows:
-# xjoin(d1, d2; on) ->  default definition, will call the specialized
-#                       dataframes definition or the generic one from here
-# xjoin(d1, d2; on, <any of the JOINKWARGS>) -> will always call the
-#                       generic definition from here even if you pass dataframes
 
+"""
+    leftjoin(d1::DTable, d2; on=nothing, l_sorted=false, r_sorted=false, r_unique=false, lookup=nothing)
+
+Perform a left join of `d1` with any `Tables.jl` compatible table type.
+Returns a `DTable` with the result.
+
+If the underlying table type happens to have a `leftjoin` implementation
+and none of the below `DTable` related kwargs will be provided the specialized function will be used.
+A good example of that is calling `leftjoin` on a `DTable` with a `DataFrame` underlying type
+and a `d2` of `DataFrame` type.
+
+# Keyword arguments
+
+- `on`: Column symbols to join on. Can be provided as a symbol or a pair of symbols in case the column names differ. For joins on multiple columns a vector of the previously mentioned can be provided.
+- `l_sorted`: To indicate the left table is sorted - only useful if the `r_sorted` is set to `true` as well.
+- `r_sorted`: To indicate the right table is sorted.
+- `r_unique`: To indicate the right table only contains unique keys.
+- `lookup`: You can pass a dict-like structure here that will allow for quicker matching of inner rows. The structure needs to contain keys in form of a `Tuple` and values in form of type `Vector{UInt}` containing the related row indices.
+"""
 function leftjoin(d1::DTable, d2; kwargs...)
     f = if any(k in JOINKWARGS for k in keys(kwargs))
         (l, r, ks) -> _leftjoin(l, r; ks...)
@@ -28,6 +41,25 @@ leftjoin(l, r; on=nothing) = _leftjoin(l, r; on=on)
 _leftjoin(l, r; kwargs...) = _join(:leftjoin, l, r; kwargs...)
 
 
+"""
+    innerjoin(d1::DTable, d2; on=nothing, l_sorted=false, r_sorted=false, r_unique=false, lookup=nothing)
+
+Perform an inner join of `d1` with any `Tables.jl` compatible table type.
+Returns a `DTable` with the result.
+
+If the underlying table type happens to have a `innerjoin` implementation
+and none of the below `DTable` related kwargs will be provided the specialized function will be used.
+A good example of that is calling `innerjoin` on a `DTable` with a `DataFrame` underlying type
+and a `d2` of `DataFrame` type.
+
+# Keyword arguments
+
+- `on`: Column symbols to join on. Can be provided as a symbol or a pair of symbols in case the column names differ. For joins on multiple columns a vector of the previously mentioned can be provided.
+- `l_sorted`: To indicate the left table is sorted - only useful if the `r_sorted` is set to `true` as well.
+- `r_sorted`: To indicate the right table is sorted.
+- `r_unique`: To indicate the right table only contains unique keys.
+- `lookup`: You can pass a dict-like structure here that will allow for quicker matching of inner rows. The structure needs to contain keys in form of a `Tuple` and values in form of type `Vector{UInt}` containing the related row indices.
+"""
 function innerjoin(d1::DTable, d2; kwargs...)
     f = if any(k in JOINKWARGS for k in keys(kwargs))
         (l, r, ks) -> _innerjoin(l, r; ks...)
@@ -49,13 +81,14 @@ function _join(
         l_sorted=false,
         r_sorted=false,
         r_unique=false,
-        build_lookup=false,
-        lookup_table=nothing
+        lookup=nothing
     )
 
     names, _, other_r, cmp_l, cmp_r = resolve_colnames(l, r, on)
 
-    inner_l, inner_r = if r_sorted && l_sorted
+    inner_l, inner_r = if lookup !== nothing
+        match_inner_indices_lookup(l, lookup, cmp_l)
+    elseif r_sorted && l_sorted
         match_inner_indices_lsorted_rsorted(l, r, cmp_l, cmp_r, r_unique) # loop through r once
     elseif r_unique
         match_inner_indices_runique(l, r, cmp_l, cmp_r) # break on first match
@@ -64,6 +97,7 @@ function _join(
     else
         match_inner_indices(l, r, cmp_l, cmp_r)
     end
+
     outer_l = type == :innerjoin ? Set{UInt}() : find_outer_indices(l, inner_l)
     build_joined_table(type, names, l, r, inner_l, inner_r, outer_l, other_r)
 end

--- a/src/table/join_interface.jl
+++ b/src/table/join_interface.jl
@@ -1,52 +1,69 @@
 import DataAPI: leftjoin, innerjoin
 
 const JOINKWARGS = Set([
-    :l_sorted,
-    :r_sorted,
-    :r_unique,
-    :build_lookup,
-    :lookup_table,])
+        :l_sorted,
+        :r_sorted,
+        :r_unique,
+        :build_lookup,
+        :lookup_table,
+    ])
 
+# so the function selection goes as follows:
+# xjoin(d1, d2; on) ->  default definition, will call the specialized
+#                       dataframes definition or the generic one from here
+# xjoin(d1, d2; on, <any of the JOINKWARGS>) -> will always call the
+#                       generic definition from here even if you pass dataframes
 
 function leftjoin(d1::DTable, d2; kwargs...)
-    f = (_d1, _d2, kwargs) -> leftjoin(_d1, _d2; kwargs...)
-    if any(k in JOINKWARGS for k in keys(kwargs))
-        f = (_d1, _d2, kwargs) -> _leftjoin(_d1, _d2; kwargs...)
+    f = if any(k in JOINKWARGS for k in keys(kwargs))
+        (l, r, ks) -> _leftjoin(l, r; ks...)
+    else
+        (l, r, ks) -> leftjoin(l, r; ks...)
     end
-
     v = [Dagger.@spawn f(c, d2, kwargs) for c in d1.chunks]
     DTable(v, d1.tabletype)
 end
 
-leftjoin(l, r; on = nothing) = _leftjoin(l, r; on = on)
+leftjoin(l, r; on=nothing) = _leftjoin(l, r; on=on)
 _leftjoin(l, r; kwargs...) = _join(:leftjoin, l, r; kwargs...)
 
 
 function innerjoin(d1::DTable, d2; kwargs...)
-    f = (_d1, _d2, kwargs) -> innerjoin(_d1, _d2; kwargs...)
-    if any(k in JOINKWARGS for k in keys(kwargs))
-        f = (_d1, _d2, kwargs) -> _innerjoin(_d1, _d2; kwargs...)
+    f = if any(k in JOINKWARGS for k in keys(kwargs))
+        (l, r, ks) -> _innerjoin(l, r; ks...)
+    else
+        (l, r, ks) -> innerjoin(l, r; ks...)
     end
     v = [Dagger.@spawn f(c, d2, kwargs) for c in d1.chunks]
     DTable(v, d1.tabletype)
 end
 
-innerjoin(l, r; on = nothing) = _innerjoin(l, r; on = on)
+innerjoin(l, r; on=nothing) = _innerjoin(l, r; on=on)
 _innerjoin(l, r; kwargs...) = _join(:innerjoin, l, r; kwargs...)
 
 
 function _join(
         type::Symbol,
         l, r;
-        on = nothing,
-        l_sorted = false,
-        r_sorted = false,
-        r_unique = false,
-        build_lookup = false,
-        lookup_table = nothing
+        on=nothing,
+        l_sorted=false,
+        r_sorted=false,
+        r_unique=false,
+        build_lookup=false,
+        lookup_table=nothing
     )
+
     names, _, other_r, cmp_l, cmp_r = resolve_colnames(l, r, on)
-    inner_l, inner_r = match_inner_indices(l, r, cmp_l, cmp_r)
+
+    inner_l, inner_r = if r_sorted && l_sorted
+        match_inner_indices_lsorted_rsorted(l, r, cmp_l, cmp_r, r_unique) # loop through r once
+    elseif r_unique
+        match_inner_indices_runique(l, r, cmp_l, cmp_r) # break on first match
+    elseif r_sorted
+        match_inner_indices_rsorted(l, r, cmp_l, cmp_r) # break on last match
+    else
+        match_inner_indices(l, r, cmp_l, cmp_r)
+    end
     outer_l = type == :innerjoin ? Set{UInt}() : find_outer_indices(l, inner_l)
     build_joined_table(type, names, l, r, inner_l, inner_r, outer_l, other_r)
 end

--- a/src/table/join_interface.jl
+++ b/src/table/join_interface.jl
@@ -1,0 +1,29 @@
+import DataAPI: leftjoin, innerjoin
+
+
+function leftjoin(d1::DTable, d2; on = nothing)
+    f = (_d1, _d2, _on) -> leftjoin(_d1, _d2, on = _on)
+    v = [Dagger.@spawn f(c, d2, on) for c in d1.chunks]
+    DTable(v, d1.tabletype)
+end
+
+function leftjoin(l, r; on = nothing)
+    names, _, other_r, cmp_l, cmp_r = resolve_colnames(l, r, on)
+    inner_l, inner_r = match_inner_indices(l, r, cmp_l, cmp_r)
+    outer_l = find_outer_indices(l, inner_l)
+    build_joined_table(:leftjoin, names, l, r, inner_l, inner_r, outer_l, other_r)
+end
+
+
+function innerjoin(d1::DTable, d2; on = nothing)
+    f = (_d1, _d2, _on) -> innerjoin(_d1, _d2, on = _on)
+    v = [Dagger.@spawn f(c, d2, on) for c in d1.chunks]
+    DTable(v, d1.tabletype)
+end
+
+function innerjoin(l, r; on = nothing)
+    names, _, other_r, cmp_l, cmp_r = resolve_colnames(l, r, on)
+    inner_l, inner_r = match_inner_indices(l, r, cmp_l, cmp_r)
+    outer_l = Set{UInt}()
+    build_joined_table(:innerjoin, names, l, r, inner_l, inner_r, outer_l, other_r)
+end

--- a/src/table/operations.jl
+++ b/src/table/operations.jl
@@ -76,7 +76,7 @@ to restrict the reduction to the specified columns.
 The reduced values are provided in a NamedTuple under names of reduced columns.
 
 For the `init` kwarg please refer to `Base.reduce` documentation,
-as it follows the same principles. 
+as it follows the same principles.
 
 # Examples
 ```julia

--- a/src/table/tables.jl
+++ b/src/table/tables.jl
@@ -78,7 +78,7 @@ function _iterate(iter::DTableRowIterator, chunk_index)
         i = iterate(row_iterator)
         chunk_index += 1
     end
-    if i === nothing 
+    if i === nothing
         return nothing
     else
         row, row_state = i
@@ -92,7 +92,7 @@ Base.iterate(iter::DTableRowIterator) = _iterate(iter, 1)
 function Base.iterate(iter::DTableRowIterator, state)
     (row_iterator, row_state, next_chunk_index) = state
     i = iterate(row_iterator, row_state)
-    if i === nothing 
+    if i === nothing
         _iterate(iter, next_chunk_index)
     else
         row, row_state = i
@@ -153,7 +153,7 @@ Tables.columns(table::GDTable) = DTableColumnIterator(table.dtable)
 Tables.schema(table::GDTable) = determine_schema(table.dtable)
 Tables.getcolumn(table::GDTable, col::Symbol) = Tables.getcolumn(table.dtable, col)
 Tables.getcolumn(table::GDTable, idx::Int) = Tables.getcolumn(table.dtable, idx)
-Tables.columnnames(table::GDTable) = determine_columnnames(table.dtable) 
+Tables.columnnames(table::GDTable) = determine_columnnames(table.dtable)
 
 #######################################
 # GDTable partitions

--- a/test/table.jl
+++ b/test/table.jl
@@ -376,30 +376,34 @@ using TableOperations
         end
     end
     @testset "join" begin
-        d1 = DataFrame(a=collect(-2:10),b=a=collect(-2:10))
-        d2_keys = [1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9, 9, 12]
-        d2 = DataFrame(a=d2_keys, c=collect(1:length(d2_keys)))
+        rng = MersenneTwister(2137)
 
-        n1 = (a=collect(-2:1000),b=a=collect(-2:1000))
-        n2 = (a=d2_keys, c=collect(1:length(d2_keys)))
+        a_len = 1000
+        b_len = 100
+
+        genkeys = (n) -> rand(rng, Int32, n).%100
+        genrand = (n) -> collect(1:n)
+
+        d1 = DataFrame(a=genkeys(a_len), b=genrand(a_len))
+        d2 = DataFrame(a=genkeys(b_len), c=genrand(b_len))
 
         lj1 = leftjoin(d1, d2, on=:a)
         lj1u = leftjoin(d1, unique(d2, :a), on=:a)
-        lj2 = fetch(leftjoin(DTable(d1, 2), d2, on=:a))
-        lj3 = fetch(leftjoin(DTable(d1, 2, tabletype=NamedTuple), d2, on=:a), DataFrame)
-        lj4 = fetch(leftjoin(DTable(d1, 2, tabletype=NamedTuple), sort(d2, :a), on=:a, r_sorted=true), DataFrame)
-        lj5 = fetch(leftjoin(DTable(d1, 2, tabletype=NamedTuple), unique(d2, :a), on=:a, r_unique=true), DataFrame)
-        lj6 = fetch(leftjoin(DTable(d1, 2, tabletype=NamedTuple), sort(d2, :a), on=:a, r_sorted=true, l_sorted=true), DataFrame)
-        lj7 = fetch(leftjoin(DTable(d1, 2, tabletype=NamedTuple), sort(unique(d2, :a), :a), on=:a, r_sorted=true, l_sorted=true, r_unique=true), DataFrame)
+        lj2 = fetch(leftjoin(DTable(d1, 7), d2, on=:a))
+        lj3 = fetch(leftjoin(DTable(d1, 7, tabletype=NamedTuple), d2, on=:a), DataFrame)
+        lj4 = fetch(leftjoin(DTable(d1, 7, tabletype=NamedTuple), sort(d2, :a), on=:a, r_sorted=true), DataFrame)
+        lj5 = fetch(leftjoin(DTable(d1, 7, tabletype=NamedTuple), unique(d2, :a), on=:a, r_unique=true), DataFrame)
+        lj6 = fetch(leftjoin(DTable(sort(d1, :a), 7, tabletype=NamedTuple), sort(d2, :a), on=:a, r_sorted=true, l_sorted=true), DataFrame)
+        lj7 = fetch(leftjoin(DTable(sort(d1, :a), 7, tabletype=NamedTuple), sort(unique(d2, :a), :a), on=:a, r_sorted=true, l_sorted=true, r_unique=true), DataFrame)
 
-        sort!(lj1, :a)
-        sort!(lj1u, :a)
-        sort!(lj2, :a)
-        sort!(lj3, :a)
-        sort!(lj4, :a)
-        sort!(lj5, :a)
-        sort!(lj6, :a)
-        sort!(lj7, :a)
+        sort!(lj1, [:a, :b])
+        sort!(lj1u, [:a, :b])
+        sort!(lj2, [:a, :b])
+        sort!(lj3, [:a, :b])
+        sort!(lj4, [:a, :b])
+        sort!(lj5, [:a, :b])
+        sort!(lj6, [:a, :b])
+        sort!(lj7, [:a, :b])
 
         @test isequal(lj1, lj2)
         @test isequal(lj1, lj3)
@@ -409,10 +413,29 @@ using TableOperations
         @test isequal(lj1u, lj7)
 
         ij1 = innerjoin(d1, d2, on=:a)
-        ij2 = fetch(innerjoin(DTable(d1, 2), d2, on=:a))
-        ij3 = fetch(innerjoin(DTable(d1, 2, tabletype=NamedTuple), d2, on=:a), DataFrame)
+        ij1u = innerjoin(d1, unique(d2, :a), on=:a)
+        ij2 = fetch(innerjoin(DTable(d1, 7), d2, on=:a))
+        ij3 = fetch(innerjoin(DTable(d1, 7, tabletype=NamedTuple), d2, on=:a), DataFrame)
+        ij4 = fetch(innerjoin(DTable(d1, 7, tabletype=NamedTuple), sort(d2, :a), on=:a, r_sorted=true), DataFrame)
+        ij5 = fetch(innerjoin(DTable(d1, 7, tabletype=NamedTuple), unique(d2, :a), on=:a, r_unique=true), DataFrame)
+        ij6 = fetch(innerjoin(DTable(sort(d1, :a), 7, tabletype=NamedTuple), sort(d2, :a), on=:a, r_sorted=true, l_sorted=true), DataFrame)
+        ij7 = fetch(innerjoin(DTable(sort(d1, :a), 7, tabletype=NamedTuple), sort(unique(d2, :a), :a), on=:a, r_sorted=true, l_sorted=true, r_unique=true), DataFrame)
 
+        sort!(ij1, [:a, :b])
+        sort!(ij1u, [:a, :b])
+        sort!(ij2, [:a, :b])
+        sort!(ij3, [:a, :b])
+        sort!(ij4, [:a, :b])
+        sort!(ij5, [:a, :b])
+        sort!(ij6, [:a, :b])
+        sort!(ij7, [:a, :b])
+
+
+        @test isequal(ij1, ij2)
         @test isequal(ij1, ij3)
-        @test isequal(ij1, ij3)
+        @test isequal(ij1, ij4)
+        @test isequal(ij1u, ij5)
+        @test isequal(ij1, ij6)
+        @test isequal(ij1u, ij7)
     end
 end

--- a/test/table.jl
+++ b/test/table.jl
@@ -95,7 +95,7 @@ using TableOperations
         for src in [nt, df]
             dt = DTable(src, 100)
 
-            # Single result 
+            # Single result
             mt = map(x -> (r = x.a + x.b, ), dt)
             mf = map(x -> x.a + x.b, eachrow(df))
             @test fetch(mt).r == mf
@@ -243,7 +243,7 @@ using TableOperations
 
         ######################################################
         # multi col groupby
-        d = DTable((a=cs1, b=cs2), 4) 
+        d = DTable((a=cs1, b=cs2), 4)
 
         for kwargs in kwargs_set
             g = Dagger.groupby(d, [:a, :b]; kwargs...)
@@ -331,7 +331,7 @@ using TableOperations
 
     @testset "tables.jl source" begin
         nt = (a=1:100, b=1:100)
-        
+
         d1 = DTable(nt, 10) # standard row based constructor
 
         # partition constructor, check with DTable as input
@@ -377,12 +377,10 @@ using TableOperations
     end
 
     @testset "join" begin
-        rng = MersenneTwister(2137)
-
         a_len = 1000
         b_len = 100
 
-        genkeys = (n, m) -> rand(rng, Int32, n).%m
+        genkeys = (n, m) -> rand(Int32, n).%m
         geninds = (n) -> collect(1:n)
 
         d1_single = DataFrame(a=genkeys(a_len, 100), b=geninds(a_len))

--- a/test/table.jl
+++ b/test/table.jl
@@ -423,8 +423,9 @@ using TableOperations
             lj7 = fetch(leftjoin(DTable(sort(d1, r_colsymbols), 111, tabletype=NamedTuple), sort(unique(d2, r_colsymbols), r_colsymbols), on=on, r_sorted=true, l_sorted=true, r_unique=true), DataFrame)
             lj8 = fetch(leftjoin(DTable(d1, 111, tabletype=NamedTuple), d2, on=on, lookup=d2_lookup), DataFrame)
             lj9 = fetch(leftjoin(Dagger.groupby(DTable(d1, 111, tabletype=NamedTuple), r_colsymbols), d2, on=on), DataFrame)
+            lj10 = fetch(leftjoin(DTable(d1, a_len ÷ 10), DTable(d2, b_len ÷ 10), on=on), DataFrame)
 
-            sort!.([lj1, lj1u, lj2, lj3, lj4, lj5, lj6, lj7, lj8, lj9], Ref(propertynames(lj1)))
+            sort!.([lj1, lj1u, lj2, lj3, lj4, lj5, lj6, lj7, lj8, lj9, lj10], Ref(propertynames(lj1)))
 
             @test isequal(lj1, lj2)
             @test isequal(lj1, lj3)
@@ -434,6 +435,7 @@ using TableOperations
             @test isequal(lj1u, lj7)
             @test isequal(lj1, lj8)
             @test isequal(lj1, lj9)
+            @test isequal(lj1, lj10)
 
             ij1 = innerjoin(d1, d2, on=on)
             ij1u = innerjoin(d1, unique(d2, r_colsymbols), on=on)
@@ -445,8 +447,9 @@ using TableOperations
             ij7 = fetch(innerjoin(DTable(sort(d1, r_colsymbols), 111, tabletype=NamedTuple), sort(unique(d2, r_colsymbols), r_colsymbols), on=on, r_sorted=true, l_sorted=true, r_unique=true), DataFrame)
             ij8 = fetch(innerjoin(DTable(d1, 111, tabletype=NamedTuple), d2, on=on, lookup=d2_lookup), DataFrame)
             ij9 = fetch(innerjoin(Dagger.groupby(DTable(d1, 111, tabletype=NamedTuple), r_colsymbols), d2, on=on), DataFrame)
+            ij10 = fetch(innerjoin(DTable(d1, a_len ÷ 10), DTable(d2, b_len ÷ 10), on=on), DataFrame)
 
-            sort!.([ij1, ij1u, ij2, ij3, ij4, ij5, ij6, ij7, ij8, ij9], Ref(propertynames(ij1)))
+            sort!.([ij1, ij1u, ij2, ij3, ij4, ij5, ij6, ij7, ij8, ij9, ij10], Ref(propertynames(ij1)))
 
             @test isequal(ij1, ij2)
             @test isequal(ij1, ij3)
@@ -456,6 +459,7 @@ using TableOperations
             @test isequal(ij1u, ij7)
             @test isequal(ij1, ij8)
             @test isequal(ij1, ij9)
+            @test isequal(ij1, ij10)
         end
     end
 end

--- a/test/table.jl
+++ b/test/table.jl
@@ -387,7 +387,7 @@ using TableOperations
         d2_single = DataFrame(a=genkeys(b_len, 100), c=geninds(b_len))
 
         d1_mul = DataFrame(a=genkeys(a_len, 10), b=genkeys(a_len, 10), c=geninds(a_len))
-        d2_mul = DataFrame(a=genkeys(a_len, 10), b=genkeys(a_len, 10), d=geninds(a_len))
+        d2_mul = DataFrame(a=genkeys(b_len, 10), b=genkeys(b_len, 10), d=geninds(b_len))
 
 
         configs = [

--- a/test/table.jl
+++ b/test/table.jl
@@ -377,17 +377,19 @@ using TableOperations
     end
 
     @testset "join" begin
+        rng = MersenneTwister(2137)
+
         a_len = 1000
         b_len = 100
 
-        genkeys = (n, m) -> rand(Int32, n).%m
+        genkeys = (r, n, m) -> rand(r, Int32, n).%m
         geninds = (n) -> collect(1:n)
 
-        d1_single = DataFrame(a=genkeys(a_len, 100), b=geninds(a_len))
-        d2_single = DataFrame(a=genkeys(b_len, 100), c=geninds(b_len))
+        d1_single = DataFrame(a=genkeys(rng, a_len, 100), b=geninds(a_len))
+        d2_single = DataFrame(a=genkeys(rng, b_len, 100), c=geninds(b_len))
 
-        d1_mul = DataFrame(a=genkeys(a_len, 10), b=genkeys(a_len, 10), c=geninds(a_len))
-        d2_mul = DataFrame(a=genkeys(b_len, 10), b=genkeys(b_len, 10), d=geninds(b_len))
+        d1_mul = DataFrame(a=genkeys(rng, a_len, 10), b=genkeys(rng, a_len, 10), c=geninds(a_len))
+        d2_mul = DataFrame(a=genkeys(rng, b_len, 10), b=genkeys(rng, b_len, 10), d=geninds(b_len))
 
 
         configs = [

--- a/test/table.jl
+++ b/test/table.jl
@@ -376,9 +376,9 @@ using TableOperations
         end
     end
     @testset "join" begin
-        d1 = DataFrame(a=collect(-2:10))
-        d2_keys = [1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9, 9]
-        d2 = DataFrame(a=d2_keys, b=collect(1:length(d2_keys)))
+        d1 = DataFrame(a=collect(-2:10),b=a=collect(-2:10))
+        d2_keys = [1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9, 9, 12]
+        d2 = DataFrame(a=d2_keys, c=collect(1:length(d2_keys)))
 
         lj1 = leftjoin(d1, d2, on=:a)
         lj2 = fetch(leftjoin(DTable(d1, 2), d2, on=:a))
@@ -397,5 +397,6 @@ using TableOperations
 
         @test isequal(ij1, ij3)
         @test isequal(ij1, ij3)
+
     end
 end

--- a/test/table.jl
+++ b/test/table.jl
@@ -380,16 +380,33 @@ using TableOperations
         d2_keys = [1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9, 9, 12]
         d2 = DataFrame(a=d2_keys, c=collect(1:length(d2_keys)))
 
+        n1 = (a=collect(-2:1000),b=a=collect(-2:1000))
+        n2 = (a=d2_keys, c=collect(1:length(d2_keys)))
+
         lj1 = leftjoin(d1, d2, on=:a)
+        lj1u = leftjoin(d1, unique(d2, :a), on=:a)
         lj2 = fetch(leftjoin(DTable(d1, 2), d2, on=:a))
         lj3 = fetch(leftjoin(DTable(d1, 2, tabletype=NamedTuple), d2, on=:a), DataFrame)
+        lj4 = fetch(leftjoin(DTable(d1, 2, tabletype=NamedTuple), sort(d2, :a), on=:a, r_sorted=true), DataFrame)
+        lj5 = fetch(leftjoin(DTable(d1, 2, tabletype=NamedTuple), unique(d2, :a), on=:a, r_unique=true), DataFrame)
+        lj6 = fetch(leftjoin(DTable(d1, 2, tabletype=NamedTuple), sort(d2, :a), on=:a, r_sorted=true, l_sorted=true), DataFrame)
+        lj7 = fetch(leftjoin(DTable(d1, 2, tabletype=NamedTuple), sort(unique(d2, :a), :a), on=:a, r_sorted=true, l_sorted=true, r_unique=true), DataFrame)
 
         sort!(lj1, :a)
+        sort!(lj1u, :a)
         sort!(lj2, :a)
         sort!(lj3, :a)
+        sort!(lj4, :a)
+        sort!(lj5, :a)
+        sort!(lj6, :a)
+        sort!(lj7, :a)
 
         @test isequal(lj1, lj2)
         @test isequal(lj1, lj3)
+        @test isequal(lj1, lj4)
+        @test isequal(lj1u, lj5)
+        @test isequal(lj1, lj6)
+        @test isequal(lj1u, lj7)
 
         ij1 = innerjoin(d1, d2, on=:a)
         ij2 = fetch(innerjoin(DTable(d1, 2), d2, on=:a))
@@ -397,6 +414,5 @@ using TableOperations
 
         @test isequal(ij1, ij3)
         @test isequal(ij1, ij3)
-
     end
 end

--- a/test/table.jl
+++ b/test/table.jl
@@ -375,4 +375,27 @@ using TableOperations
             @test all([el%10 == v%10 for el in Tables.getcolumn(partition, :a)])
         end
     end
+    @testset "join" begin
+        d1 = DataFrame(a=collect(-2:10))
+        d2_keys = [1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9, 9]
+        d2 = DataFrame(a=d2_keys, b=collect(1:length(d2_keys)))
+
+        lj1 = leftjoin(d1, d2, on=:a)
+        lj2 = fetch(leftjoin(DTable(d1, 2), d2, on=:a))
+        lj3 = fetch(leftjoin(DTable(d1, 2, tabletype=NamedTuple), d2, on=:a), DataFrame)
+
+        sort!(lj1, :a)
+        sort!(lj2, :a)
+        sort!(lj3, :a)
+
+        @test isequal(lj1, lj2)
+        @test isequal(lj1, lj3)
+
+        ij1 = innerjoin(d1, d2, on=:a)
+        ij2 = fetch(innerjoin(DTable(d1, 2), d2, on=:a))
+        ij3 = fetch(innerjoin(DTable(d1, 2, tabletype=NamedTuple), d2, on=:a), DataFrame)
+
+        @test isequal(ij1, ij3)
+        @test isequal(ij1, ij3)
+    end
 end

--- a/test/table.jl
+++ b/test/table.jl
@@ -375,8 +375,9 @@ using TableOperations
             @test all([el%10 == v%10 for el in Tables.getcolumn(partition, :a)])
         end
     end
+
     @testset "join" begin
-        rng = MersenneTwister(69420)
+        rng = MersenneTwister(2137)
 
         a_len = 1000
         b_len = 100
@@ -395,13 +396,13 @@ using TableOperations
 
         lj1 = leftjoin(d1, d2, on=:a)
         lj1u = leftjoin(d1, unique(d2, :a), on=:a)
-        lj2 = fetch(leftjoin(DTable(d1, 7), d2, on=:a))
-        lj3 = fetch(leftjoin(DTable(d1, 7, tabletype=NamedTuple), d2, on=:a), DataFrame)
-        lj4 = fetch(leftjoin(DTable(d1, 7, tabletype=NamedTuple), sort(d2, :a), on=:a, r_sorted=true), DataFrame)
-        lj5 = fetch(leftjoin(DTable(d1, 7, tabletype=NamedTuple), unique(d2, :a), on=:a, r_unique=true), DataFrame)
-        lj6 = fetch(leftjoin(DTable(sort(d1, :a), 7, tabletype=NamedTuple), sort(d2, :a), on=:a, r_sorted=true, l_sorted=true), DataFrame)
-        lj7 = fetch(leftjoin(DTable(sort(d1, :a), 7, tabletype=NamedTuple), sort(unique(d2, :a), :a), on=:a, r_sorted=true, l_sorted=true, r_unique=true), DataFrame)
-        lj8 = fetch(leftjoin(DTable(d1, 7, tabletype=NamedTuple), d2, on=:a, lookup=d2_lookup), DataFrame)
+        lj2 = fetch(leftjoin(DTable(d1, 111), d2, on=:a))
+        lj3 = fetch(leftjoin(DTable(d1, 111, tabletype=NamedTuple), d2, on=:a), DataFrame)
+        lj4 = fetch(leftjoin(DTable(d1, 111, tabletype=NamedTuple), sort(d2, :a), on=:a, r_sorted=true), DataFrame)
+        lj5 = fetch(leftjoin(DTable(d1, 111, tabletype=NamedTuple), unique(d2, :a), on=:a, r_unique=true), DataFrame)
+        lj6 = fetch(leftjoin(DTable(sort(d1, :a), 111, tabletype=NamedTuple), sort(d2, :a), on=:a, r_sorted=true, l_sorted=true), DataFrame)
+        lj7 = fetch(leftjoin(DTable(sort(d1, :a), 111, tabletype=NamedTuple), sort(unique(d2, :a), :a), on=:a, r_sorted=true, l_sorted=true, r_unique=true), DataFrame)
+        lj8 = fetch(leftjoin(DTable(d1, 111, tabletype=NamedTuple), d2, on=:a, lookup=d2_lookup), DataFrame)
 
         sort!(lj1, [:a, :b])
         sort!(lj1u, [:a, :b])
@@ -423,13 +424,13 @@ using TableOperations
 
         ij1 = innerjoin(d1, d2, on=:a)
         ij1u = innerjoin(d1, unique(d2, :a), on=:a)
-        ij2 = fetch(innerjoin(DTable(d1, 7), d2, on=:a))
-        ij3 = fetch(innerjoin(DTable(d1, 7, tabletype=NamedTuple), d2, on=:a), DataFrame)
-        ij4 = fetch(innerjoin(DTable(d1, 7, tabletype=NamedTuple), sort(d2, :a), on=:a, r_sorted=true), DataFrame)
-        ij5 = fetch(innerjoin(DTable(d1, 7, tabletype=NamedTuple), unique(d2, :a), on=:a, r_unique=true), DataFrame)
-        ij6 = fetch(innerjoin(DTable(sort(d1, :a), 7, tabletype=NamedTuple), sort(d2, :a), on=:a, r_sorted=true, l_sorted=true), DataFrame)
-        ij7 = fetch(innerjoin(DTable(sort(d1, :a), 7, tabletype=NamedTuple), sort(unique(d2, :a), :a), on=:a, r_sorted=true, l_sorted=true, r_unique=true), DataFrame)
-        ij8 = fetch(innerjoin(DTable(d1, 7, tabletype=NamedTuple), d2, on=:a, lookup=d2_lookup), DataFrame)
+        ij2 = fetch(innerjoin(DTable(d1, 111), d2, on=:a))
+        ij3 = fetch(innerjoin(DTable(d1, 111, tabletype=NamedTuple), d2, on=:a), DataFrame)
+        ij4 = fetch(innerjoin(DTable(d1, 111, tabletype=NamedTuple), sort(d2, :a), on=:a, r_sorted=true), DataFrame)
+        ij5 = fetch(innerjoin(DTable(d1, 111, tabletype=NamedTuple), unique(d2, :a), on=:a, r_unique=true), DataFrame)
+        ij6 = fetch(innerjoin(DTable(sort(d1, :a), 111, tabletype=NamedTuple), sort(d2, :a), on=:a, r_sorted=true, l_sorted=true), DataFrame)
+        ij7 = fetch(innerjoin(DTable(sort(d1, :a), 111, tabletype=NamedTuple), sort(unique(d2, :a), :a), on=:a, r_sorted=true, l_sorted=true, r_unique=true), DataFrame)
+        ij8 = fetch(innerjoin(DTable(d1, 111, tabletype=NamedTuple), d2, on=:a, lookup=d2_lookup), DataFrame)
 
         sort!(ij1, [:a, :b])
         sort!(ij1u, [:a, :b])


### PR DESCRIPTION
- [x] leftjoin generic for any Tables.jl type
- [x] innerjoin generic for any Tables.jl type
- [x] inner matching passes with different kwargs for optimization (`r_sorted`, `l_sorted`, `r_unique`)
- [x] fallback to specialized methods (e.g. dataframes will use its own joins internally)
- [x] support for passing lookup tables to quickly match indices using a hash table for example
- [x] outerjoin research - answer: it's possible but not really nice of a solution, so skip for this PR
- [x] how to handle dtable x dtable joins? - answer: it works, but not necessairly the optimal way of doing it