### PR TITLE
Fix remove workers test

### DIFF
--- a/src/sch/Sch.jl
+++ b/src/sch/Sch.jl
@@ -821,7 +821,9 @@ function evict_all_chunks!(ctx, to_evict)
     end
 end
 function evict_chunks!(log_sink, chunks::Set{Chunk})
-    ctx = Context(;log_sink)
+    # Need worker id or else Context might use Processors which user does not want us to use.
+    # In particular workers which have not yet run using Dagger will cause the call below to throw an exception
+    ctx = Context([myid()];log_sink) 
     for chunk in chunks
         timespan_start(ctx, :evict, myid(), (;data=chunk))
         haskey(CHUNK_CACHE, chunk) && delete!(CHUNK_CACHE, chunk)

--- a/test/scheduler.jl
+++ b/test/scheduler.jl
@@ -198,7 +198,7 @@ end
             function testfun(i)
                 i <= 4 && return myid()
                 # Wait for test to do its thing before we proceed
-                while blocked
+                if blocked
                     sleep(0.1) # just so we don't end up overflowing or something while waiting for workers to be added
                     # Here we would like to just wait to be rescheduled on another worker (which is not blocked)
                     # but this functionality does not exist, so instead we do this weird thing where we reschedule


### PR DESCRIPTION
As promised earlier, here is an attempt to fix the remove workers test.

It turned out a bit more evil than I had hoped as it was quite difficult to yank the workers after work had started and any alternative suggestions to using the logging framework for this is appreciated.

The change in `Sch` is because you'd otherwise get errors for not having ran `using Dagger` on the workers in the add workers test after it completes.