### PR TITLE
docs: Reword and remove garbage

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,19 +13,19 @@ makedocs(;
     ),
     pages = [
         "Home" => "index.md",
+        "Distributed Table" => "dtable.md",
         "Processors" => "processors.md",
-        "Checkpointing" => "checkpointing.md",
         "Scopes" => "scopes.md",
         "Dynamic Scheduler Control" => "dynamic.md",
         "Logging and Graphing" => "logging.md",
         "Scheduler Visualization" => "scheduler-visualization.md",
         "Benchmarking" => "benchmarking.md",
-        "Scheduler Internals" => "scheduler-internals.md",
-        "Distributed Table" => "dtable.md",
+        "Checkpointing" => "checkpointing.md",
         "API" => [
             "Types" => "api/types.md",
             "Functions and Macros" => "api/functions.md",
-        ]
+        ],
+        "Scheduler Internals" => "scheduler-internals.md",
     ]
 )
 

--- a/docs/src/api/functions.md
+++ b/docs/src/api/functions.md
@@ -7,7 +7,7 @@ CurrentModule = Dagger
 Pages = ["functions.md"]
 ```
 
-## General
+## General Functions
 ```@docs
 delayed
 spawn
@@ -20,7 +20,7 @@ order
 treereduce
 ```
 
-## Tables
+## Table Functions
 ```@docs
 tabletype
 tabletype!
@@ -30,13 +30,13 @@ filter
 groupby
 ```
 
-## Arrays
+## Array Functions
 ```@docs
 alignfirst
 view
 ```
 
-## Processors
+## Processor Functions
 ```@docs
 execute!
 iscompatible
@@ -49,18 +49,18 @@ get_tls
 set_tls!
 ```
 
-## Context
+## Context Functions
 ```@docs
 addprocs!
 rmprocs!
 ```
 
-## Logging
+## Logging Functions
 ```@docs
 get_logs!
 ```
 
-## Thunk Execution Environment
+## Thunk Execution Environment Functions
 
 These functions are used within the function called by a `Thunk`.
 
@@ -69,7 +69,7 @@ in_thunk
 thunk_processor
 ```
 
-### Dynamic Scheduler Control
+### Dynamic Scheduler Control Functions
 
 These functions query and control the scheduler remotely.
 
@@ -83,7 +83,7 @@ Sch.halt!
 Sch.get_dag_ids
 ```
 
-## File IO
+## File IO Functions
 
 !!! warning
     These APIs are currently untested and may be removed or modified.
@@ -93,7 +93,7 @@ save
 load
 ```
 
-# Macros
+# Macros API
 ```@docs
 @par
 @spawn

--- a/docs/src/api/types.md
+++ b/docs/src/api/types.md
@@ -7,7 +7,7 @@ CurrentModule = Dagger
 Pages = ["types.md"]
 ```
 
-## General
+## General Types
 ```@docs
 Thunk
 EagerThunk
@@ -15,38 +15,38 @@ Chunk
 UnitDomain
 ```
 
-## Tables
+## Table Types
 ```@docs
 DTable
 GDTable
 ```
 
-## Arrays
+## Array Types
 ```@docs
 DArray
 Blocks
 ArrayDomain
 ```
 
-## Processors
+## Processor Types
 ```@docs
 Processor
 OSProc
 ThreadProc
 ```
 
-## Context
+## Context Types
 ```@docs
 Context
 ```
 
-## Logging
+## Logging Types
 ```@docs
 NoOpLog
 LocalEventLog
 ```
 
-## Scheduling
+## Scheduling Types
 ```@docs
 Sch.SchedulerOptions
 Sch.ThunkOptions
@@ -54,7 +54,7 @@ Sch.MaxUtilization
 Sch.DynamicThunkException
 ```
 
-## File IO
+## File IO Types
 
 !!! warning
     These APIs are currently untested and may be removed or modified.

