### PR TITLE
at-spawn: Don't capture args in variable

### DIFF
--- a/src/thunk.jl
+++ b/src/thunk.jl
@@ -312,8 +312,9 @@ function _par(ex::Expr; lazy=true, recur=true, opts=())
             return :(Dagger.delayed($(esc(f)); $(opts...))($(_par.(args; lazy=lazy, recur=false)...)))
         else
             return quote
-                args = ($(_par.(args; lazy=lazy, recur=false)...),)
-                $spawn($(esc(f)), args...; $(opts...))
+                let args = ($(_par.(args; lazy=lazy, recur=false)...),)
+                    $spawn($(esc(f)), args...; $(opts...))
+                end
             end
         end
     else


### PR DESCRIPTION
This caused the arguments to be silently captured in a `gensym`'d variable in the enclosing module.

Thanks to @krynju for helping me narrow this down!