### PR TITLE
eager: Force kill scheduler on exit

### DIFF
--- a/test/thunk.jl
+++ b/test/thunk.jl
@@ -48,7 +48,7 @@ end
 end
 
 @testset "@spawn" begin
-    @test !isassigned(Dagger.Sch.EAGER_CONTEXT)
+    @test Dagger.Sch.EAGER_CONTEXT[] === nothing
     @testset "per-call" begin
         x = 2
         a = @spawn x + x


### PR DESCRIPTION
Prevents warnings from MemPool that it had to forcibly evict references.