--- a/docs/src/dtable.md
+++ b/docs/src/dtable.md
@@ -286,19 +286,3 @@ Key: b
    1 │ b         3
    2 │ b         4
 ```
-
-# API
-
-```@docs
-DTable
-tabletype
-tabletype!
-trim
-trim!
-map
-filter
-reduce
-groupby
-keys
-getindex
-```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,19 +2,39 @@
 
 ## Usage
 
-The main function for using Dagger is `delayed`
+The main function for using Dagger is `spawn`:
 
-`delayed(f; options...)`
+`Dagger.spawn(f, args...; options...)`
 
-It returns a function which when called creates a `Thunk` object representing a call to function `f` with the given arguments. If it is called with other thunks as input, then they form a graph with input nodes directed at the output. The function `f` gets the result of the input Thunks.
-Thunks don't pass keyword argument to the function `f`. Options kwargs... to `delayed` are passed to the scheduler to control its behavior:
+or `@spawn` for the more convenient macro form:
+
+`Dagger.@spawn [option=value]... f(args...)`
+
+When called, it creates an `EagerThunk` (also known as a "thunk" or "task")
+object representing a call to function `f` with the arguments `args`. If it is
+called with other thunks as inputs, such as in `Dagger.@spawn f(Dagger.@spawn
+g())`, then the function `f` gets passed the results of those input thunks. If
+those thunks aren't yet finished executing, then the execution of `f` waits on
+all of its input thunks to complete before executing.
+
+The key point is that, for each argument to a thunk, if the argument is an
+`EagerThunk`, it'll be executed before this node and its result will be passed
+into the function `f`. If the argument is *not* an `EagerThunk` (instead, some
+other type of Julia object), it'll be passed as-is to the function `f`.
+
+Thunks don't accept regular keyword arguments for the function `f`. Instead,
+the `options` kwargs are passed to the scheduler to control its behavior:
+- Any field in `Dagger.Sch.ThunkOptions` (see [Scheduler and Thunk options](@ref))
+- `meta::Bool` -- Pass the input `Chunk` objects themselves to `f` and not the value contained in them
+
+There are also some extra kwargs that can be passed, although they're considered advanced options to be used only by developers or library authors:
 - `get_result::Bool` -- return the actual result to the scheduler instead of `Chunk` objects. Used when `f` explicitly constructs a Chunk or when return value is small (e.g. in case of reduce)
-- `meta::Bool` -- pass the input “Chunk” objects themselves to `f` and not the value contained in them - this is always run on the master process
 - `persist::Bool` -- the result of this Thunk should not be released after it becomes unused in the DAG
 - `cache::Bool` -- cache the result of this Thunk such that if the thunk is evaluated again, one can just reuse the cached value. If it’s been removed from cache, recompute the value.
 
-# DAG creation interface
-Here is a very simple example DAG:
+### Simple example
+
+Let's see a very simple directed acyclic graph (or DAG) constructed with Dagger:
 
 ```julia
 using Dagger
@@ -23,15 +43,80 @@ add1(value) = value + 1
 add2(value) = value + 2
 combine(a...) = sum(a)
 
-p = delayed(add1)(4)
-q = delayed(add2)(p)
-r = delayed(add1)(3)
-s = delayed(combine)(p, q, r)
+p = Dagger.@spawn add1(4)
+q = Dagger.@spawn add2(p)
+r = Dagger.@spawn add1(3)
+s = Dagger.@spawn combine(p, q, r)
 
