### PR TITLE
Add DaggerMPI subpackage for MPI integrations

### DIFF
--- a/lib/DaggerMPI/Project.toml
+++ b/lib/DaggerMPI/Project.toml
@@ -1,0 +1,8 @@
+name = "DaggerMPI"
+uuid = "37bfb287-2338-4693-8557-581796463535"
+authors = ["Julian P Samaroo <jpsamaroo@jpsamaroo.me>"]
+version = "0.1.0"
+
+[deps]
+Dagger = "d58978e5-989f-55fb-8d15-ea34adc7bf54"
+MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"

--- a/lib/DaggerMPI/src/DaggerMPI.jl
+++ b/lib/DaggerMPI/src/DaggerMPI.jl
@@ -1,0 +1,159 @@
+module DaggerMPI
+
+using Dagger
+using MPI
+
+struct MPIProcessor{P,C} <: Dagger.Processor
+    proc::P
+    comm::MPI.Comm
+    color_algo::C
+end
+
+struct SimpleColoring end
+function (sc::SimpleColoring)(comm, key)
+    return UInt64(rem(key, MPI.Comm_size(comm)))
+end
+
+const MPI_PROCESSORS = Ref{Int}(-1)
+
+const PREVIOUS_PROCESSORS = Set()
+
+function initialize(comm::MPI.Comm=MPI.COMM_WORLD; color_algo=SimpleColoring())
+    @assert MPI_PROCESSORS[] == -1 "DaggerMPI already initialized"
+
+    # Force eager_thunk to run
+    fetch(Dagger.@spawn 1+1)
+
+    MPI.Init(; finalize_atexit=false)
+    procs = Dagger.get_processors(OSProc())
+    i = 0
+    empty!(Dagger.PROCESSOR_CALLBACKS)
+    empty!(Dagger.OSPROC_PROCESSOR_CACHE)
+    for proc in procs
+        Dagger.add_processor_callback!("mpiprocessor_$i") do
+            return MPIProcessor(proc, comm, color_algo)
+        end
+        i += 1
+    end
+    MPI_PROCESSORS[] = i
+
+    # FIXME: Hack to populate new processors
+    Dagger.get_processors(OSProc())
+
+    return nothing
+end
+
+function finalize()
+    @assert MPI_PROCESSORS[] > -1 "DaggerMPI not yet initialized"
+    for i in 1:MPI_PROCESSORS[]
+        Dagger.delete_processor_callback!("mpiprocessor_$i")
+    end
+    empty!(Dagger.PROCESSOR_CALLBACKS)
+    empty!(Dagger.OSPROC_PROCESSOR_CACHE)
+    i = 1
+    for proc in PREVIOUS_PROCESSORS
+        Dagger.add_processor_callback!("old_processor_$i") do
+            return proc
+        end
+        i += 1
+    end
+    empty!(PREVIOUS_PROCESSORS)
+    MPI.Finalize()
+    MPI_PROCESSORS[] = -1
+end
+
+"References a value stored on some MPI rank."
+struct MPIColoredValue{T}
+    color::UInt64
+    value::T
+    comm::MPI.Comm
+end
+
+Dagger.get_parent(proc::MPIProcessor) = Dagger.OSProc()
+Dagger.default_enabled(proc::MPIProcessor) = true
+
+"Busy-loop Irecv that yields to other tasks."
+function recv_yield(src, tag, comm)
+    while true
+        got, value, _ = MPI.irecv(src, tag, comm)
+        if got
+            return value
+        end
+        # TODO: Sigmoidal backoff
+        yield()
+    end
+end
+
+function Dagger.execute!(proc::MPIProcessor, f, args...)
+    rank = MPI.Comm_rank(proc.comm)
+    tag = abs(Base.unsafe_trunc(Int32, Dagger.get_task_hash() >> 32))
+    color = proc.color_algo(proc.comm, tag)
+    if rank == color
+        @debug "[$rank] Executing $f on $tag"
+        return MPIColoredValue(color, Dagger.execute!(proc.proc, f, args...), proc.comm)
+    end
+    # Return nothing, we won't use this value anyway
+    @debug "[$rank] Skipped $f on $tag"
+    return MPIColoredValue(color, nothing, proc.comm)
+end
+
+function Dagger.move(from_proc::MPIProcessor, to_proc::MPIProcessor, x::Dagger.Chunk)
+    @assert from_proc.comm == to_proc.comm "Mixing different MPI communicators is not supported"
+    @assert Dagger.chunktype(x) <: MPIColoredValue
+    x_value = fetch(x)
+    rank = MPI.Comm_rank(from_proc.comm)
+    tag = abs(Base.unsafe_trunc(Int32, Dagger.get_task_hash(:input) >> 32))
+    other_tag = abs(Base.unsafe_trunc(Int32, Dagger.get_task_hash(:self) >> 32))
+    other = from_proc.color_algo(from_proc.comm, other_tag)
+    if x_value.color == rank == other
+        # We generated and will use this input
+        return Dagger.move(from_proc.proc, to_proc.proc, x_value.value)
+    elseif x_value.color == rank
+        # We generated this input
+        @debug "[$rank] Starting P2P send to [$other] from $tag to $other_tag"
+        MPI.isend(x_value.value, other, tag, from_proc.comm)
+        @debug "[$rank] Finished P2P send to [$other] from $tag to $other_tag"
+        return Dagger.move(from_proc.proc, to_proc.proc, x_value.value)
+    elseif other == rank
+        # We will use this input
+        @debug "[$rank] Starting P2P recv from $tag to $other_tag"
+        value = recv_yield(x_value.color, tag, from_proc.comm)
+        @debug "[$rank] Finished P2P recv from $tag to $other_tag"
+        return Dagger.move(from_proc.proc, to_proc.proc, value)
+    else
+        # We didn't generate and will not use this input
+        return nothing
+    end
+end
+
+function Dagger.move(from_proc::MPIProcessor, to_proc::Dagger.Processor, x::Dagger.Chunk)
+    @assert Dagger.chunktype(x) <: MPIColoredValue
+    x_value = fetch(x)
+    rank = MPI.Comm_rank(from_proc.comm)
+    tag = abs(Base.unsafe_trunc(Int32, Dagger.get_task_hash(:input) >> 32))
+    if rank == x_value.color
+        # FIXME: Broadcast send
+        @sync for other in 0:(MPI.Comm_size(from_proc.comm)-1)
+            other == rank && continue
+            @async begin
+                @debug "[$rank] Starting bcast send to [$other] on $tag"
+                MPI.isend(x_value.value, other, tag, from_proc.comm)
+                @debug "[$rank] Finished bcast send to [$other] on $tag"
+            end
+        end
+        return Dagger.move(from_proc.proc, to_proc, x_value.value)
+    else
+        @debug "[$rank] Starting bcast recv on $tag"
+        value = recv_yield(x_value.color, tag, from_proc.comm)
+        @debug "[$rank] Finished bcast recv on $tag"
+        return Dagger.move(from_proc.proc, to_proc, value)
+    end
+end
+
+function Dagger.move(from_proc::Dagger.Processor, to_proc::MPIProcessor, x::Dagger.Chunk)
+    @assert !(Dagger.chunktype(x) <: MPIColoredValue)
+    rank = MPI.Comm_rank(to_proc.comm)
+    return MPIColoredValue(rank, Dagger.move(from_proc, to_proc.proc, x), from_proc.comm)
+end
+
+end # module

