### PR TITLE
Distribute the scheduler!

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,12 +4,12 @@
     queue: "juliaecosystem"
     sandbox.jl: "true"
 steps:
-  - label: Julia 1.6
+  - label: Julia 1.7
     timeout_in_minutes: 60
     <<: *test
     plugins:
       - JuliaCI/julia#v1:
-          version: "1.6"
+          version: "1.7"
       - JuliaCI/julia-test#v1:
           julia_args: "--threads=1"
       # - JuliaCI/julia-coverage#v1:
@@ -19,7 +19,7 @@ steps:
     <<: *test
     plugins:
       - JuliaCI/julia#v1:
-          version: "1.6-nightly"
+          version: "1.7-nightly"
       - JuliaCI/julia-test#v1:
           julia_args: "--threads=1"
       # - JuliaCI/julia-coverage#v1:
@@ -33,6 +33,6 @@ steps:
       serial: true
     plugins:
       - docker#v3.7.0:
-          image: julia:1.5.3
+          image: julia:1.7.0
     artifacts:
       - benchmarks/TODO

--- a/.github/workflows/ci-julia-1.7-nightly.yml
+++ b/.github/workflows/ci-julia-1.7-nightly.yml
@@ -1,4 +1,4 @@
-name: CI (Julia 1.6-nightly)
+name: CI (Julia 1.7-nightly)
 on:
   push:
     branches:
@@ -9,14 +9,14 @@ defaults:
   run:
     shell: bash
 jobs:
-  CI-julia-1-6-nightly:
-    name: CI-julia-1-6-nightly
+  CI-julia-1-7-nightly:
+    name: CI-julia-1-7-nightly
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         version:
-          - '1.6-nightly'
+          - '1.7-nightly'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.14.1"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
+ConcurrentCollections = "5060bff5-0b44-40c5-b522-fcd3ca5cecdd"
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,7 @@ SentinelArrays = "1"
 StatsBase = "0.28, 0.29, 0.30, 0.31, 0.32, 0.33"
 TableOperations = "1"
 Tables = "1.1"
-julia = "1.6"
+julia = "1.7"
 
 [extras]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/docs/src/dynamic.md
+++ b/docs/src/dynamic.md
@@ -25,9 +25,9 @@ various uses:
 [`Dagger.add_thunk!`](@ref)
 
 When working with thunks acquired from `get_dag_ids` or `add_thunk!`,
-you will have `ThunkID` objects which refer to a thunk by ID. Scheduler
-control functions which work with thunks accept or return `ThunkID`s. For
-example, one can create a new thunkt and get its result with `Base.fetch`:
+you will have `ThunkRef` objects which reference a thunk. Scheduler
+control functions which work with thunks accept or return `ThunkRef`s. For
+example, one can create a new thunk and get its result with `Base.fetch`:
 
 ```julia
 function mythunk(x)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -86,7 +86,7 @@ wait(x)
 @assert isready(x)
 ```
 
