### PR TITLE
Optimize `tochunk` for simple arrays

### DIFF
--- a/src/sch/util.jl
+++ b/src/sch/util.jl
@@ -445,6 +445,9 @@ function walk_data_inner(f, x, seen, to_visit)
     return true
 end
 function walk_data_inner(f, x::Union{Array,Tuple}, seen, to_visit)
+    if x isa AbstractVecOrMat && !isstructtype(eltype(x)) && eltype(x) !== Any
+        return true
+    end
     for idx in firstindex(x):lastindex(x)
         if x isa Array
             isassigned(x, idx) || continue


### PR DESCRIPTION
I believe iterating over complete arrays to check them is not necessary
But I'm not sure if these are necessary conditions, so wip

helps in cases such as:
```julia
julia> a = rand(10000000);

##### pre PR

julia> @time Dagger.tochunk(a)
 26.077782 seconds (20.00 M allocations: 814.515 MiB, 5.63% gc time)
Dagger.Chunk{Vector{Float64}, MemPool.DRef, OSProc, AnyScope}(Vector{Float64}, ArrayDomain{1}((1:10000000,)), MemPool.DRef(1, 1, 0x0000000004c4b400), OSProc(1), AnyScope(), false)

##### After PR

julia> @time Dagger.tochunk(a)
  0.024828 seconds (54.02 k allocations: 2.784 MiB, 99.73% compilation time: 82% of which was recompilation)
Dagger.Chunk{Vector{Float64}, MemPool.DRef, OSProc, AnyScope}(Vector{Float64}, ArrayDomain{1}((1:10000000,)), MemPool.DRef(1, 3, 0x0000000004c4b400), OSProc(1), AnyScope(), false)
julia> @time Dagger.tochunk(a)
  0.000033 seconds (44 allocations: 2.484 KiB)
Dagger.Chunk{Vector{Float64}, MemPool.DRef, OSProc, AnyScope}(Vector{Float64}, ArrayDomain{1}((1:10000000,)), MemPool.DRef(1, 4, 0x0000000004c4b400), OSProc(1), AnyScope(), false)


```