-@assert collect(s) == 16
+@assert fetch(s) == 16
 ```
 
-The above computation can also be written in a more Julia-idiomatic syntax with `@par`:
+The thunks `p`, `q`, `r`, and `s` have the following structure:
+
+![graph](https://user-images.githubusercontent.com/25916/26920104-7b9b5fa4-4c55-11e7-97fb-fe5b9e73cae6.png)
+
+The final result (from `fetch(s)`) is the obvious consequence of the operation:
+
+ `add1(4) + add2(add1(4)) + add1(3)`
+
+ `(4 + 1) + ((4 + 1) + 2) + (3 + 1) == 16`
+
+### Eager Execution
+
+Dagger's `@spawn` macro works similarly to `@async` and `Threads.@spawn`: when
+called, it wraps the function call specified by the user in an `EagerThunk`
+object, and immediately places it onto a running scheduler, to be executed once
+its dependencies are fulfilled.
+
+```julia
+x = rand(400,400)
+y = rand(400,400)
+zt = Dagger.@spawn x * y
+z = fetch(zt)
+@assert isapprox(z, x * y)
+```
+
+One can also `wait` on the result of `@spawn` and check completion status with
+`isready`:
+
+```julia
+x = Dagger.@spawn sleep(10)
+@assert !isready(x)
+wait(x)
+@assert isready(x)
+```
+
+One can also safely call `@spawn` from another worker (not ID 1), and it will be executed correctly:
+
+```
+x = fetch(Distributed.@spawnat 2 Dagger.@spawn 1+2) # fetches the result of `@spawnat`
+x::EagerThunk
+@assert fetch(x) == 3 # fetch the result of `@spawn`
+```
+
+This is useful for nested execution, where an `@spawn`'d thunk calls `@spawn`. This is detailed further in [Dynamic Scheduler Control](@ref).
+
+### Errors
+
+If a thunk errors while running under the eager scheduler, it will be marked as
+having failed, all dependent (downstream) thunks will be marked as failed, and
+any future thunks that use a failed thunk as input will fail. Failure can be
+determined with `fetch`, which will re-throw the error that the
+originally-failing thunk threw. `wait` and `isready` will *not* check whether a
+thunk or its upstream failed; they only check if the thunk has completed, error
+or not.
+
+This failure behavior is not the default for lazy scheduling ([Lazy API](@ref)),
+but can be enabled by setting the scheduler/thunk option ([Scheduler and Thunk options](@ref))
+`allow_error` to `true`.  However, this option isn't terribly useful for
+non-dynamic usecases, since any thunk failure will propagate down to the output
+thunk regardless of where it occurs.
+
+### Lazy API
+
+Alongside the modern eager API, Dagger also has a legacy lazy API, accessible
+via `@par` or `delayed`. The above computation can be executed with the lazy
+API by substituting `@spawn` with `@par` and `fetch` with `collect`:
 
 ```julia
 p = @par add1(4)
@@ -42,7 +127,7 @@ s = @par combine(p, q, r)
 @assert collect(s) == 16
 ```
 
-or similarly:
+or similarly, in block form:
 
 ```julia
 s = @par begin
