### PR TITLE
Update broken links in docs

### DIFF
--- a/docs/src/api/functions.md
+++ b/docs/src/api/functions.md
@@ -20,22 +20,6 @@ order
 treereduce
 ```
 
-## Table Functions
-```@docs
-tabletype
-tabletype!
-trim
-trim!
-map
-filter
-reduce
-groupby
-leftjoin
-innerjoin
-keys
-getindex
-```
-
 ## Array Functions
 ```@docs
 alignfirst
@@ -56,8 +40,10 @@ set_tls!
 ```
 
 ## Shard Functions
-[`Dagger.@shard`](@ref)
-[`Dagger.shard`](@ref)
+```@docs
+@shard
+shard
+```
 
 ## Context Functions
 ```@docs

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -258,7 +258,7 @@ effectively when either the cached per-processor information is outdated, or
 when the estimates about the task's behavior are inaccurate. To minimize the
 impact of this potential workload imbalance, the worker schedulers' processors
 will attempt to steal tasks from each other when they are under-occupied. Tasks
-will only be stolen if their [scope](`Scopes`) matches the processor attempting
+will only be stolen if their [scope](scopes.md) matches the processor attempting
 the steal, so tasks with wider scopes have better balancing potential.
 
 ### Scheduler/Thunk Options

--- a/docs/src/scopes.md
+++ b/docs/src/scopes.md
@@ -60,8 +60,6 @@ Setting a scope on the function treats it as a regular piece of data (like the
 arguments to the function), so it participates in the scoping rules described
 in the following sections all the same.
 
-[`Dagger.scope`](@ref)
-
 Now, let's try out some other kinds of scopes, starting with `NodeScope`. This
 scope encompasses the server that one or more Julia processes may be running
 on. Say we want to use memory mapping (mmap) to more efficiently send arrays


### PR DESCRIPTION
There are some broken links in the Dagger documentations. This PR fixes them.