### PR TITLE
affinity now returns Pair not Vector{Pair}, fixes #295

### DIFF
--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -114,15 +114,10 @@ move(to_proc::Processor, x) =
 
 ### ChunkIO
 affinity(r::DRef) = OSProc(r.owner)=>r.size
-function affinity(r::FileRef)
-    if haskey(MemPool.who_has_read, r.file)
-        Pair{OSProc, UInt64}[OSProc(dref.owner) => r.size for dref in MemPool.who_has_read[r.file]]
-    elseif r.force_pid[] !== nothing
-        Pair{OSProc, UInt64}[OSProc(r.force_pid[]) => 1]
-    else
-        Pair{OSProc, UInt64}[OSProc(w) => r.size for w in MemPool.get_workers_at(r.host)]
-    end
-end
+# this previously returned a vector with all machines that had the file cached
+# but now only returns the owner and size, for consistency with affinity(::DRef),
+# see #295
+affinity(r::FileRef) = OSProc(1)=>r.size
 
 """
     tochunk(x, proc; persist=false, cache=false) -> Chunk

--- a/src/thunk.jl
+++ b/src/thunk.jl
@@ -58,7 +58,7 @@ mutable struct Thunk
     cache::Bool   # release the result giving the worker an opportunity to
                   # cache it
     cache_ref::Any
-    affinity::Union{Nothing, Vector{Pair{OSProc, Int}}}
+    affinity::Union{Nothing, Pair{OSProc, Int}}
     eager_ref::Union{DRef,Nothing}
     options::Any # stores scheduler-specific options
     function Thunk(f, xs...;
@@ -109,10 +109,9 @@ function affinity(t::Thunk)
            #    end
            #else
                 if isa(inp, Union{Chunk, Thunk})
-                    for a in affinity(inp)
-                        proc, sz = a
-                        aff[proc] = get(aff, proc, 0) + sz
-                    end
+                    # TODO if inp is a FileRef, affinity[1] will always be OSProc(1)
+                    proc, sz = affinity(inp)
+                    aff[proc] = get(aff, proc, 0) + sz
                 end
            #end
         end

--- a/test/array.jl
+++ b/test/array.jl
@@ -215,8 +215,8 @@ using MemPool
     f = MemPool.FileRef("/tmp/d", aff[2])
     aff = Dagger.affinity(f)
     #@test length(aff) == 3
-    @test (aff[1][1]).pid in procs()
-    @test aff[1][2] == sizeof(Int)*10
+    @test (aff[1]).pid in procs()
+    @test aff[2] == sizeof(Int)*10
 end
 
 @testset "show_plan" begin


### PR DESCRIPTION
I'm seeing one test error on 1.6.3 but I see the same error in the CI output on master, so I don't think it was introduced by this change. The test suite still prints "Dagger tests passed" when done.

One concern is that the first element of the affinity pair is used on line 114 of `thunk.jl`, though in #295 we thought it wasn't. The first element of the pair for a fileref is now OSProc(1) always. I'm not sure how this will affect job scheduling.