### PR TITLE
Implement work stealing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.16.3"
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 ContextVariablesX = "6add18c4-b38d-439d-96f6-d6bc489c04c5"
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/src/Dagger.jl
+++ b/src/Dagger.jl
@@ -36,6 +36,7 @@ include("chunks.jl")
 include("compute.jl")
 include("utils/clock.jl")
 include("utils/system_uuid.jl")
+include("utils/locked-object.jl")
 include("sch/Sch.jl"); using .Sch
 
 # Array computations

--- a/src/processor.jl
+++ b/src/processor.jl
@@ -1,5 +1,7 @@
 export OSProc, Context, addprocs!, rmprocs!
 
+import Base: @invokelatest
+
 """
     Processor
 
@@ -157,7 +159,7 @@ function execute!(proc::ThreadProc, @nospecialize(f), @nospecialize(args...))
     task = Task() do
         set_tls!(tls)
         TimespanLogging.prof_task_put!(tls.sch_handle.thunk_id.id)
-        f(args...)
+        @invokelatest f(args...)
     end
     task.sticky = true
     ret = ccall(:jl_set_task_tid, Cint, (Any, Cint), task, proc.tid-1)

--- a/src/processor.jl
+++ b/src/processor.jl
@@ -159,6 +159,7 @@ function execute!(proc::ThreadProc, @nospecialize(f), @nospecialize(args...))
         TimespanLogging.prof_task_put!(tls.sch_handle.thunk_id.id)
         f(args...)
     end
+    task.sticky = true
     ret = ccall(:jl_set_task_tid, Cint, (Any, Cint), task, proc.tid-1)
     if ret == 0
         error("jl_set_task_tid == 0")

--- a/src/processor.jl
+++ b/src/processor.jl
@@ -313,8 +313,7 @@ get_tls() = (
     sch_uid=task_local_storage(:_dagger_sch_uid),
     sch_handle=task_local_storage(:_dagger_sch_handle),
     processor=thunk_processor(),
-    time_utilization=task_local_storage(:_dagger_time_utilization),
-    alloc_utilization=task_local_storage(:_dagger_alloc_utilization),
+    task_spec=task_local_storage(:_dagger_task_spec),
 )
 
 """
@@ -326,6 +325,5 @@ function set_tls!(tls)
     task_local_storage(:_dagger_sch_uid, tls.sch_uid)
     task_local_storage(:_dagger_sch_handle, tls.sch_handle)
     task_local_storage(:_dagger_processor, tls.processor)
-    task_local_storage(:_dagger_time_utilization, tls.time_utilization)
-    task_local_storage(:_dagger_alloc_utilization, tls.alloc_utilization)
+    task_local_storage(:_dagger_task_spec, tls.task_spec)
 end

--- a/src/sch/Sch.jl
+++ b/src/sch/Sch.jl
@@ -97,8 +97,10 @@ struct ComputeState
     chan::RemoteChannel{Channel{Any}}
 end
 
+const UID_COUNTER = Threads.Atomic{UInt64}(1)
+
 function start_state(deps::Dict, node_order, chan)
