### PR TITLE
Minimize overhead of `add_thunk!`

### DIFF
--- a/src/sch/dynamic.jl
+++ b/src/sch/dynamic.jl
@@ -196,7 +196,7 @@ function _add_thunk!(ctx, state, task, tid, (f, args, kwargs, future, ref))
     GC.@preserve _args begin
         thunk = Thunk(f, _args...; kwargs...)
         # Create a `DRef` to `thunk` so that the caller can preserve it
-        thunk_ref = poolset(thunk)
+        thunk_ref = poolset(thunk; size=64)
         thunk_id = ThunkID(thunk.id, thunk_ref)
         state.thunk_dict[thunk.id] = WeakThunk(thunk)
         reschedule_inputs!(state, thunk)

--- a/src/sch/dynamic.jl
+++ b/src/sch/dynamic.jl
@@ -208,6 +208,7 @@ function _add_thunk!(ctx, state, task, tid, (f, args, kwargs, future, ref))
             # Preserve the `EagerThunkFinalizer` through `thunk`
             thunk.eager_ref = ref
         end
+        state.valid[thunk] = nothing
         put!(state.chan, RescheduleSignal())
         timespan_finish(ctx, :add_thunk, tid, 0)
         return thunk_id

--- a/src/sch/util.jl
+++ b/src/sch/util.jl
@@ -101,6 +101,9 @@ function reschedule_inputs!(state, thunk, seen=Set{Thunk}())
     while !isempty(to_visit)
         thunk = pop!(to_visit)
         push!(seen, thunk)
+        if haskey(state.valid, thunk)
+            continue
+        end
         if haskey(state.cache, thunk) || (thunk in state.ready) || (thunk in state.running)
             continue
         end


### PR DESCRIPTION
Does some simple optimizations to reduce the overhead of deep and wide DAGs, and `@spawn` in general.