### PR TITLE
Use `juliaecosystem` CI queue

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 .test: &test
   if: build.env("DAGGER_BENCHMARK") != "true"
   agents:
-    queue: "julia"
+    queue: "juliaecosystem"
     sandbox.jl: "true"
 steps:
   - label: Julia 1.6


### PR DESCRIPTION
We want to keep the `julia` CI queue dedicated for base julia CI.  If you know of any other projects using the `julia` queue, please make this change in them as well.  :)