-    state = ComputeState(rand(UInt64),
+    state = ComputeState(Threads.atomic_add!(UID_COUNTER, UInt64(1)),
                          OneToMany(),
                          deps,
                          Vector{Thunk}(undef, 0),

--- a/src/sch/Sch.jl
+++ b/src/sch/Sch.jl
@@ -9,8 +9,11 @@ import Random: randperm
 import Base: @invokelatest
 
 import ..Dagger
-import ..Dagger: Context, Processor, Thunk, WeakThunk, ThunkFuture, ThunkFailedException, Chunk, WeakChunk, OSProc, AnyScope, DefaultScope
+import ..Dagger: Context, Processor, Thunk, WeakThunk, ThunkFuture, ThunkFailedException, Chunk, WeakChunk, OSProc, AnyScope, DefaultScope, LockedObject
 import ..Dagger: order, dependents, noffspring, istask, inputs, unwrap_weak_checked, affinity, tochunk, timespan_start, timespan_finish, procs, move, chunktype, processor, default_enabled, get_processors, get_parent, execute!, rmprocs!, addprocs!, thunk_processor, constrain, cputhreadtime
+import DataStructures: PriorityQueue, enqueue!, dequeue_pair!, peek
+
+import ..Dagger
 
 const OneToMany = Dict{Thunk, Set{Thunk}}
 
@@ -185,16 +188,20 @@ that are instances/subtypes of a contained type. Alternatively, a function can
 be supplied, and the function will be called with a processor as the sole
 argument and should return a `Bool` result to indicate whether or not to use
 the given processor. `nothing` enables all default processors.
-- `time_util::Dict{Type,Any}=Dict{Type,Any}()`: Indicates the maximum expected
-time utilization for this thunk. Each keypair maps a processor type to the
-utilization, where the value can be a real (approximately the number of
-nanoseconds taken), or `MaxUtilization()` (utilizes all processors of this
-type). By default, the scheduler assumes that this thunk only uses one
-processor.
-- `alloc_util::Dict{Type,UInt64}=Dict{Type,UInt64}()`: Indicates the maximum
-expected memory utilization for this thunk. Each keypair maps a processor type
-to the utilization, where the value is an integer representing approximately
-the maximum number of bytes allocated at any one time.
+- `time_util::Dict{Type,Any}`: Indicates the maximum expected time utilization
+for this thunk. Each keypair maps a processor type to the utilization, where
+the value can be a real (approximately the number of nanoseconds taken), or
+`MaxUtilization()` (utilizes all processors of this type). By default, the
+scheduler assumes that this thunk only uses one processor.
+- `alloc_util::Dict{Type,UInt64}`: Indicates the maximum expected memory
+utilization for this thunk. Each keypair maps a processor type to the
+utilization, where the value is an integer representing approximately the
+maximum number of bytes allocated at any one time.
+- `occupancy::Dict{Type,Real}`: Indicates the maximum expected processor
+occupancy for this thunk. Each keypair maps a processor type to the
+utilization, where the value can be a real between 0 and 1 (the occupancy
+ratio, where 1 is full occupancy). By default, the scheduler assumes that this
+thunk has full occupancy.
 - `allow_errors::Bool=true`: Allow this thunk to error without affecting
 non-dependent thunks.
 - `checkpoint=nothing`: If not `nothing`, uses the provided function to save
@@ -217,14 +224,12 @@ Base.@kwdef struct ThunkOptions
     proclist = nothing
     time_util::Union{Dict{Type,Any},Nothing} = nothing
     alloc_util::Union{Dict{Type,UInt64},Nothing} = nothing
+    occupancy::Union{Dict{Type,Real},Nothing} = nothing
     allow_errors::Union{Bool,Nothing} = nothing
     checkpoint = nothing
     restore = nothing
     storage::Union{Chunk,Nothing} = nothing
 end
-
-# Eager scheduling
-include("eager.jl")
 
 """
     Base.merge(sopts::SchedulerOptions, topts::ThunkOptions) -> ThunkOptions
@@ -239,6 +244,7 @@ function Base.merge(sopts::SchedulerOptions, topts::ThunkOptions)
                  proclist,
                  topts.time_util,
                  topts.alloc_util,
+                 topts.occupancy,
                  allow_errors,
                  topts.checkpoint,
                  topts.restore,
@@ -271,6 +277,7 @@ function populate_defaults(opts::ThunkOptions, Tf, Targs)
         maybe_default(:proclist),
         maybe_default(:time_util),
         maybe_default(:alloc_util),
+        maybe_default(:occupancy),
         maybe_default(:allow_errors),
         maybe_default(:checkpoint),
         maybe_default(:restore),
@@ -280,6 +287,9 @@ end
 
 function cleanup(ctx)
 end
+
+# Eager scheduling
+include("eager.jl")
 
 const WORKER_MONITOR_LOCK = Threads.ReentrantLock()
 const WORKER_MONITOR_TASKS = Dict{Int,Task}()
@@ -605,7 +615,7 @@ function schedule!(ctx, state, procs=procs_to_use(ctx))
         populate_processor_cache_list!(state, procs)
 
         # Schedule tasks
-        to_fire = Dict{Tuple{OSProc,<:Processor},Vector{Tuple{Thunk,<:Any,<:Any}}}()
+        to_fire = Dict{Tuple{OSProc,<:Processor},Vector{Tuple{Thunk,<:Any,<:Any,UInt64,UInt32}}}()
         failed_scheduling = Thunk[]
 
         # Select a new task and get its options
@@ -697,11 +707,15 @@ function schedule!(ctx, state, procs=procs_to_use(ctx))
             gproc = get_parent(proc)
             can_use, scope = can_use_proc(task, gproc, proc, opts, scope)
             if can_use
-                has_cap, est_time_util, est_alloc_util = has_capacity(state, proc, gproc.pid, opts.time_util, opts.alloc_util, sig)
+                has_cap, est_time_util, est_alloc_util, est_occupancy =
+                    has_capacity(state, proc, gproc.pid, opts.time_util, opts.alloc_util, opts.occupancy, sig)
                 if has_cap
                     # Schedule task onto proc
                     # FIXME: est_time_util = est_time_util isa MaxUtilization ? cap : est_time_util
-                    push!(get!(()->Vector{Tuple{Thunk,<:Any,<:Any}}(), to_fire, (gproc, proc)), (task, est_time_util, est_alloc_util))
+                    proc_tasks = get!(to_fire, (gproc, proc)) do
+                        Vector{Tuple{Thunk,<:Any,<:Any,UInt64,UInt32}}()
+                    end
+                    push!(proc_tasks, (task, scope, est_time_util, est_alloc_util, est_occupancy))
                     state.worker_time_pressure[gproc.pid][proc] += est_time_util
                     @dagdebug task :schedule "Scheduling to $gproc -> $proc"
                     @goto pop_task
@@ -723,7 +737,8 @@ function schedule!(ctx, state, procs=procs_to_use(ctx))
         # N.B. if we only have one processor, we need to select it now
         can_use, scope = can_use_proc(task, entry.gproc, entry.proc, opts, scope)
         if can_use
-            has_cap, est_time_util, est_alloc_util = has_capacity(state, entry.proc, entry.gproc.pid, opts.time_util, opts.alloc_util, sig)
+            has_cap, est_time_util, est_alloc_util, est_occupancy =
+                has_capacity(state, entry.proc, entry.gproc.pid, opts.time_util, opts.alloc_util, opts.occupancy, sig)
             if has_cap
                 selected_entry = entry
             else
@@ -748,7 +763,8 @@ function schedule!(ctx, state, procs=procs_to_use(ctx))
 
             can_use, scope = can_use_proc(task, entry.gproc, entry.proc, opts, scope)
             if can_use
-                has_cap, est_time_util, est_alloc_util = has_capacity(state, entry.proc, entry.gproc.pid, opts.time_util, opts.alloc_util, sig)
+                has_cap, est_time_util, est_alloc_util, est_occupancy =
+                    has_capacity(state, entry.proc, entry.gproc.pid, opts.time_util, opts.alloc_util, opts.occupancy, sig)
                 if has_cap
                     # Select this processor
                     selected_entry = entry
@@ -767,7 +783,10 @@ function schedule!(ctx, state, procs=procs_to_use(ctx))
         # Schedule task onto proc
         gproc, proc = entry.gproc, entry.proc
         est_time_util = est_time_util isa MaxUtilization ? cap : est_time_util
-        push!(get!(()->Vector{Tuple{Thunk,<:Any,<:Any}}(), to_fire, (gproc, proc)), (task, est_time_util, est_alloc_util))
+        proc_tasks = get!(to_fire, (gproc, proc)) do
+            Vector{Tuple{Thunk,<:Any,<:Any,UInt64,UInt32}}()
+        end
+        push!(proc_tasks, (task, scope, est_time_util, est_alloc_util, est_occupancy))
 
         # Proceed to next entry to spread work
         state.procs_cache_list[] = state.procs_cache_list[].next
@@ -885,13 +904,13 @@ function evict_chunks!(log_sink, chunks::Set{Chunk})
     nothing
 end
 
-fire_task!(ctx, thunk::Thunk, p, state; time_util=10^9, alloc_util=10^6) =
-    fire_task!(ctx, (thunk, time_util, alloc_util), p, state)
-fire_task!(ctx, (thunk, time_util, alloc_util)::Tuple{Thunk,<:Any}, p, state) =
-    fire_tasks!(ctx, [(thunk, time_util, alloc_util)], p, state)
+fire_task!(ctx, thunk::Thunk, p, state; scope=AnyScope(), time_util=10^9, alloc_util=10^6, occupancy=typemax(UInt32)) =
+    fire_task!(ctx, (thunk, scope, time_util, alloc_util, occupancy), p, state)
+fire_task!(ctx, (thunk, scope, time_util, alloc_util, occupancy)::Tuple{Thunk,<:Any}, p, state) =
+    fire_tasks!(ctx, [(thunk, scope, time_util, alloc_util, occupancy)], p, state)
 function fire_tasks!(ctx, thunks::Vector{<:Tuple}, (gproc, proc), state)
     to_send = []
-    for (thunk, time_util, alloc_util) in thunks
+    for (thunk, scope, time_util, alloc_util, occupancy) in thunks
         push!(state.running, thunk)
         state.running_on[thunk] = gproc
         if thunk.cache && thunk.cache_ref !== nothing
@@ -939,8 +958,9 @@ function fire_tasks!(ctx, thunks::Vector{<:Tuple}, (gproc, proc), state)
         sch_handle = SchedulerHandle(ThunkID(thunk.id, nothing), state.worker_chans[gproc.pid]...)
 
         # TODO: De-dup common fields (log_sink, uid, etc.)
-        push!(to_send, Any[thunk.id, time_util, alloc_util, chunktype(thunk.f), data, thunk.get_result,
-                           thunk.persist, thunk.cache, thunk.meta, options,
+        push!(to_send, Any[thunk.id, time_util, alloc_util, occupancy,
+                           scope, chunktype(thunk.f), data,
+                           thunk.get_result, thunk.persist, thunk.cache, thunk.meta, options,
                            propagated, ids,
                            (log_sink=ctx.log_sink, profile=ctx.profile),
                            sch_handle, state.uid])
@@ -966,38 +986,319 @@ function fire_tasks!(ctx, thunks::Vector{<:Tuple}, (gproc, proc), state)
     end
 end
 
-"""
-    do_tasks(to_proc, chan, tasks)
-
-Executes a batch of tasks on `to_proc`.
-"""
-function do_tasks(to_proc, chan, tasks)
-    for task in tasks
-        thunk_id = task[1]
-        should_launch = lock(TASK_SYNC) do
-            # Already running; don't try to re-launch
-            if !(thunk_id in TASKS_RUNNING)
-                push!(TASKS_RUNNING, thunk_id)
-                true
-            else
-                false
-            end
+@static if VERSION >= v"1.9"
+const Doorbell = Base.Event
+else
+# We need a sticky, resetable signal
+mutable struct Doorbell
+    waiter::Union{Task,Nothing}
+    @atomic sleeping::Int
+    Doorbell() = new(nothing, 0)
+end
+function Base.wait(db::Doorbell)
+    db.waiter = current_task()
+    while true
+        _, succ = @atomicreplace db.sleeping 0 => 1
+        if succ
+            # No messages, wait for someone to wake us
+            wait()
         end
-        should_launch || continue
-        @async begin
-            try
-                result = do_task(to_proc, task)
-                put!(chan, (myid(), to_proc, thunk_id, result))
-            catch ex
-                bt = catch_backtrace()
-                put!(chan, (myid(), to_proc, thunk_id, (CapturedException(ex, bt), nothing)))
+        _, succ = @atomicreplace db.sleeping 2 => 0
+        if succ
+            # We had a notification
+            return
+        end
+    end
+end
+function Base.notify(db::Doorbell)
+    while true
+        if (@atomic db.sleeping) == 2
+            # Doorbell already rung
+            return
+        end
+
+        _, succ = @atomicreplace db.sleeping 0 => 2
+        if succ
+            # Task was definitely busy, we're done
+            return
+        end
+
+        _, succ = @atomicreplace db.sleeping 1 => 2
+        if succ
+            # Task was sleeping, wake it and wait for it to awaken
+            waiter = db.waiter
+            @assert waiter !== nothing
+            waiter::Task
+            schedule(waiter)
+            while true
+                sleep_value = @atomic db.sleeping
+                if sleep_value == 0 || sleep_value == 2
+                    return
+                end
+                #if waiter._state === Base.task_state_runnable && t.queue === nothing
+                #    schedule(waiter)
+                #else
+                    yield()
+                #end
             end
         end
     end
 end
-"Executes a single task on `to_proc`."
-function do_task(to_proc, comm)
-    thunk_id, est_time_util, est_alloc_util, Tf, data, send_result, persist, cache, meta, options, propagated, ids, ctx_vars, sch_handle, uid = comm
+end
+
+struct ProcessorInternalState
+    ctx::Context
+    proc::Processor
+    queue::LockedObject{PriorityQueue{Vector{Any}, UInt32, Base.Order.ForwardOrdering}}
+    reschedule::Doorbell
+    tasks::Dict{Int,Task}
+    proc_occupancy::Base.RefValue{UInt32}
+    time_pressure::Base.RefValue{UInt64}
+end
+struct ProcessorState
+    state::ProcessorInternalState
+    runner::Task
+end
+
+const PROCESSOR_TASK_STATE = LockedObject(Dict{UInt64,Dict{Processor,ProcessorState}}())
+
+function proc_states(f::Base.Callable, uid::UInt64)
+    lock(PROCESSOR_TASK_STATE) do all_states
+        if !haskey(all_states, uid)
+            all_states[uid] = Dict{Processor,ProcessorState}()
+        end
+        our_states = all_states[uid]
+        return f(our_states)
+    end
+end
+proc_states(f::Base.Callable) =
+    proc_states(f, task_local_storage(:_dagger_sch_uid)::UInt64)
+
+task_tid_for_processor(::Processor) = nothing
+task_tid_for_processor(proc::Dagger.ThreadProc) = proc.tid
+
+stealing_permitted(::Processor) = true
+stealing_permitted(proc::Dagger.ThreadProc) = proc.owner != 1 || proc.tid != 1
+
+proc_has_occupancy(proc_occupancy, task_occupancy) =
+    UInt64(task_occupancy) + UInt64(proc_occupancy) <= typemax(UInt32)
+
+function start_processor_runner!(istate::ProcessorInternalState, uid::UInt64, return_queue::RemoteChannel)
+    to_proc = istate.proc
+    proc_run_task = @task begin
+        ctx = istate.ctx
+        tasks = istate.tasks
+        proc_occupancy = istate.proc_occupancy
+        time_pressure = istate.time_pressure
+
+        while isopen(return_queue)
+            # Wait for new tasks
+            timespan_start(ctx, :proc_run_wait, to_proc, nothing)
+            wait(istate.reschedule)
+            @static if VERSION >= v"1.9"
+                reset(istate.reschedule)
+            end
+            timespan_finish(ctx, :proc_run_wait, to_proc, nothing)
+
+            # Fetch a new task to execute
+            timespan_start(ctx, :proc_run_fetch, to_proc, nothing)
+            task_and_occupancy = lock(istate.queue) do queue
+                # Only steal if there are multiple queued tasks, to prevent
+                # ping-pong of tasks between empty queues
+                if length(queue) == 0
+                    return nothing
+                end
+                _, occupancy = peek(queue)
+                if proc_has_occupancy(proc_occupancy[], occupancy)
+                    return dequeue_pair!(queue)
+                end
+                return nothing
+            end
+            if task_and_occupancy === nothing
+                timespan_finish(ctx, :proc_run_fetch, to_proc, nothing)
+
+                if !stealing_permitted(to_proc)
+                    continue
+                end
+
+                if proc_occupancy[] == typemax(UInt32)
+                    continue
+                end
+
+                # Try to steal a task
+                timespan_start(ctx, :steal_local, to_proc, nothing)
+
+                # Try to steal from local queues randomly
+                # TODO: Prioritize stealing from busiest processors
+                states = collect(proc_states(values, uid))
+                # TODO: Try to pre-allocate this
+                P = randperm(length(states))
+                for state in getindex.(Ref(states), P)
+                    other_istate = state.state
+                    if other_istate.proc === to_proc
+                        continue
+                    end
+                    # FIXME: We need to lock two queues to compare occupancies
+                    proc_occupancy_cached = lock(istate.queue) do _
+                        proc_occupancy[]
+                    end
+                    task_and_occupancy = lock(other_istate.queue) do queue
+                        if length(queue) == 0
+                            return nothing
+                        end
+                        task, occupancy = peek(queue)
+                        scope = task[5]
+                        if !isa(constrain(scope, Dagger.ExactScope(to_proc)),
+                                Dagger.InvalidScope) &&
+                           typemax(UInt32) - proc_occupancy_cached >= occupancy
+                            # Compatible, steal this task
+                            return dequeue_pair!(queue)
+                        end
+                        return nothing
+                    end
+                    if task_and_occupancy !== nothing
+                        from_proc = other_istate.proc
+                        thunk_id = task[1]
+                        @dagdebug thunk_id :execute "Stolen from $from_proc by $to_proc"
+                        timespan_finish(ctx, :steal_local, to_proc, (;from_proc, thunk_id))
+                        # TODO: Keep stealing until we hit full occupancy?
+                        @goto execute
+                    end
+                end
+                timespan_finish(ctx, :steal_local, to_proc, nothing)
+
+                # TODO: Try to steal from remote queues
+
+                continue
+            end
+
+            @label execute
+            task, task_occupancy = task_and_occupancy
+            thunk_id = task[1]
+            time_util = task[2]
+            timespan_finish(ctx, :proc_run_fetch, to_proc, (;thunk_id, proc_occupancy=proc_occupancy[], task_occupancy))
+
+            # Execute the task and return its result
+            t = @task begin
+                result = try
+                    do_task(to_proc, task)
+                catch err
+                    bt = catch_backtrace()
+                    (CapturedException(err, bt), nothing)
+                finally
+                    lock(istate.queue) do _
+                        delete!(tasks, thunk_id)
+                        proc_occupancy[] -= task_occupancy
+                        time_pressure[] -= time_util
+                    end
+                    notify(istate.reschedule)
+                end
+                try
+                    put!(return_queue, (myid(), to_proc, thunk_id, result))
+                catch err
+                    if unwrap_nested_exception(err) isa InvalidStateException || !isopen(return_queue)
+                        @dagdebug thunk_id :execute "Return queue is closed, failing to put result" chan=return_queue exception=(err, catch_backtrace())
+                    else
+                        rethrow(err)
+                    end
+                end
+            end
+            lock(istate.queue) do _
+                tid = task_tid_for_processor(to_proc)
+                if tid !== nothing
+                    t.sticky = true
+                    ret = ccall(:jl_set_task_tid, Cint, (Any, Cint), t, tid-1)
+                else
+                    t.sticky = false
+                end
+                tasks[thunk_id] = errormonitor(schedule(t))
+                proc_occupancy[] += task_occupancy
+                time_pressure[] += time_util
+            end
+        end
+    end
+    tid = task_tid_for_processor(to_proc)
+    if tid !== nothing
+        proc_run_task.sticky = true
+        ret = ccall(:jl_set_task_tid, Cint, (Any, Cint), proc_run_task, tid-1)
+    else
+        proc_run_task.sticky = false
+    end
+    return errormonitor(schedule(proc_run_task))
+end
+
+"""
+    do_tasks(to_proc, return_queue, tasks)
+
+Executes a batch of tasks on `to_proc`, returning their results through
+`return_queue`.
+"""
+function do_tasks(to_proc, return_queue, tasks)
+    # FIXME: This is terrible
+    ctx_vars = first(tasks)[15]
+    ctx = Context(Processor[]; log_sink=ctx_vars.log_sink, profile=ctx_vars.profile)
+    uid = first(tasks)[17]
+    state = proc_states(uid) do states
+        get!(states, to_proc) do
+            queue = PriorityQueue{Vector{Any}, UInt32}()
+            queue_locked = LockedObject(queue)
+            reschedule = Doorbell()
+            istate = ProcessorInternalState(ctx, to_proc,
+                                            queue_locked, reschedule,
+                                            Dict{Int,Task}(),
+                                            Ref(UInt32(0)), Ref(UInt64(0)))
+            runner = start_processor_runner!(istate, uid, return_queue)
+            @static if VERSION < v"1.9"
+                reschedule.waiter = runner
+            end
+            return ProcessorState(istate, runner)
+        end
+    end
+    istate = state.state
+    lock(istate.queue) do queue
+        for task in tasks
+            thunk_id = task[1]
+            occupancy = task[4]
+            timespan_start(ctx, :enqueue, (;to_proc, thunk_id), nothing)
+            should_launch = lock(TASK_SYNC) do
+                # Already running; don't try to re-launch
+                if !(thunk_id in TASKS_RUNNING)
+                    push!(TASKS_RUNNING, thunk_id)
+                    true
+                else
+                    false
+                end
+            end
+            should_launch || continue
+            enqueue!(queue, task, occupancy)
+            timespan_finish(ctx, :enqueue, (;to_proc, thunk_id), nothing)
+        end
+    end
+    notify(istate.reschedule)
+
+    # Kick other processors to make them steal
+    # TODO: Alternatively, automatically balance work instead of blindly enqueueing
+    states = collect(proc_states(values, uid))
+    P = randperm(length(states))
+    for other_state in getindex.(Ref(states), P)
+        other_istate = other_state.state
+        if other_istate.proc === to_proc
+            continue
+        end
+        notify(other_istate.reschedule)
+    end
+end
+
+"""
+    do_task(to_proc, task_desc) -> Any
+
+Executes a single task specified by `task_desc` on `to_proc`.
+"""
+function do_task(to_proc, task_desc)
+    thunk_id, est_time_util, est_alloc_util, est_occupancy,
+        scope, Tf, data,
+        send_result, persist, cache, meta,
+        options, propagated, ids, ctx_vars, sch_handle, uid = task_desc
     ctx = Context(Processor[]; log_sink=ctx_vars.log_sink, profile=ctx_vars.profile)
 
     from_proc = OSProc()
@@ -1031,7 +1332,6 @@ function do_task(to_proc, comm)
             "[$(myid()), $thunk_id] $f($Tdata) $msg: $est_alloc_util | $real_alloc_util/$storage_cap"
         end
     end
-
     lock(TASK_SYNC) do
         while true
             # Get current time utilization for the selected processor
@@ -1163,8 +1463,7 @@ function do_task(to_proc, comm)
             sch_uid=uid,
             sch_handle=sch_handle,
             processor=to_proc,
-            time_utilization=est_time_util,
-            alloc_utilization=est_alloc_util,
+            task_spec=task_desc,
         ))
 
         res = Dagger.with_options(propagated) do
@@ -1215,7 +1514,7 @@ function do_task(to_proc, comm)
         gc_allocd=(isa(result_meta, Chunk) ? result_meta.handle.size : 0),
         transfer_rate=(transfer_size[] > 0 && transfer_time[] > 0) ? round(UInt64, transfer_size[] / (transfer_time[] / 10^9)) : nothing,
     )
-    (result_meta, metadata)
+    return (result_meta, metadata)
 end
 
 end # module Sch

--- a/src/sch/dynamic.jl
+++ b/src/sch/dynamic.jl
@@ -207,9 +207,11 @@ function _add_thunk!(ctx, state, task, tid, (f, args, kwargs, future, ref))
         thunk_id = ThunkID(thunk.id, thunk_ref)
         state.thunk_dict[thunk.id] = WeakThunk(thunk)
         reschedule_inputs!(state, thunk)
+        @dagdebug thunk :submit "Added to scheduler"
         if future !== nothing
             # Ensure we attach a future before the thunk is scheduled
             _register_future!(ctx, state, task, tid, (future, thunk_id, false))
+            @dagdebug thunk :submit "Registered future"
         end
         if ref !== nothing
             # Preserve the `EagerThunkFinalizer` through `thunk`

--- a/src/sch/eager.jl
+++ b/src/sch/eager.jl
@@ -19,11 +19,13 @@ function init_eager()
     @async try
         sopts = SchedulerOptions(;allow_errors=true)
         scope = Dagger.ExactScope(Dagger.ThreadProc(1, 1))
+        topts = ThunkOptions(;occupancy=Dict(Dagger.ThreadProc=>0))
         atexit() do
             EAGER_FORCE_KILL[] = true
             close(EAGER_THUNK_CHAN)
         end
-        Dagger.compute(ctx, Dagger.delayed(eager_thunk; scope)(); options=sopts)
+        Dagger.compute(ctx, Dagger.delayed(eager_thunk; scope, options=topts)();
+                       options=sopts)
     catch err
         iob = IOContext(IOBuffer(), :color=>true)
         println(iob, "Error in eager scheduler:")
@@ -37,41 +39,47 @@ function init_eager()
     end
 end
 
-"Adjusts the scheduler's cached pressure indicators for the specified worker by
-the specified amount, and signals the scheduler to try scheduling again if
-pressure decreased."
-function adjust_pressure!(h::SchedulerHandle, proc::Processor, pressure)
-    uid = Dagger.get_tls().sch_uid
-    lock(TASK_SYNC) do
-        PROCESSOR_TIME_UTILIZATION[uid][proc][] += pressure
-        notify(TASK_SYNC)
-    end
-    exec!(_adjust_pressure!, h, myid(), proc, pressure)
-end
-function _adjust_pressure!(ctx, state, task, tid, (pid, proc, pressure))
-    state.worker_time_pressure[pid][proc] += pressure
-    if pressure < 0
-        put!(state.chan, RescheduleSignal())
-    end
-    nothing
-end
-
-"Allows a thunk to safely wait on another thunk, by temporarily reducing its
-effective pressure to 0."
+"""
+Allows a thunk to safely wait on another thunk by temporarily reducing its
+effective occupancy to 0, which allows a newly-spawned task to run.
+"""
 function thunk_yield(f)
     if Dagger.in_thunk()
         h = sch_handle()
         tls = Dagger.get_tls()
-        proc = tls.processor
-        util = tls.time_utilization
-        adjust_pressure!(h, proc, -util)
+        proc = Dagger.thunk_processor()
+        proc_istate = proc_states(tls.sch_uid) do states
+            states[proc].state
+        end
+        task_occupancy = tls.task_spec[4]
+
+        # Decrease our occupancy and inform the processor to reschedule
+        lock(proc_istate.queue) do _
+            proc_istate.proc_occupancy[] -= task_occupancy
+            @assert 0 <= proc_istate.proc_occupancy[] <= typemax(UInt32)
+        end
+        notify(proc_istate.reschedule)
         try
-            f()
+            # Run the yielding code
+            return f()
         finally
-            adjust_pressure!(h, proc, util)
+            # Wait for processor to have occupancy to run this task
+            while true
+                ready = lock(proc_istate.queue) do _
+                    @assert 0 <= proc_istate.proc_occupancy[] <= typemax(UInt32)
+                    if proc_has_occupancy(proc_istate.proc_occupancy[], task_occupancy)
+                        proc_istate.proc_occupancy[] += task_occupancy
+                        @assert 0 <= proc_istate.proc_occupancy[] <= typemax(UInt32)
+                        return true
+                    end
+                    return false
+                end
+                ready && break
+                yield()
+            end
         end
     else
-        f()
+        return f()
     end
 end
 
@@ -83,8 +91,6 @@ function eager_thunk()
         nothing
     end
     tls = Dagger.get_tls()
-    # Don't apply pressure from this thunk
-    adjust_pressure!(h, tls.processor, -tls.time_utilization)
     while isopen(EAGER_THUNK_CHAN)
         try
             added_future, future, uid, ref, f, args, opts = take!(EAGER_THUNK_CHAN)

--- a/src/utils/locked-object.jl
+++ b/src/utils/locked-object.jl
@@ -1,0 +1,16 @@
+# Copied from CUDA.jl
+
+struct LockedObject{T}
+    lock::ReentrantLock
+    payload::T
+end
+LockedObject(payload) = LockedObject(Threads.ReentrantLock(), payload)
+
+function Base.lock(f, x::LockedObject)
+    lock(x.lock)
+    try
+        return f(x.payload)
+    finally
+        unlock(x.lock)
+    end
+end

--- a/test/options.jl
+++ b/test/options.jl
@@ -70,7 +70,7 @@ end
         @test fetch(Dagger.@spawn sf(obj)) == 0
         @test fetch(Dagger.@spawn sf(obj)) == 0
     end
-    Dagger.with_options(;scope=Dagger.ExactScope(Dagger.ThreadProc(1,1)), processor=Dagger.ThreadProc(1,1), meta=true) do
+    Dagger.with_options(;scope=Dagger.ExactScope(Dagger.ThreadProc(1,1)), processor=OSProc(1), meta=true) do
         @test fetch(Dagger.@spawn sf(obj)) == 43
         @test fetch(Dagger.@spawn sf(obj)) == 43
     end


### PR DESCRIPTION
Adds logic to do work stealing within and across workers, which can help prevent workload imbalance and processor starvation.

Todo:
- [x] Consider a non-racy implementation of `Sch.Doorbell` (`Base.Event`)
- [x] ~Add tests~ Existing tests should be sufficient
- [x] Add docs