### PR TITLE
Add missing check to walk_data

### DIFF
--- a/src/sch/util.jl
+++ b/src/sch/util.jl
@@ -413,6 +413,11 @@ Walks the data contained in `x` in DFS fashion, and executes `f` at each object
 that hasn't yet been seen.
 """
 function walk_data(f, @nospecialize(x))
+    action = f(x)
+    if action !== missing
+        return action
+    end
+
     seen = IdDict{Any,Nothing}()
     to_visit = Any[x]
 


### PR DESCRIPTION
Fixes a bug in the storage safety check, where the topmost object isn't directly checked, leading to hitting a (very) slow path.

@krynju 