### PR TITLE
Context: Add global context for lazy API

### DIFF
--- a/src/array/darray.jl
+++ b/src/array/darray.jl
@@ -84,7 +84,7 @@ compute(ctx, x::ArrayOp; options=nothing) =
 collect(ctx::Context, x::ArrayOp; options=nothing) =
     collect(ctx, compute(ctx, x; options=options); options=options)
 
-collect(x::ArrayOp; options=nothing) = collect(Context(), x; options=options)
+collect(x::ArrayOp; options=nothing) = collect(Context(global_context()), x; options=options)
 
 function Base.show(io::IO, ::MIME"text/plain", x::ArrayOp)
     write(io, string(typeof(x)))

--- a/src/compute.jl
+++ b/src/compute.jl
@@ -2,20 +2,20 @@ export stage, cached_stage, compute, debug_compute, free!, cleanup
 
 ###### Scheduler #######
 
-compute(x; options=nothing) = compute(Context(), x; options=options)
+compute(x; options=nothing) = compute(Context(global_context()), x; options=options)
 compute(ctx, c::Chunk; options=nothing) = c
 
 collect(ctx::Context, t::Thunk; options=nothing) =
     collect(ctx, compute(ctx, t; options=options); options=options)
 collect(d::Union{Chunk,Thunk}; options=nothing) =
-    collect(Context(), d; options=options)
+    collect(Context(global_context()), d; options=options)
 
 abstract type Computation end
 
 compute(ctx, c::Computation; options=nothing) =
     compute(ctx, stage(ctx, c); options=options)
 collect(c::Computation; options=nothing) =
-    collect(Context(), c; options=options)
+    collect(Context(global_context()), c; options=options)
 
 """
     compute(ctx::Context, d::Thunk; options=nothing) -> Chunk
@@ -48,7 +48,7 @@ function debug_compute(ctx::Context, args...; profile=false, options=nothing)
 end
 
 function debug_compute(arg; profile=false, options=nothing)
-    ctx = Context()
+    ctx = Context(global_context())
     dbgctx = Context(procs(ctx), LocalEventLog(), profile)
     debug_compute(dbgctx, arg; options=options)
 end
@@ -56,7 +56,7 @@ end
 Base.@deprecate gather(ctx, x) collect(ctx, x)
 Base.@deprecate gather(x) collect(x)
 
-cleanup() = cleanup(Context())
+cleanup() = cleanup(Context(global_context()))
 function cleanup(ctx::Context)
     if :scheduler in keys(PLUGINS)
         scheduler = PLUGINS[:scheduler]

--- a/src/file-io.jl
+++ b/src/file-io.jl
@@ -113,7 +113,7 @@ function save(ctx, chunk::Chunk{X, FileReader}, file_path::AbstractString) where
    end
 end
 
-save(chunk::Union{Chunk, Thunk}, file_path::AbstractString) = save(Context(), chunk, file_path)
+save(chunk::Union{Chunk, Thunk}, file_path::AbstractString) = save(Context(global_context()), chunk, file_path)
 
 
 

--- a/src/processor.jl
+++ b/src/processor.jl
@@ -225,9 +225,17 @@ Context(procs::Vector{P}=Processor[OSProc(w) for w in workers()];
     Context(procs, proc_lock, proc_notify, log_sink, log_file,
             profile, options)
 Context(xs::Vector{Int}; kwargs...) = Context(map(OSProc, xs); kwargs...)
-Context(ctx::Context, xs::Vector) = # make a copy
+Context(ctx::Context, xs::Vector=copy(procs(ctx))) = # make a copy
     Context(xs; log_sink=ctx.log_sink, log_file=ctx.log_file,
                 profile=ctx.profile, options=ctx.options)
+
+const GLOBAL_CONTEXT = Ref{Context}()
+function global_context()
+    if !isassigned(GLOBAL_CONTEXT)
+        GLOBAL_CONTEXT[] = Context()
+    end
+    return GLOBAL_CONTEXT[]
+end
 
 """
     write_event(ctx::Context, event::Event)

--- a/src/ui/graph.jl
+++ b/src/ui/graph.jl
@@ -237,7 +237,8 @@ function show_plan(logs::Vector{Timespan}, t::Thunk)
 end
 
 function show_plan(c)
-    t = thunkize(Context(), stage(Context(), c))
+    ctx = Context(global_context())
+    t = thunkize(ctx, stage(ctx, c))
     show_plan(t)
 end
 


### PR DESCRIPTION
To allow `delayed` to inherit from a global context, making logging and scheduler visualization easy to configure globally.