### PR TITLE
signature: Don't capture input arguments

### DIFF
--- a/src/sch/util.jl
+++ b/src/sch/util.jl
@@ -252,7 +252,9 @@ end
 chunktype(x) = typeof(x)
 function signature(task::Thunk, state)
     sig = Any[chunktype(task.f)]
-    append!(sig, collect_task_inputs(state, task))
+    for input in collect_task_inputs(state, task)
+        push!(sig, chunktype(input))
+    end
     sig
 end
 


### PR DESCRIPTION
Fixes an issue where `Dagger.Sch.signature` captures input arguments, instead of their types.

Thanks to @krynju for putting together a DTables reproducer!