@@ -55,86 +140,45 @@ end
 @assert collect(s) == 16
 ```
 
-The connections between nodes `p`, `q`, `r` and `s` is represented by this dependency graph:
-
-![graph](https://user-images.githubusercontent.com/25916/26920104-7b9b5fa4-4c55-11e7-97fb-fe5b9e73cae6.png)
-
-
-The final result is the obvious consequence of the operation
-
- `add1(4)` + `add2(add1(4))` + `add1(3)`
-
- `(4 + 1)` + `((4 + 1) + 2)` + `(3 + 1)` = 16
-
-To compute and fetch the result of a thunk (say `s`), you can call `collect(s)`. `collect` will fetch the result of the computation to the master process. Alternatively, if you want to compute but not fetch the result you can call `compute` on the thunk. This will return a `Chunk` object which references the result. If you pass in a `Chunk` objects as an input to a delayed function, then the function will get executed with the value of the `Chunk` -- this evaluation will likely happen where the input chunks are, to reduce communication.
-
-The key point is that, for each argument to a node, if the argument is a `Thunk`, it'll be executed before this node and its result will be passed into the function `f` provided.
-If the argument is *not* a `Thunk` (just some regular Julia object), it'll be passed as-is to the function `f`.
-
-### Polytree
-
-[Polytrees](https://en.wikipedia.org/wiki/Polytree) are easily supported by Dagger. To make this work, pass all the head nodes `Thunk`s into a call to `delayed` as arguments, which will act as the top node for the graph.
-```julia
-group(x...) = [x...]
-top_node = delayed(group)(head_nodes...)
-compute(top_node)
-```
-
-## Eager Execution
-
-Similar to `@par`, Dagger has an `@spawn` macro (and matching `Dagger.spawn`)
-which works similarly to `@async` and `Threads.@spawn`: when called, it wraps
-the function call specified by the user in an `EagerThunk` object, and
-immediately places it onto a running scheduler, to be executed once its
-dependencies are fulfilled. This contrasts with `@par` in that `@par` does not
-begin executing its thunks until `collect` or `compute` are called on a given
-thunk or one of its downstream dependencies. Additionally, one fetches the
-result of any `@spawn` call with `fetch`. As a concrete example:
+Alternatively, if you want to compute but not fetch the result of a lazy
+operation, you can call `compute` on the thunk. This will return a `Chunk`
+object which references the result (see [Chunks](@ref) for more details):
 
 ```julia
-x = rand(400,400)
-y = rand(400,400)
-zt = Dagger.@spawn x * y
-z = fetch(zt)
+x = @par 1+2
+cx = compute(x)
+cx::Chunk
+@assert collect(cx) == 3
 ```
 
-One can also `wait` on the result of `@spawn` and check completion status with
-`isready`:
+Note that, as a legacy API, usage of the lazy API is generally discouraged for modern usage of Dagger. The reasons for this are numerous:
+- Nothing useful is happening while the DAG is being constructed, adding extra latency
+- Dynamically expanding the DAG can't be done with `@par` and `delayed`, making recursive nesting annoying to write
+- Each call to `compute`/`collect` starts a new scheduler, and destroys it at the end of the computation, wasting valuable time on setup and teardown
+- Distinct schedulers don't share runtime metrics or learned parameters, thus causing the scheduler to act less intelligently
+- Distinct schedulers can't share work or data directly
 
-```julia
-x = Dagger.@spawn sleep(10)
-@assert !isready(x)
-wait(x)
-@assert isready(x)
-@info "Done!"
-```
+## Chunks
 
-One can also safely call `@spawn` from another worker (not id 1), and it will
-be sent to worker 1 to schedule:
+Dagger relies heavily on communication between workers to operate. To make this
+efficient when communicating potentially large units of data, Dagger uses a
+remote reference, called a `Dagger.Chunk`, to refer to objects which exist on
+another worker. `Chunk`s are backed by a distributed refcounting mechanism
+provided by MemPool.jl, which ensures that the referenced data is not GC'd
+until all `Chunk`s referencing that object are GC'd from all workers containing
+them. Conveniently, if you pass in a `Chunk` object as an input to a function
+using either API, then the thunk's payload function will get executed with the
+value contained in the `Chunk`. The scheduler also understands `Chunk`s, and
+will try to schedule work close to where their `Chunk` inputs reside, to reduce
+communication overhead.
 
-```
-x = fetch(Distributed.@spawnat 2 Dagger.@spawn 1+2) # actually scheduled on worker 1
-x::EagerThunk
-@assert fetch(x) == 3
-```
+`Chunk`s also have a cached type, a "processor", and a "scope", which are
+important for identifying the type of the object, where in memory (CPU RAM, GPU
+VRAM, etc.) the value resides, and where the value is allowed to be transferred
+and dereferenced. See [Processors](@ref) and [Scopes](@ref) for more details on
+how these properties can be used to control scheduling behavior around `Chunk`s.
 
-This is useful for nested execution, where an `@spawn`'d thunk calls `@spawn`.
-
-If a thunk errors while running under the eager scheduler, it will be marked as
-having failed, all dependent (downstream) thunks will be marked as failed, and
-any future thunks that use a failed thunk as input will fail. Failure can be
-determined with `fetch`, which will re-throw the error that the
-originally-failing thunk threw. `wait` and `isready` will *not* check whether a
-thunk or its upstream failed; they only check if the thunk has completed, error
-or not.
-
-This failure behavior is not the default for lazy scheduling, but can be
-enabled by setting the scheduler/thunk option (see below) `allow_error` to
-`true`.  However, this option isn't terribly useful for non-dynamic usecases,
-since any thunk failure will propagate down to the output thunk regardless of
-where it occurs.
-
-## Scheduler and Thunk options
+### Scheduler and Thunk options
 
 While Dagger generally "just works", sometimes one needs to exert some more
 fine-grained control over how the scheduler allocates work. There are two
@@ -144,123 +188,29 @@ parallel mechanisms to achieve this: Scheduler options (from
 same options, with the difference being that Scheduler options operate
 globally across an entire DAG, and Thunk options operate on a thunk-by-thunk
 basis. Scheduler options can be constructed and passed to `collect()` or
-`compute()` as the keyword argument `options`, and Thunk options can be passed
-to Dagger's `delayed` function similarly: `delayed(myfunc)(arg1, arg2, ...;
-options=opts)`. Check the docstring for the two options structs to see what
-options are available.
-
-## Rough high level description of scheduling
-
-- First picks the leaf Thunks and distributes them to available workers. Each worker is given at most 1 task at a time. If input to the node is a `Chunk`, then workers which already have the chunk are preferred.
-- When a worker finishes a thunk it will return a `Chunk` object to the scheduler.
-- Once the worker has returned a `Chunk`, the scheduler picks the next task for the worker -- this is usually the task the worker immediately made available (if possible). In the small example above, if worker 2 finished `p` it will be given `q` since it will already have the result of `p` which is input to `q`.
-- The scheduler also issues "release" Commands to chunks that are no longer required by nodes in the DAG: for example, when `s` is computed all of `p`, `q`, `r` are released to free up memory. This can be prevented by passing `persist` or `cache` options to `delayed`.
-
-## Modeling of Dagger programs
-
-The key API for parallel and heterogeneous execution is `Dagger.delayed`.
-The call signature of `Dagger.delayed` is the following:
+`compute()` as the keyword argument `options` for lazy API usage:
 
 ```julia
