### PR TITLE
Don't clobber the scheduler

### DIFF
--- a/lib/DaggerWebDash/src/index.html
+++ b/lib/DaggerWebDash/src/index.html
@@ -80,8 +80,10 @@ function linePlot(container, core_key, data_key, title, ylabel) {
             data = values[data_key];
 
         // Set axis domains
-        var time_min = d3.min(core, function(d){return d.timestamp;});
-        var time_max = d3.max(core, function(d){return d.timestamp;});
+        //var time_min = d3.min(core, function(d){return d.timestamp;});
+        //var time_max = d3.max(core, function(d){return d.timestamp;});
+        var time_min = seek_ts_start;
+        var time_max = seek_ts_stop;
         xScale.domain([time_min, time_max]);
         yScale.domain([0, d3.max(data)]);
 
@@ -180,8 +182,10 @@ function ganttPlot(container, core_key, id_key, timeline_key, esat_key, psat_key
             psat = values[psat_key];
 
         // Set axis domains
-        var time_min = d3.min(core, function(d){return d.timestamp;});
-        var time_max = d3.max(core, function(d){return d.timestamp;});
+        //var time_min = d3.min(core, function(d){return d.timestamp;});
+        //var time_max = d3.max(core, function(d){return d.timestamp;});
+        var time_min = seek_ts_start;
+        var time_max = seek_ts_stop;
         xScale.domain([time_min, time_max]);
         var allkeys = new Set();
         var ekeys = new Set();

--- a/lib/DaggerWebDash/src/index.html
+++ b/lib/DaggerWebDash/src/index.html
@@ -344,8 +344,8 @@ function ganttPlot(container, core_key, id_key, timeline_key, esat_key, psat_key
             ctx.beginPath();
             ctx.globalAlpha = 1.0;
             ctx.strokeStyle = "steelblue";
-            ctx.moveTo(0, y_bot);
-            var last_y = 0;
+            var last_y = satScale(subsat[0]);
+            ctx.moveTo(0, last_y);
             for (i = 0; i < core.length; i++) {
                 var sat_x = xScale(core[i].timestamp),
                     sat_y = satScale(subsat[i]);

--- a/src/sch/Sch.jl
+++ b/src/sch/Sch.jl
@@ -595,13 +595,21 @@ function schedule!(ctx, state, procs=procs_to_use(ctx))
         end
         "Like `sum`, but replaces `nothing` entries with the average of non-`nothing` entries."
         function impute_sum(xs)
-            all(x->!isa(x, Chunk), xs) && return 0
-            avg = round(UInt64, mean(filter(x->x isa Chunk, xs)))
-            total = 0
+            length(xs) == 0 && return 0
+
+            total = zero(eltype(xs))
+            nothing_count = 0
+            something_count = 0
             for x in xs
-                total += x !== nothing ? x : avg
+                if isnothing(x)
+                    nothing_count += 1
+                else
+                    something_count += 1
+                    total += x
+                end
             end
-            total
+
+            total + nothing_count * total / something_count
         end
 
         # Schedule tasks

--- a/src/sch/Sch.jl
+++ b/src/sch/Sch.jl
@@ -3,6 +3,7 @@ module Sch
 using Distributed
 import MemPool: DRef, poolset
 import Statistics: mean
+import Random: randperm
 
 import ..Dagger
 import ..Dagger: Context, Processor, Thunk, WeakThunk, ThunkFuture, ThunkFailedException, Chunk, OSProc, AnyScope
@@ -657,15 +658,31 @@ function schedule!(ctx, state, procs=procs_to_use(ctx))
         inputs = filter(t->istask(t)||isa(t,Chunk), unwrap_weak_checked.(task.inputs))
         chunks = [istask(input) ? state.cache[input] : input for input in inputs]
         #local_procs = unique(map(c->c isa Chunk ? processor(c) : OSProc(), chunks))
-        local_procs = vcat([Dagger.get_processors(gp) for gp in procs]...)
+        local_procs = unique(vcat([Dagger.get_processors(gp) for gp in procs]...))
         if length(local_procs) > fallback_threshold
             @goto fallback
         end
         affinities = Dict(proc=>impute_sum([affinity(chunk)[2] for chunk in filter(c->isa(c,Chunk)&&get_parent(processor(c))==get_parent(proc), chunks)]) for proc in local_procs)
         # Estimate cost to move data and get scheduled
         costs = Dict(proc=>state.worker_pressure[get_parent(proc).pid][proc]+(aff/tx_rate) for (proc,aff) in affinities)
+
+        # shuffle procs around
+        P = randperm(length(local_procs))
+        local_procs = getindex.(Ref(local_procs), P)
+
         sort!(local_procs, by=p->costs[p])
         scheduled = false
+
+        # Move our corresponding ThreadProc to be the last considered
+        if length(local_procs) > 1
+            sch_threadproc = Dagger.ThreadProc(myid(), Threads.threadid())
+            sch_thread_idx = findfirst(proc->proc==sch_threadproc, local_procs)
+            if sch_thread_idx !== nothing
+                deleteat!(local_procs, sch_thread_idx)
+                push!(local_procs, sch_threadproc)
+            end
+        end
+
         for proc in local_procs
             gproc = get_parent(proc)
             if can_use_proc(task, gproc, proc, opts, scope)

--- a/src/sch/dynamic.jl
+++ b/src/sch/dynamic.jl
@@ -185,6 +185,7 @@ end
 add_thunk!(f, h::SchedulerHandle, args...; future=nothing, ref=nothing, kwargs...) =
     exec!(_add_thunk!, h, f, args, kwargs, future, ref)
 function _add_thunk!(ctx, state, task, tid, (f, args, kwargs, future, ref))
+    timespan_start(ctx, :add_thunk, tid, 0)
     _args = map(arg->arg isa ThunkID ? state.thunk_dict[arg.id] : arg, args)
     GC.@preserve _args begin
         thunk = Thunk(f, _args...; kwargs...)
@@ -202,6 +203,7 @@ function _add_thunk!(ctx, state, task, tid, (f, args, kwargs, future, ref))
             thunk.eager_ref = ref
         end
         put!(state.chan, RescheduleSignal())
+        timespan_finish(ctx, :add_thunk, tid, 0)
         return thunk_id
     end
 end

--- a/src/scopes.jl
+++ b/src/scopes.jl
@@ -7,7 +7,7 @@ struct AnyScope <: AbstractScope end
 
 "Union of two or more scopes."
 struct UnionScope <: AbstractScope
-    scopes::NTuple{N,<:AbstractScope} where N
+    scopes::Tuple
 end
 UnionScope(scopes...) = UnionScope((scopes...,))
 UnionScope(scopes::Vector{<:AbstractScope}) = UnionScope((scopes...,))

--- a/test/logging.jl
+++ b/test/logging.jl
@@ -92,7 +92,7 @@
         esat = l1[:esat]
         @test any(e->haskey(e, :scheduler_init), esat)
         @test any(e->haskey(e, :schedule), esat)
-        @test any(e->haskey(e, :fire_multi), esat)
+        @test any(e->haskey(e, :fire), esat)
         @test any(e->haskey(e, :take), esat)
         @test any(e->haskey(e, :finish), esat)
         # Note: May one day be true as scheduler evolves
@@ -108,7 +108,7 @@
             esat = lo[:esat]
             @test !any(e->haskey(e, :scheduler_init), esat)
             @test !any(e->haskey(e, :schedule), esat)
-            @test !any(e->haskey(e, :fire_multi), esat)
+            @test !any(e->haskey(e, :fire), esat)
             @test !any(e->haskey(e, :take), esat)
             @test !any(e->haskey(e, :finish), esat)
             psat = lo[:psat]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ addprocs(3)
 using Test
 using Dagger
 using UUIDs
+import MemPool
 
 include("util.jl")
 include("fakeproc.jl")

--- a/test/scheduler.jl
+++ b/test/scheduler.jl
@@ -399,3 +399,20 @@ end
 @testset "Chunk Caching" begin
     compute(delayed(testevicted)(delayed(testpresent)(c1,c2)))
 end
+
+@testset "MemPool.approx_size" begin
+    for (obj, size) in [
+        (rand(100), 100*sizeof(Float64)),
+        (rand(Float32, 100), 100*sizeof(Float32)),
+        (rand(1:10, 100), 100*sizeof(Int)),
+        (fill(:a, 10), missing),
+        (fill("a", 10), missing),
+        (fill('a', 10), missing),
+    ]
+        if size !== missing
+            @test MemPool.approx_size(obj) == size
+        else
+            @test MemPool.approx_size(obj) !== nothing
+        end
+    end
+end

--- a/test/scheduler.jl
+++ b/test/scheduler.jl
@@ -311,6 +311,60 @@ end
     end
 end
 
+@testset "Scheduler algorithms" begin
+    # New function to hide from scheduler's function cost cache
+    mynothing(args...) = nothing
+
+    # New non-singleton struct to hide from `approx_size`
+    struct MyStruct
+        x::Int
+    end
+
+    state = Dagger.Sch.EAGER_STATE[]
+    tproc1 = Dagger.ThreadProc(1, 1)
+    tproc2 = Dagger.ThreadProc(first(workers()), 1)
+    procs = [tproc1, tproc2]
+
+    pres1 = state.worker_pressure[1][tproc1]
+    pres2 = state.worker_pressure[first(workers())][tproc2]
+    tx_rate = state.transfer_rate[]
+
+    for (args, tx_size) in [
+        ([1, 2], 0),
+        ([Dagger.tochunk(1), 2], sizeof(Int)),
+        ([1, Dagger.tochunk(2)], sizeof(Int)),
+        ([Dagger.tochunk(1), Dagger.tochunk(2)], 2*sizeof(Int)),
+        # TODO: Why does this work? Seems slow
+        ([Dagger.tochunk(MyStruct(1))], sizeof(MyStruct)),
+        ([Dagger.tochunk(MyStruct(1)), Dagger.tochunk(1)], sizeof(MyStruct)+sizeof(Int)),
+    ]
+        for arg in args
+            if arg isa Chunk
+                aff = Dagger.affinity(arg)
+                @test aff[1] == OSProc(1)
+                @test aff[2] == MemPool.approx_size(MemPool.poolget(arg.handle))
+            end
+        end
+
+        cargs = map(arg->MemPool.poolget(arg.handle), filter(arg->isa(arg, Chunk), args))
+        est_tx_size = Dagger.Sch.impute_sum(map(MemPool.approx_size, cargs))
+        @test est_tx_size == tx_size
+
+        t = delayed(mynothing)(args...)
+        sorted_procs, costs = Dagger.Sch.estimate_task_costs(state, procs, t)
+
+        @test tproc1 in sorted_procs
+        @test tproc2 in sorted_procs
+        @test sorted_procs[1] == tproc1
+        @test sorted_procs[2] == tproc2
+
+        @test haskey(costs, tproc1)
+        @test haskey(costs, tproc2)
+        @test costs[tproc1] ≈ pres1 # All chunks are local
+        @test costs[tproc2] ≈ (tx_size/tx_rate) + pres2 # All chunks are remote
+    end
+end
+
 @testset "Dynamic Thunks" begin
     @testset "Exec" begin
         a = delayed(dynamic_exec)(2)


### PR DESCRIPTION
This PR is a set of bugfixes and optimizations that aim to improve the scheduler's ability to pump out tasks to workers, and maximize throughput. It will try to fix the following issues:

- [x] The scheduler thread should generally be de-prioritized for running tasks, or else scheduling will hang while a blocking task executes. All other potentially eligible processors should be considered before the scheduler thread.
- [x] Blocking tasks on workers may strangle the task trying to launch work (in `do_tasks`), which then (by nature of holding the scheduler lock) hangs the scheduler in `fire_tasks!`, which prevents new tasks from being added to the scheduler and launched. We shouldn't hold the lock during this time, and in the future, we'll want to have a dedicated thread for each worker to receive and launch work from.
- [x] Checking for new workers happens far too frequently; we should make this event-driven instead. I intend to funnel `Context` modifications through a custom `setproperty!` call which will notify any listening tasks that the set of available workers has changed (@DrChainsaw ).

Todo:
- [x] Refactor and test scheduler network optimization logic
- [x] Test `MemPool.approxsize` returns non-`nothing` for important types
- [x] Find and fix hangs introduced by https://github.com/JuliaParallel/Dagger.jl/pull/310/commits/22c235f02827fea54bdcbeed49849a1a60c6fac0