### PR TITLE
spawn: Disallow passing Thunk as argument

### DIFF
--- a/src/thunk.jl
+++ b/src/thunk.jl
@@ -243,6 +243,9 @@ eager_next_id() = Threads.atomic_add!(EAGER_ID_COUNTER, one(UInt64))
 
 function _spawn(f, args...; options, kwargs...)
     Dagger.Sch.init_eager()
+    for arg in args
+        @assert !isa(arg, Thunk) "Cannot use Thunks in spawn"
+    end
     uid = eager_next_id()
     future = ThunkFuture()
     finalizer_ref = poolset(EagerThunkFinalizer(uid))

--- a/test/thunk.jl
+++ b/test/thunk.jl
@@ -248,4 +248,8 @@ end
         g = (x) -> fetch(Dagger.spawn(f, x; proclist=s))
         fetch(Dagger.spawn(g, 10; proclist=s))
     end
+    @testset "no cross-scheduler Thunk usage" begin
+        a = delayed(+)(1,2)
+        @test_throws Exception Dagger.spawn(identity, a)
+    end
 end


### PR DESCRIPTION
We can't currently support passing `Thunk`s into `@spawn`, so explicitly detect and disallow this for now.