### PR TITLE
Updating Task cost estimation

### DIFF
--- a/src/sch/util.jl
+++ b/src/sch/util.jl
@@ -399,8 +399,16 @@ function estimate_task_costs(state, procs, task, inputs)
     transfer_costs = Dict(proc=>impute_sum([affinity(chunk)[2] for chunk in filter(c->get_parent(processor(c))!=get_parent(proc), chunks)]) for proc in procs)
 
     # Estimate total cost to move data and get task running after currently-scheduled tasks
-    costs = Dict(proc=>state.worker_time_pressure[get_parent(proc).pid][proc]+(tx_cost/tx_rate) for (proc, tx_cost) in transfer_costs)
-
+    costs = Dict(proc-> begin
+                        if proc == state.scheduler
+                            # For non-Chunk, model cost from scheduler to worker
+                            data_size = sum(affinity(input)[2] for input in filter(x -> !(x isa Chunk), inputs))
+                            scheduler_to_worker_cost = (data_size / tx_rate) + state.scheduler_time_pressure
+                            state.worker_time_pressure[get_parent(proc).pid][proc] + scheduler_to_worker_cost
+                        else
+                            state.worker_time_pressure[get_parent(proc).pid][proc] + (transfer_costs[proc] / tx_rate)
+                        end
+                    end, procs)
     # Shuffle procs around, so equally-costly procs are equally considered
     P = randperm(length(procs))
     procs = getindex.(Ref(procs), P)


### PR DESCRIPTION
Changed the costs dictionary to calculate the cost for each worker to include the cost of moving non-Chunk inputs from the scheduler to the worker. We sum the data size of all non-Chunk inputs and calculate the cost of moving that data from the scheduler to the worker using the transfer rate and then add that cost to the state.scheduler_time_pressure to get the total cost for the scheduler. 