-thunk = Dagger.delayed(func)(args...)
+t = @par 1+2
+opts = Dagger.Sch.ThunkOptions(;single=1) # Execute on worker 1
+
+compute(t; options=opts)
+
+collect(t; options=opts)
 ```
 
-This invocation serves to construct a single node in a computational graph.
-`func` is a Julia function, which normally takes some number of arguments, of
-length `N` and of types `Targs`. The set of arguments `args...` is specified
-with ellipses to indicate that many arguments may be passed between the
-parentheses. When correctly invoked, `args...` is of length `N` and of types
-`Targs` (or suitable subtypes of `Targs`, for each respective argument in
-`args...`).  `thunk` is an instance of a Dagger `Thunk`, which is the value
-used internally by Dagger to represent a node in the graph.
-
-A `Thunk` may be "computed":
+Thunk options can be passed to `@spawn/spawn`, `@par`, and `delayed` similarly:
 
 ```julia
-chunk = Dagger.compute(thunk)
+# Execute on worker 1
+
+Dagger.@spawn single=1 1+2
+
+Dagger.spawn(+, 1, 2; single=1)
+
+opts = Dagger.Sch.ThunkOptions(;single=1)
+delayed(+)(1, 2; options=opts)
 ```
 
-Computing a `Thunk` performs roughly the same logic as the following Julia
-function invocation:
-
-```julia
-result = func(args...)
-```
-
-Such an invocation invokes `func` on `args...`, returning `result`. Computing
-the above thunk would produce a value with the same type as `result`, with the
-caveat that the result will be wrapped by a `Dagger.Chunk` (`chunk` in the
-above example). A `Chunk` is a reference to a value stored on a compute
-process within the `Distributed` cluster that Dagger is operating within. A
-`Chunk` may be "collected", which will return the wrapped value to the
-collecting process, which in the above example will be `result`:
-
-```julia
-result = collect(chunk)
-```
-
-In order to create a graph with more than a single node, arguments to
-`delayed` may themselves be `Thunk`s or `Chunk`s. For example, the sum of the
-elements of vector `[1,2,3,4]` may be represented in Dagger as follows:
-
-```julia
-thunk1 = Dagger.delayed(+)(1, 2)
-thunk2 = Dagger.delayed(+)(3, 4)
-thunk3 = Dagger.delayed(+)(thunk1, thunk2)
-```
-
-A graph has now been constructed, where `thunk1` and `thunk2` are dependencies
-("inputs") to `thunk3`. Computing `thunk3` and then collecting its resulting
-`Chunk` would result in the answer that is expected from the operation:
-
-```julia
-chunk = compute(thunk3)
-result = collect(chunk)
-```
-
-```julia-repl
-julia> result == 10
-true
-```
-
-`result` now has the `Int64` value `10`, which is the result of summing the
-elements of the vector `[1,2,3,4]`. For convenience, computation may be
-performed together with collection, like so:
-
-```julia
-result = collect(thunk3)
-```
-
-The above summation example is equivalent to the following invocation in plain
-Julia:
-
-```julia
-x1 = 1 + 2
-x2 = 3 + 4
-result = x1 + x2
-result == 10
-```
-
-However, there are key differences when using Dagger to perform this operation
-as compared to performing this operation without Dagger. In Dagger, the graph
-is constructed separately from computing the graph ("lazily"), whereas without
-Dagger the graph is executed immediately ("eagerly"). Dagger makes use of this
-lazy construction approach to allow modifying the actual execution of the
-overall operation in useful ways.
-
-By default, computing a Dagger graph creates an instance of a scheduler, which
-will be provided the graph to execute. The scheduler executes the individual
-nodes of the graph on their arguments in the order specified by the graph
-(ensuring dependencies to a node are satisfied before executing said node) on
-compute processes in the cluster; the scheduler process itself typically does
-not execute the nodes directly. Additionally, if a given set of nodes do not
-depend on each other (the value generated by a node is not an input to another
-node in the set), then those nodes may be executed in parallel, and the
-scheduler attempts to schedule such nodes in parallel when possible.
-
-The scheduler also orchestrates data movement between compute processes, such
-that inputs to a given node are available on the compute process that is
-scheduled to execute said node. The scheduler attempts to minimize data
-movement between compute processes; it does so by trying to schedule nodes
-which depend on a given input on the same compute process that computed and
-retains that input.
+[`Dagger.Sch.SchedulerOptions`](@ref)
+[`Dagger.Sch.ThunkOptions`](@ref)

--- a/docs/src/scheduler-internals.md
+++ b/docs/src/scheduler-internals.md
@@ -1,5 +1,10 @@
 # Scheduler Internals
 
+!!! warn
+    This information is outdated, and until Dagger's internal scheduling APIs
+    stabilize, it may become less and less accurate. Always read the source to
+    understand what actually happens in Sch!
+
 The scheduler is called `Dagger.Sch`. It contains a single internal instance
 of type `ComputeState`, which maintains all necessary state to represent the
 set of waiting, ready, and completed (or "finished") graph nodes, cached


### PR DESCRIPTION
Fixes some of the poor wording and organization in the documentation, and focuses the documentation on the eager API, rather than the legacy lazy API.

Thanks to @kshyatt (and others over the past few months) for pointing out these much-needed changes!