-One can also safely call `@spawn` from another worker (not ID 1), and it will be executed correctly:
+One can also safely call `@spawn` from any worker, and it will be executed correctly:
 
 ```
 x = fetch(Distributed.@spawnat 2 Dagger.@spawn 1+2) # fetches the result of `@spawnat`

--- a/lib/DaggerWebDash/src/core.jl
+++ b/lib/DaggerWebDash/src/core.jl
@@ -5,6 +5,7 @@ sanitize(t::NamedTuple) = map(sanitize, t)
 sanitize(x::Function) = repr(x)
 sanitize(d::Dict) = Dict([sanitize(k)=>sanitize(d[k]) for k in keys(d)])
 sanitize(a::Array) = sanitize.(a)
+sanitize(tid::Dagger.ThunkID) = (;wid=tid.wid, id=tid.id)
 sanitize(x) = x
 
 StructTypes.StructType(::Type{<:Dagger.Processor}) = StructTypes.CustomStruct()

--- a/lib/DaggerWebDash/src/index.html
+++ b/lib/DaggerWebDash/src/index.html
@@ -80,8 +80,10 @@ function linePlot(container, core_key, data_key, title, ylabel) {
             data = values[data_key];
 
         // Set axis domains
-        var time_min = d3.min(core, function(d){return d.timestamp;});
-        var time_max = d3.max(core, function(d){return d.timestamp;});
+        //var time_min = d3.min(core, function(d){return d.timestamp;});
+        //var time_max = d3.max(core, function(d){return d.timestamp;});
+        var time_min = seek_ts_start;
+        var time_max = seek_ts_stop;
         xScale.domain([time_min, time_max]);
         yScale.domain([0, d3.max(data)]);
 
@@ -180,8 +182,10 @@ function ganttPlot(container, core_key, id_key, timeline_key, esat_key, psat_key
             psat = values[psat_key];
 
         // Set axis domains
-        var time_min = d3.min(core, function(d){return d.timestamp;});
-        var time_max = d3.max(core, function(d){return d.timestamp;});
+        //var time_min = d3.min(core, function(d){return d.timestamp;});
+        //var time_max = d3.max(core, function(d){return d.timestamp;});
+        var time_min = seek_ts_start;
+        var time_max = seek_ts_stop;
         xScale.domain([time_min, time_max]);
         var allkeys = new Set();
         var ekeys = new Set();

--- a/lib/DaggerWebDash/src/index.html
+++ b/lib/DaggerWebDash/src/index.html
@@ -344,8 +344,8 @@ function ganttPlot(container, core_key, id_key, timeline_key, esat_key, psat_key
             ctx.beginPath();
             ctx.globalAlpha = 1.0;
             ctx.strokeStyle = "steelblue";
-            ctx.moveTo(0, y_bot);
-            var last_y = 0;
+            var last_y = satScale(subsat[0]);
+            ctx.moveTo(0, last_y);
             for (i = 0; i < core.length; i++) {
                 var sat_x = xScale(core[i].timestamp),
                     sat_y = satScale(subsat[i]);

--- a/src/Dagger.jl
+++ b/src/Dagger.jl
@@ -19,6 +19,13 @@ const PLUGIN_CONFIGS = Dict{Symbol,String}(
     :scheduler => "Dagger.Sch"
 )
 
+"An identifier to uniquely identify a `Thunk`."
+struct ThunkID
+    wid::Int
+    id::Int
+end
+Base.hash(id::ThunkID, h::UInt) = hash(typeof(id), hash((id.wid, id.id), h))
+
 include("lib/util.jl")
 include("lib/logging.jl")
 

--- a/src/lib/logging.jl
+++ b/src/lib/logging.jl
@@ -254,7 +254,7 @@ empty_prof() = ProfilerResult(UInt[], Dict{UInt64, Vector{Base.StackTraces.Stack
 
 const prof_refcount = Ref{Threads.Atomic{Int}}(Threads.Atomic{Int}(0))
 const prof_lock = Threads.ReentrantLock()
-const prof_tasks = Dict{Int64, Vector{Task}}()
+const prof_tasks = Dict{ThunkID, Vector{Task}}()
 
 function prof_task_put!(tid, task::Task=Base.current_task())
     lock(prof_lock) do

--- a/src/processor.jl
+++ b/src/processor.jl
@@ -161,7 +161,7 @@ function execute!(proc::ThreadProc, f, args...)
     task = Task() do
         set_tls!(tls)
         prof_task_put!(tls.sch_handle.thunk_ref.id)
-        f(args...)
+        Base.invokelatest(f, args...)
     end
     ret = ccall(:jl_set_task_tid, Cint, (Any, Cint), task, proc.tid-1)
     if ret == 0

--- a/src/processor.jl
+++ b/src/processor.jl
@@ -156,60 +156,29 @@ end
 iscompatible(proc::ThreadProc, opts, f, args...) = true
 iscompatible_func(proc::ThreadProc, opts, f) = true
 iscompatible_arg(proc::ThreadProc, opts, x) = true
-@static if VERSION >= v"1.3.0-DEV.573"
-    function execute!(proc::ThreadProc, f, args...)
-        tls = get_tls()
-        task = Task() do
-            set_tls!(tls)
-            prof_task_put!(tls.sch_handle.thunk_id.id)
-            f(args...)
-        end
-        ret = ccall(:jl_set_task_tid, Cint, (Any, Cint), task, proc.tid-1)
-        if ret == 0
-            error("jl_set_task_tid == 0")
-        end
-        @assert Threads.threadid(task) == proc.tid
-        schedule(task)
-        try
-            fetch(task)
-        catch err
-            @static if VERSION >= v"1.1"
-                @static if VERSION < v"1.7-rc1"
-                    stk = Base.catch_stack(task)
-                else
-                    stk = Base.current_exceptions(task)
-                end
-                err, frames = stk[1]
-                rethrow(CapturedException(err, frames))
-            else
-                rethrow(task.result)
-            end
-        end
+function execute!(proc::ThreadProc, f, args...)
+    tls = get_tls()
+    task = Task() do
+        set_tls!(tls)
+        prof_task_put!(tls.sch_handle.thunk_ref.id)
+        f(args...)
     end
-else
-    # TODO: Use Threads.@threads?
-    function execute!(proc::ThreadProc, f, args...)
-        tls = get_tls()
-        task = @async begin
-            set_tls!(tls)
-            prof_task_put!(tls.sch_handle.thunk_id.id)
-            f(args...)
+    ret = ccall(:jl_set_task_tid, Cint, (Any, Cint), task, proc.tid-1)
+    if ret == 0
+        error("jl_set_task_tid == 0")
+    end
+    @assert Threads.threadid(task) == proc.tid
+    schedule(task)
+    try
+        fetch(task)
+    catch err
+        @static if VERSION < v"1.7-rc1"
+            stk = Base.catch_stack(task)
+        else
+            stk = Base.current_exceptions(task)
         end
-        try
-            fetch(task)
-        catch err
-            @static if VERSION >= v"1.1"
-                @static if VERSION < v"1.7-rc1"
-                    stk = Base.catch_stack(task)
-                else
-                    stk = Base.current_exceptions(task)
-                end
-                err, frames = stk[1]
-                rethrow(CapturedException(err, frames))
-            else
-                rethrow(task.result)
-            end
-        end
+        err, frames = stk[1]
+        rethrow(CapturedException(err, frames))
     end
 end
 get_parent(proc::ThreadProc) = OSProc(proc.owner)

--- a/src/sch/Sch.jl
+++ b/src/sch/Sch.jl
@@ -976,7 +976,7 @@ function do_task(to_proc, extra_util, thunk_id, Tf, data, send_result, persist, 
         if ((extra_util isa MaxUtilization) && (real_util[] > 0)) ||
            ((extra_util isa Real) && (extra_util + real_util[] > cap))
             # Fully subscribed, wait and re-check
-            @debug "($(myid())) $f ($thunk_id) Waiting for free $(typeof(to_proc)): $extra_util | $(real_util[])/$cap"
+            @debug "($(myid())) $f ($thunk_id) Waiting for free $to_proc: $extra_util | $(real_util[])/$cap"
             wait(TASK_SYNC)
             unlock(TASK_SYNC)
         else
@@ -1021,7 +1021,7 @@ function do_task(to_proc, extra_util, thunk_id, Tf, data, send_result, persist, 
         pop!(TASKS_RUNNING, thunk_id)
         notify(TASK_SYNC)
     end
-    @debug "($(myid())) $f ($thunk_id) Releasing $(typeof(to_proc)): $extra_util | $(real_util[])/$cap"
+    @debug "($(myid())) $f ($thunk_id) Releasing $to_proc: $extra_util | $(real_util[])/$cap"
     metadata = (
         pressure=real_util[],
         loadavg=((Sys.loadavg()...,) ./ Sys.CPU_THREADS),

--- a/src/sch/Sch.jl
+++ b/src/sch/Sch.jl
@@ -595,13 +595,21 @@ function schedule!(ctx, state, procs=procs_to_use(ctx))
         end
         "Like `sum`, but replaces `nothing` entries with the average of non-`nothing` entries."
         function impute_sum(xs)
-            all(x->!isa(x, Chunk), xs) && return 0
-            avg = round(UInt64, mean(filter(x->x isa Chunk, xs)))
-            total = 0
+            length(xs) == 0 && return 0
+
+            total = zero(eltype(xs))
+            nothing_count = 0
+            something_count = 0
             for x in xs
-                total += x !== nothing ? x : avg
+                if isnothing(x)
+                    nothing_count += 1
+                else
+                    something_count += 1
+                    total += x
+                end
             end
-            total
+
+            total + nothing_count * total / something_count
         end
 
         # Schedule tasks

--- a/src/sch/Sch.jl
+++ b/src/sch/Sch.jl
@@ -3,6 +3,7 @@ module Sch
 using Distributed
 import MemPool: DRef, poolset
 import Statistics: mean
+import Random: randperm
 
 import ..Dagger
 import ..Dagger: Context, Processor, Thunk, WeakThunk, ThunkFuture, ThunkFailedException, Chunk, OSProc, AnyScope
@@ -657,15 +658,31 @@ function schedule!(ctx, state, procs=procs_to_use(ctx))
         inputs = filter(t->istask(t)||isa(t,Chunk), unwrap_weak_checked.(task.inputs))
         chunks = [istask(input) ? state.cache[input] : input for input in inputs]
         #local_procs = unique(map(c->c isa Chunk ? processor(c) : OSProc(), chunks))
-        local_procs = vcat([Dagger.get_processors(gp) for gp in procs]...)
+        local_procs = unique(vcat([Dagger.get_processors(gp) for gp in procs]...))
         if length(local_procs) > fallback_threshold
             @goto fallback
         end
         affinities = Dict(proc=>impute_sum([affinity(chunk)[2] for chunk in filter(c->isa(c,Chunk)&&get_parent(processor(c))==get_parent(proc), chunks)]) for proc in local_procs)
         # Estimate cost to move data and get scheduled
         costs = Dict(proc=>state.worker_pressure[get_parent(proc).pid][proc]+(aff/tx_rate) for (proc,aff) in affinities)
+
+        # shuffle procs around
+        P = randperm(length(local_procs))
+        local_procs = getindex.(Ref(local_procs), P)
+
         sort!(local_procs, by=p->costs[p])
         scheduled = false
+
+        # Move our corresponding ThreadProc to be the last considered
+        if length(local_procs) > 1
+            sch_threadproc = Dagger.ThreadProc(myid(), Threads.threadid())
+            sch_thread_idx = findfirst(proc->proc==sch_threadproc, local_procs)
+            if sch_thread_idx !== nothing
+                deleteat!(local_procs, sch_thread_idx)
+                push!(local_procs, sch_threadproc)
+            end
+        end
+
         for proc in local_procs
             gproc = get_parent(proc)
             if can_use_proc(task, gproc, proc, opts, scope)

--- a/src/sch/dynamic.jl
+++ b/src/sch/dynamic.jl
@@ -185,6 +185,7 @@ end
 add_thunk!(f, h::SchedulerHandle, args...; future=nothing, ref=nothing, kwargs...) =
     exec!(_add_thunk!, h, f, args, kwargs, future, ref)
 function _add_thunk!(ctx, state, task, tid, (f, args, kwargs, future, ref))
+    timespan_start(ctx, :add_thunk, tid, 0)
     _args = map(arg->arg isa ThunkID ? state.thunk_dict[arg.id] : arg, args)
     GC.@preserve _args begin
         thunk = Thunk(f, _args...; kwargs...)
@@ -202,6 +203,7 @@ function _add_thunk!(ctx, state, task, tid, (f, args, kwargs, future, ref))
             thunk.eager_ref = ref
         end
         put!(state.chan, RescheduleSignal())
+        timespan_finish(ctx, :add_thunk, tid, 0)
         return thunk_id
     end
 end

--- a/src/sch/eager.jl
+++ b/src/sch/eager.jl
@@ -1,6 +1,6 @@
 const EAGER_INIT = Ref{Bool}(false)
 const EAGER_THUNK_CHAN = Channel(typemax(Int))
-const EAGER_ID_MAP = Dict{UInt64,Int}()
+const EAGER_ID_MAP = Dict{UInt64,ThunkID}()
 const EAGER_CONTEXT = Ref{Context}()
 const EAGER_STATE = Ref{ComputeState}()
 
@@ -83,7 +83,7 @@ function eager_thunk()
             added_future, future, uid, ref, f, args, opts = take!(EAGER_THUNK_CHAN)
             # preserve inputs until they enter the scheduler
             tid = GC.@preserve args begin
-                _args = map(x->x isa Dagger.EagerThunk ? ThunkID(EAGER_ID_MAP[x.uid], x.thunk_ref) : x, args)
+                _args = map(x->x isa Dagger.EagerThunk ? ThunkRef(EAGER_ID_MAP[x.uid], x.thunk_ref) : x, args)
                 add_thunk!(f, h, _args...; future=future, ref=ref, opts...)
             end
             EAGER_ID_MAP[uid] = tid.id

--- a/src/sch/util.jl
+++ b/src/sch/util.jl
@@ -193,17 +193,13 @@ function fetch_report(task)
     try
         fetch(task)
     catch err
-        @static if VERSION >= v"1.1"
-            @static if VERSION < v"1.7-rc1"
-                stk = Base.catch_stack(task)
-            else
-                stk = Base.current_exceptions(task)
-            end
-            err, frames = stk[1]
-            rethrow(CapturedException(err, frames))
+        @static if VERSION < v"1.7-rc1"
+            stk = Base.catch_stack(task)
         else
-            rethrow(task.result)
+            stk = Base.current_exceptions(task)
         end
+        err, frames = stk[1]
+        rethrow(CapturedException(err, frames))
     end
 end
 

--- a/src/sch/util.jl
+++ b/src/sch/util.jl
@@ -9,6 +9,55 @@ unwrap_nested_exception(err::RemoteException) =
     unwrap_nested_exception(err.captured)
 unwrap_nested_exception(err) = err
 
+""""
+Returns the result and error status of `thunk` if it's cached in the scheduler,
+as a `Some{Tuple{<:Any,Bool}}`. If it's not present, `nothing` is returned.
+"""
+function cache_lookup(state, thunk::Thunk)
+    if haskey(state.cache, thunk)
+        return Some((state.cache[thunk], get(state.errored, thunk, false)))
+    end
+    nothing
+end
+function cache_lookup(state, thunk::ThunkRef)
+    if haskey(state.cache_remote, thunk)
+        return Some((state.cache_remote[thunk], get(state.errored_remote, thunk, false)))
+    end
+    nothing
+end
+function cache_lookup_checked(state, thunk)
+    value = cache_lookup(state, thunk)
+    if value === nothing
+        throw(KeyError(thunk))
+    end
+    value.value
+end
+
+"Stores `value` and `error` as the cached value and error status of `thunk`."
+function cache_store!(state, thunk::Thunk, value, error=false)
+    state.cache[thunk] = value
+    state.errored[thunk] = error
+end
+function cache_store!(state, thunk::ThunkRef, value, error=false)
+    state.cache_remote[thunk] = value
+    state.errored_remote[thunk] = error
+end
+
+"""
+Removes `thunk` from the preservation set of `thunk_remote`; if
+`thunk_remote`'s preservation set becomes empty, removes the cached result of
+`thunk_remote`.
+"""
+function cache_evict_remote!(state, thunk_ref::ThunkRef, thunk::Thunk)
+    pres_set = state.waiting_remote[thunk_ref]
+    pop!(pres_set, thunk)
+    if length(pres_set) == 0
+        delete!(state.waiting_remote, thunk_ref)
+        delete!(state.cache_remote, thunk_ref)
+        delete!(state.errored_remote, thunk_ref)
+    end
+end
+
 "Fills the result for all registered futures of `node`."
 function fill_registered_futures!(state, node, failed)
     if haskey(state.futures, node)
@@ -20,8 +69,10 @@ function fill_registered_futures!(state, node, failed)
     end
 end
 
-"Cleans up any inputs that aren't needed any longer, and returns a `Set{Chunk}`
-of all chunks that can now be evicted from workers."
+"""
+Cleans up any inputs that aren't needed any longer, and returns a `Set{Chunk}`
+of all chunks that can now be evicted from workers.
+"""
 function cleanup_inputs!(state, node)
     to_evict = Set{Chunk}()
     for inp in unwrap_weak_checked.(node.inputs)
@@ -34,10 +85,17 @@ function cleanup_inputs!(state, node)
                 pop!(w, node)
             end
             if isempty(w)
-                if istask(inp) && haskey(state.cache, inp)
-                    _node = state.cache[inp]
-                    if _node isa Chunk
-                        push!(to_evict, _node)
+                if istask(inp)
+                    value = cache_lookup(state, inp)
+                    if value !== nothing
+                        value, _ = value.value
+                        if value isa Chunk
+                            push!(to_evict, value)
+                        end
+                        if inp isa ThunkRef
+                            # We're done executing, remove us from the preservation set
+                            cache_evict_remote!(state, inp, node)
+                        end
                     end
                 elseif inp isa Chunk
                     push!(to_evict, inp)
@@ -51,7 +109,11 @@ end
 
 "Schedules any dependents that may be ready to execute."
 function schedule_dependents!(state, node, failed)
-    for dep in sort!(collect(get(()->Set{Thunk}(), state.waiting_data, node)), by=state.node_order)
+    for dep in sort!(collect(get(()->Set{AnyThunk}(), state.waiting_data, node)), by=state.node_order)
+        # If remote dep, we will notify the owning scheduler in `fill_registered_futures!`
+        dep isa ThunkRef && continue
+
+        # Is this dependent ready to execute?
         dep_isready = false
         if haskey(state.waiting, dep)
             set = state.waiting[dep]
@@ -71,39 +133,120 @@ function schedule_dependents!(state, node, failed)
     end
 end
 
+"Preserves local thunk dependents of the remote `thunk`."
+function preserve_local_dependents!(state, thunk::ThunkRef)
+    pres_set = get!(()->Set{Thunk}(), state.waiting_remote, thunk)
+    for dep in get(()->Set{AnyThunk}(), state.waiting_data, thunk)
+        push!(pres_set, dep)
+    end
+end
+
 """
 Prepares the scheduler to schedule `thunk`, including scheduling `thunk` if
 its inputs are satisfied.
 """
-function reschedule_inputs!(state, thunk, seen=Set{Thunk}())
+function reschedule_inputs!(state, thunk, seen=Set{AnyThunk}())
     thunk in seen && return
     push!(seen, thunk)
     if haskey(state.cache, thunk) || (thunk in state.ready) || (thunk in state.running)
+        # Dependencies have already been satisfied
         return
     end
-    w = get!(()->Set{Thunk}(), state.waiting, thunk)
-    for input in thunk.inputs
-        input = unwrap_weak_checked(input)
-        if istask(input) || (input isa Chunk)
-            push!(get!(()->Set{Thunk}(), state.waiting_data, input), thunk)
-        end
-        istask(input) || continue
-        if get(state.errored, input, false)
-            set_failed!(state, input, thunk)
-        end
-        haskey(state.cache, input) && continue
-        push!(w, input)
-        if !((input in state.running) || (input in state.ready))
-            reschedule_inputs!(state, input, seen)
+
+    if thunk isa ThunkRef
+        # We don't own these, so stop here
+        return
+    end
+
+    # We haven't executed yet, so calculate dependencies
+    # This will also tell us if we are ready to execute
+    w = get!(()->Set{AnyThunk}(), state.waiting, thunk)
+    for input in unwrap_weak_checked.(thunk.inputs)
+        istask(input) || (input isa Chunk) || continue
+
+        # We need to preserve this value for our execution
+        push!(get!(()->Set{AnyThunk}(), state.waiting_data, input), thunk)
+
+        # This input is a value, good to go
+        input isa Chunk && continue
+
+        # Input is a thunk, check if it has completed
+        value = cache_lookup(state, input)
+        if value !== nothing
+            # Input has completed and we have the value, set failure and be done
+            value, error = value.value
+            if error
+                set_failed!(state, input, thunk)
+            end
+        else
+            # We're still waiting on this input to complete
+            push!(w, input)
+
+            if input isa Thunk
+                # Local thunk, keep rescheduling if it's not at least ready
+                if !((input in state.running) || (input in state.ready))
+                    reschedule_inputs!(state, input, seen)
+                end
+            elseif input isa ThunkRef
+                # Remote thunk, ask to be notified when it's completed
+
+                # Register a future with the owning scheduler
+                register_remote_future!(state, input)
+            end
         end
     end
     if isempty(w)
-        # Inputs are ready
+        # Inputs are satisfied, so we're either ready, or entered an error
+        # state due to an input (from `set_failed!`)
         delete!(state.waiting, thunk)
         if !get(state.errored, thunk, false)
             push!(state.ready, thunk)
         end
     end
+end
+
+"""
+Registers a future on the scheduler owning `thunk` that notifies our scheduler
+once the thunk has completed execution, and registers the thunk value and error
+state. Executes asynchronously to prevent cross-scheduler deadlock.
+"""
+function register_remote_future!(state, thunk::ThunkRef)
+    future = ThunkFuture()
+    remotecall_wait(thunk.id.wid, thunk, future, myid()) do thunk, future, our_id
+        # Do this lazily to prevent deadlock (this other scheduler might also be holding our lock)
+        errormonitor(@async begin
+            _state = EAGER_STATE[]
+            h = lock(_state.lock) do
+                t = unwrap_weak_checked(_state.thunk_dict[thunk.id])
+                if haskey(_state.cache, t)
+                    # Value is already available, set future and return
+                    put!(future, _state.cache[t]; error=_state.errored[t])
+                    return nothing
+                end
+                # Create a valid handle to access the remote scheduler
+                SchedulerHandle(thunk, _state.worker_chans[our_id]...)
+            end
+            h === nothing && return
+            register_future!(h, thunk, future)
+        end)
+    end
+
+    # Get notified later
+    errormonitor(@async begin
+        # Wait for the future
+        value, error = try
+            (fetch(future), false)
+        catch err
+            (err, true)
+        end
+        # Save the result and schedule dependents
+        lock(state.lock) do
+            cache_store!(state, thunk, value, error)
+            preserve_local_dependents!(state, thunk)
+            schedule_dependents!(state, thunk, error)
+            put!(state.chan, RescheduleSignal())
+        end
+    end)
 end
 
 "Marks `thunk` and all dependent thunks as failed."
@@ -152,18 +295,22 @@ function print_sch_status(io::IO, state, thunk; offset=0, limit=5, max_inputs=3)
         status
     end
     if offset == 0
-        println(io, "Ready ($(length(state.ready))): $(join(map(t->t.id, state.ready), ','))")
-        println(io, "Running: ($(length(state.running))): $(join(map(t->t.id, collect(state.running)), ','))")
+        println(io, "Ready ($(length(state.ready))): $(join(map(t->t.id, state.ready), ", "))")
+        println(io, "Running: ($(length(state.running))): $(join(map(t->t.id, collect(state.running)), ", "))")
         print(io, "($(status_string(thunk))) ")
     end
     println(io, "$(thunk.id): $(thunk.f)")
     for (idx,input) in enumerate(thunk.inputs)
         if input isa WeakThunk
-            input = unwrap_weak(input)
+            input = Dagger.unwrap_weak(input)
             if input === nothing
-                println(io, repeat(' ', offset+2), "(???)")
+                println(io, repeat(' ', offset+2), "[???]")
                 continue
             end
+        end
+        if input isa ThunkRef
+            println(io, repeat(' ', offset+2), "($(status_string(input))) [@$(input.id)]")
+            continue
         end
         input isa Thunk || continue
         if idx > max_inputs
@@ -218,7 +365,8 @@ end
 fn_type(x::Chunk) = x.chunktype
 fn_type(x) = typeof(x)
 function signature(task::Thunk, state)
-    inputs = map(x->istask(x) ? state.cache[x] : x, unwrap_weak_checked.(task.inputs))
+    inputs = map(unwrap_weak_checked, task.inputs)
+    inputs = map(x->istask(x) ? cache_lookup_checked(state, x)[1] : x, inputs)
     Tuple{fn_type(task.f), map(x->x isa Chunk ? x.chunktype : typeof(x), inputs)...}
 end
 
@@ -327,7 +475,7 @@ function estimate_task_costs(state, procs, task)
     tx_rate = state.transfer_rate[]
 
     # Find all Chunks
-    inputs = map(input->istask(input) ? state.cache[input] : input, unwrap_weak_checked.(task.inputs))
+    inputs = map(input->istask(input) ? cache_lookup_checked(state, input)[1] : input, unwrap_weak_checked.(task.inputs))
     chunks = convert(Vector{Chunk}, filter(t->isa(t, Chunk), [inputs...]))
 
     # Estimate network transfer costs based on data size

--- a/src/scopes.jl
+++ b/src/scopes.jl
@@ -7,7 +7,7 @@ struct AnyScope <: AbstractScope end
 
 "Union of two or more scopes."
 struct UnionScope <: AbstractScope
-    scopes::NTuple{N,<:AbstractScope} where N
+    scopes::Tuple
 end
 UnionScope(scopes...) = UnionScope((scopes...,))
 UnionScope(scopes::Vector{<:AbstractScope}) = UnionScope((scopes...,))

--- a/src/thunk.jl
+++ b/src/thunk.jl
@@ -1,7 +1,7 @@
 export Thunk, delayed, delayedmap
 
 const ID_COUNTER = Threads.Atomic{Int}(1)
-next_id() = Threads.atomic_add!(ID_COUNTER, 1)
+next_id() = ThunkID(myid(), Threads.atomic_add!(ID_COUNTER, 1))
 
 """
     Thunk
@@ -51,7 +51,7 @@ If omitted, options can also be specified by passing key-value pairs as
 mutable struct Thunk
     f::Any # usually a Function, but could be any callable
     inputs::Tuple
-    id::Int
+    id::ThunkID
     get_result::Bool # whether the worker should send the result or only the metadata
     meta::Bool
     persist::Bool # don't `free!` result after computing
@@ -62,7 +62,7 @@ mutable struct Thunk
     eager_ref::Union{DRef,Nothing}
     options::Any # stores scheduler-specific options
     function Thunk(f, xs...;
-                   id::Int=next_id(),
+                   id::ThunkID=next_id(),
                    get_result::Bool=false,
                    meta::Bool=false,
                    persist::Bool=false,

--- a/src/ui/graph.jl
+++ b/src/ui/graph.jl
@@ -81,7 +81,7 @@ _proc_color(ctx, proc::Processor) = get!(ctx.proc_to_color, proc) do
     ctx.proc_color_idx[] = clamp(ctx.proc_color_idx[]+1, 0, 128)
     "#$(Colors.hex(_color))"
 end
-_proc_color(ctx, id::Int) = _proc_color(ctx, ctx.id_to_proc[id])
+_proc_color(ctx, id::ThunkID) = _proc_color(ctx, ctx.id_to_proc[id])
 _proc_color(ctx, ::Nothing) = "black"
 _proc_shape(ctx, proc::Processor) = get!(ctx.proc_to_shape, typeof(proc)) do
     _shape = ctx.proc_shapes[ctx.proc_shape_idx[]]
@@ -122,7 +122,7 @@ end
 function write_edge(ctx, io, ts_move::Timespan, logs, inputname=nothing, inputarg=nothing)
     f, id = ts_move.timeline
     t_move = pretty_time(ts_move)
-    if id > 0
+    if id isa ThunkID
         print(io, "n_$id -> n_$(ts_move.id[1]) [label=\"Move: $t_move")
         color_src = _proc_color(ctx, id)
     else
@@ -151,8 +151,8 @@ function write_dag(io, logs::Vector, t=nothing)
            proc_to_shape = Dict{Type,String}(),
            proc_shapes = ("ellipse","box","triangle"),
            proc_shape_idx = Ref{Int}(1),
-           id_to_proc = Dict{Int,Processor}())
-    argmap = Dict{Int,Vector}()
+           id_to_proc = Dict{ThunkID,Processor}())
+    argmap = Dict{ThunkID,Vector}()
     getargs!(argmap, t)
     c = 1
     # Compute nodes
@@ -160,7 +160,7 @@ function write_dag(io, logs::Vector, t=nothing)
         c = write_node(ctx, io, ts, c)
     end
     # Argument nodes
-    argnodemap = Dict{Int,Vector{String}}()
+    argnodemap = Dict{ThunkID,Vector{String}}()
     argids = IdDict{Any,String}()
     for id in keys(argmap)
         nodes = String[]
@@ -190,7 +190,7 @@ function write_dag(io, logs::Vector, t=nothing)
         argnodemap[id] = nodes
     end
     # Move edges
-    for ts in filter(x->x.category==:move && x.timeline[2]>0, logs)
+    for ts in filter(x->x.category==:move && x.timeline[2] isa ThunkID, logs)
         write_edge(ctx, io, ts, logs)
     end
     #= FIXME: Legend (currently it's laid out horizontally)

--- a/test/logging.jl
+++ b/test/logging.jl
@@ -92,7 +92,7 @@
         esat = l1[:esat]
         @test any(e->haskey(e, :scheduler_init), esat)
         @test any(e->haskey(e, :schedule), esat)
-        @test any(e->haskey(e, :fire_multi), esat)
+        @test any(e->haskey(e, :fire), esat)
         @test any(e->haskey(e, :take), esat)
         @test any(e->haskey(e, :finish), esat)
         # Note: May one day be true as scheduler evolves
@@ -108,7 +108,7 @@
             esat = lo[:esat]
             @test !any(e->haskey(e, :scheduler_init), esat)
             @test !any(e->haskey(e, :schedule), esat)
-            @test !any(e->haskey(e, :fire_multi), esat)
+            @test !any(e->haskey(e, :fire), esat)
             @test !any(e->haskey(e, :take), esat)
             @test !any(e->haskey(e, :finish), esat)
             psat = lo[:psat]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ addprocs(3)
 using Test
 using Dagger
 using UUIDs
+import MemPool
 
 include("util.jl")
 include("fakeproc.jl")

--- a/test/scheduler.jl
+++ b/test/scheduler.jl
@@ -399,3 +399,20 @@ end
 @testset "Chunk Caching" begin
     compute(delayed(testevicted)(delayed(testpresent)(c1,c2)))
 end
+
+@testset "MemPool.approx_size" begin
+    for (obj, size) in [
+        (rand(100), 100*sizeof(Float64)),
+        (rand(Float32, 100), 100*sizeof(Float32)),
+        (rand(1:10, 100), 100*sizeof(Int)),
+        (fill(:a, 10), missing),
+        (fill("a", 10), missing),
+        (fill('a', 10), missing),
+    ]
+        if size !== missing
+            @test MemPool.approx_size(obj) == size
+        else
+            @test MemPool.approx_size(obj) !== nothing
+        end
+    end
+end

--- a/test/scheduler.jl
+++ b/test/scheduler.jl
@@ -50,17 +50,13 @@ function dynamic_get_dag(x...)
 end
 function dynamic_add_thunk(x)
     h = sch_handle()
-    id = Dagger.Sch.add_thunk!(h, x) do y
-        y+1
-    end
+    id = Dagger.Sch.add_thunk!(inc, h, x)
     wait(h, id)
     return fetch(h, id)
 end
 function dynamic_add_thunk_self_dominated(x)
     h = sch_handle()
-    id = Dagger.Sch.add_thunk!(h, h.thunk_id, x) do y
-        y+1
-    end
+    id = Dagger.Sch.add_thunk!(inc, h, h.thunk_ref, x)
     return fetch(h, id)
 end
 function dynamic_wait_fetch_multiple(x)
@@ -70,7 +66,7 @@ function dynamic_wait_fetch_multiple(x)
     for key in keys(ids)
         while !isempty(ids[key])
             val = pop!(ids[key])
-            if val == h.thunk_id
+            if val == h.thunk_ref
                 id = key
             end
         end
@@ -83,12 +79,12 @@ function dynamic_wait_fetch_multiple(x)
 end
 function dynamic_fetch_self(x)
     h = sch_handle()
-    return fetch(h, h.thunk_id)
+    return fetch(h, h.thunk_ref)
 end
 function dynamic_fetch_dominated(x)
     h = sch_handle()
     ids = Dagger.Sch.get_dag_ids(h)
-    did = pop!(ids[h.thunk_id])
+    did = pop!(ids[h.thunk_ref])
     wait(h, did)
 end
 end
@@ -397,18 +393,18 @@ end
         @test ids isa Dict
         @test length(keys(ids)) == 4
 
-        a_id = ThunkID(a.id)
-        b_id = ThunkID(b.id)
-        c_id = ThunkID(c.id)
-        d_id = ThunkID(d.id)
+        a_ref = Dagger.Sch.ThunkRef(a)
+        b_ref = Dagger.Sch.ThunkRef(b)
+        c_ref = Dagger.Sch.ThunkRef(c)
+        d_ref = Dagger.Sch.ThunkRef(d)
 
-        @test haskey(ids, d_id)
-        @test length(ids[d_id]) == 0 # no one waiting on our result
-        @test length(ids[a_id]) == 0 # b and c finished, our result is unneeded
-        @test length(ids[b_id]) == 1 # d is still executing
-        @test length(ids[c_id]) == 1 # d is still executing
-        @test pop!(ids[b_id]) == d_id
-        @test pop!(ids[c_id]) == d_id
+        @test haskey(ids, d_ref)
+        @test length(ids[d_ref]) == 0 # no one waiting on our result
+        @test length(ids[a_ref]) == 0 # b and c finished, our result is unneeded
+        @test length(ids[b_ref]) == 1 # d is still executing
+        @test length(ids[c_ref]) == 1 # d is still executing
+        @test pop!(ids[b_ref]) == d_ref
+        @test pop!(ids[c_ref]) == d_ref
     end
     @testset "Add Thunk" begin
         a = delayed(dynamic_add_thunk)(1)

--- a/test/scheduler.jl
+++ b/test/scheduler.jl
@@ -311,6 +311,60 @@ end
     end
 end
 
+@testset "Scheduler algorithms" begin
+    # New function to hide from scheduler's function cost cache
+    mynothing(args...) = nothing
+
+    # New non-singleton struct to hide from `approx_size`
+    struct MyStruct
+        x::Int
+    end
+
+    state = Dagger.Sch.EAGER_STATE[]
+    tproc1 = Dagger.ThreadProc(1, 1)
+    tproc2 = Dagger.ThreadProc(first(workers()), 1)
+    procs = [tproc1, tproc2]
+
+    pres1 = state.worker_pressure[1][tproc1]
+    pres2 = state.worker_pressure[first(workers())][tproc2]
+    tx_rate = state.transfer_rate[]
+
+    for (args, tx_size) in [
+        ([1, 2], 0),
+        ([Dagger.tochunk(1), 2], sizeof(Int)),
+        ([1, Dagger.tochunk(2)], sizeof(Int)),
+        ([Dagger.tochunk(1), Dagger.tochunk(2)], 2*sizeof(Int)),
+        # TODO: Why does this work? Seems slow
+        ([Dagger.tochunk(MyStruct(1))], sizeof(MyStruct)),
+        ([Dagger.tochunk(MyStruct(1)), Dagger.tochunk(1)], sizeof(MyStruct)+sizeof(Int)),
+    ]
+        for arg in args
+            if arg isa Chunk
+                aff = Dagger.affinity(arg)
+                @test aff[1] == OSProc(1)
+                @test aff[2] == MemPool.approx_size(MemPool.poolget(arg.handle))
+            end
+        end
+
+        cargs = map(arg->MemPool.poolget(arg.handle), filter(arg->isa(arg, Chunk), args))
+        est_tx_size = Dagger.Sch.impute_sum(map(MemPool.approx_size, cargs))
+        @test est_tx_size == tx_size
+
+        t = delayed(mynothing)(args...)
+        sorted_procs, costs = Dagger.Sch.estimate_task_costs(state, procs, t)
+
+        @test tproc1 in sorted_procs
+        @test tproc2 in sorted_procs
+        @test sorted_procs[1] == tproc1
+        @test sorted_procs[2] == tproc2
+
+        @test haskey(costs, tproc1)
+        @test haskey(costs, tproc2)
+        @test costs[tproc1] ≈ pres1 # All chunks are local
+        @test costs[tproc2] ≈ (tx_size/tx_rate) + pres2 # All chunks are remote
+    end
+end
+
 @testset "Dynamic Thunks" begin
     @testset "Exec" begin
         a = delayed(dynamic_exec)(2)

--- a/test/thunk.jl
+++ b/test/thunk.jl
@@ -157,7 +157,6 @@ end
     @testset "remote spawn" begin
         a = fetch(Distributed.@spawnat 2 Dagger.spawn(+, 1, 2))
         @test Dagger.Sch.EAGER_INIT[]
-        @test fetch(Distributed.@spawnat 2 !(Dagger.Sch.EAGER_INIT[]))
         @test a isa Dagger.EagerThunk
         @test fetch(a) == 3
 

--- a/test/util.jl
+++ b/test/util.jl
@@ -14,7 +14,7 @@ end
 replace_obj!(ex::Symbol, obj) = Expr(:(.), obj, QuoteNode(ex))
 replace_obj!(ex, obj) = ex
 function _test_throws_unwrap(terr, ex; to_match=[])
-    @gensym rerr
+    @gensym rerr rbt
     match_expr = Expr(:block)
     for m in to_match
         if m.head == :(=)
@@ -35,12 +35,20 @@ function _test_throws_unwrap(terr, ex; to_match=[])
         end
     end
     quote
+        $rbt = nothing
         $rerr = try
             $(esc(ex))
         catch err
+            $rbt = catch_backtrace()
             Dagger.Sch.unwrap_nested_exception(err)
         end
         @test $rerr isa $terr
+        if !($rerr isa $terr)
+            printstyled(stderr, "Actual error:\n"; color=:yellow, bold=true)
+            Base.showerror(stderr, $rerr)
+            Base.show_backtrace(stderr, $rbt)
+            println(stderr)
+        end
         $match_expr
     end
 end


### PR DESCRIPTION
This PR allows the scheduler to execute itself on all workers in the cluster. We first expand the notion of "thunk ID" to be per-worker, so that we can locally allocate unique IDs (and later locate where a thunk was created), and then allow the eager scheduler code to execute on all workers, instead of `remotecall`'ing to worker 1. We then allow thunks to be registered and scheduled locally (which should make recursive runtime-generated graphs vastly more efficient, no longer having to make a trip over the network). Finally, we implement local (and optionally remote?) work stealing (strictly for already-scheduled tasks, for the time being) to allow work to be kept balanced. The newly-available scheduler metrics on each worker will make it possible to optimize the choice of processor to steal from, although this can be left for later work.

Todo:
- [x] Execute the eager scheduler on all workers
- [ ] Implement local work stealing with ConcurrentCollection's `WorkStealingDeque`
- [ ] Tests for `@spawn`/`add_thunk!` with thunks owned by other schedulers
- [ ] Document new behavior
- [ ] Validate the web dashboard shows remote scheduler data
- [ ] Benchmarks