### PR TITLE
catch_stack renamed current_exceptions in Julia 1.7

### DIFF
--- a/src/processor.jl
+++ b/src/processor.jl
@@ -174,7 +174,6 @@ iscompatible_arg(proc::ThreadProc, opts, x) = true
             fetch(task)
         catch err
             @static if VERSION >= v"1.1"
-                # catch_stack renamed current_exceptions in 1.7: https://github.com/JuliaLang/julia/pull/29901
                 @static if VERSION < v"1.7-rc1"
                     stk = Base.catch_stack(task)
                 else
@@ -200,7 +199,6 @@ else
             fetch(task)
         catch err
             @static if VERSION >= v"1.1"
-                # catch_stack renamed current_exceptions in 1.7: https://github.com/JuliaLang/julia/pull/29901
                 @static if VERSION < v"1.7-rc1"
                     stk = Base.catch_stack(task)
                 else

--- a/src/sch/util.jl
+++ b/src/sch/util.jl
@@ -194,7 +194,6 @@ function fetch_report(task)
         fetch(task)
     catch err
         @static if VERSION >= v"1.1"
-            # catch_stack renamed current_exceptions in 1.7: https://github.com/JuliaLang/julia/pull/29901
             @static if VERSION < v"1.7-rc1"
                 stk = Base.catch_stack(task)
             else


### PR DESCRIPTION
`Base.catch_stack` was renamed `Base.current_exceptions` in Julia 1.7.

Tests pass on Julia 1.6 - I see some error backtraces in the console, but it ends with "Dagger tests passed," and it looks like some error backtraces are normal looking at the test run in CI. I also got a warning that parallel tests were running in serial. Tests are not passing yet on 1.7 - but they aren't on master either, and I don't think this change is related.