--- a/src/Dagger.jl
+++ b/src/Dagger.jl
@@ -36,6 +36,7 @@ include("chunks.jl")
 include("compute.jl")
 include("utils/clock.jl")
 include("utils/system_uuid.jl")
+include("utils/uhash.jl")
 include("sch/Sch.jl"); using .Sch
 
 # Array computations

--- a/src/sch/util.jl
+++ b/src/sch/util.jl
@@ -394,7 +394,7 @@ function estimate_task_costs(state, procs, task, inputs)
     transfer_costs = Dict(proc=>impute_sum([affinity(chunk)[2] for chunk in filter(c->get_parent(processor(c))!=get_parent(proc), chunks)]) for proc in procs)
 
     # Estimate total cost to move data and get task running after currently-scheduled tasks
-    costs = Dict(proc=>state.worker_time_pressure[get_parent(proc).pid][proc]+(tx_cost/tx_rate) for (proc, tx_cost) in transfer_costs)
+    costs = Dict(proc=>get(state.worker_time_pressure[get_parent(proc).pid], proc, UInt64(0))+(tx_cost/tx_rate) for (proc, tx_cost) in transfer_costs)
 
     # Shuffle procs around, so equally-costly procs are equally considered
     P = randperm(length(procs))

--- a/src/utils/uhash.jl
+++ b/src/utils/uhash.jl
@@ -1,0 +1,61 @@
+# unified hash algorithm
+
+using Dagger
+
+uhash(x, h::UInt)::UInt = hash(x, h)
+function uhash(x::Dagger.Thunk, h::UInt; sig=nothing)::UInt
+    value = hash(0xdead7453, h)
+    if x.hash != UInt(0)
+        return uhash(x.hash, value)
+    end
+    @assert sig !== nothing 
+    tt = Any[]
+    for input in x.inputs
+        input = unwrap_weak_checked(input)
+        if input isa Dagger.Thunk && input.hash != UInt(0)
+            value = uhash(input.hash, value)
+        else
+            value = uhash(input, value)
+            push!(tt, typeof(input))
+        end
+    end
+    sig = (typeof(x.f), tt)
+    value = uhash_sig(sig, value)
+    x.hash = value
+    return value
+end
+uhash(x::Dagger.WeakThunk, h::UInt)::UInt =
+    uhash(Dagger.unwrap_weak_checked(x), h)
+function uhash_sig((f, tt), h::UInt)::UInt
+    value = hash(0xdead5160, h)
+    ci_list = Base.code_typed(f, tt)
+    if length(ci_list) == 0
+        return hash(Union{}, hash(typeof(f), hash(tt, value)))
+    end
+    # tt must be concrete
+    ci = first(only(ci_list))::Core.CodeInfo
+    return uhash_code(ci, hash(typeof(f), hash(tt, value)))
+end
+function uhash_code(ci::Core.CodeInfo, h::UInt)::UInt
+    value = hash(0xdeadc0de, h)
+    for insn in ci.code
+        dump(insn)
+        value = uhash_insn(insn, h)
+    end
+    return value
+end
+function uhash_insn(insn::Expr, h::UInt)::UInt
+    value = hash(0xdeadeec54, h)
+    value = hash(insn.head, value)
+    for arg in insn.args
+        dump(insn)
+        @show uhash_insn(arg, value)
+        value = uhash_insn(arg, value)
+    end
+    return value
+end
+function uhash_insn(insn::GlobalRef, h::UInt)::UInt
+    value = hash(0xdead6147, h)
+    return hash(nameof(insn.mod), hash(insn.name, value))
+end
+uhash_insn(insn, h::UInt)::UInt = hash(insn, h)


### PR DESCRIPTION
Building on Dagger's unified hashing framework, DaggerMPI.jl allows DAGs to execute efficiently under an MPI cluster. Per-task hashes are used to "color" the DAG, disabling execution of each task on all but one MPI worker. Data movement is typically peer-to-peer using MPI Send and Recv, and is coordinated by using tags computed from the same coloring scheme. This scheme allows Dagger's scheduler to remain unmodified and unaware of the existence of an MPI cluster, while still providing "exactly once" execution semantics for each task in the DAG.