### PR TITLE
Add keyword argument support

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,12 +35,22 @@ steps:
           julia_args: "--threads=1"
       - JuliaCI/julia-coverage#v1:
           codecov: true
+  - label: Julia 1.9
+    timeout_in_minutes: 60
+    <<: *test
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.9"
+      - JuliaCI/julia-test#v1:
+          julia_args: "--threads=1"
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
   - label: Julia nightly
     timeout_in_minutes: 60
     <<: *test
     plugins:
       - JuliaCI/julia#v1:
-          version: "1.9-nightly"
+          version: "1.10-nightly"
       - JuliaCI/julia-test#v1:
           julia_args: "--threads=1"
       - JuliaCI/julia-coverage#v1:

--- a/docs/src/checkpointing.md
+++ b/docs/src/checkpointing.md
@@ -54,9 +54,9 @@ Let's see how we'd modify the above example to use checkpointing:
 
 ```julia
 using Serialization
+
 X = compute(randn(Blocks(128,128), 1024, 1024))
-Y = [delayed(sum; options=Dagger.Sch.ThunkOptions(;
-checkpoint=(thunk,result)->begin
+Y = [delayed(sum; checkpoint=(thunk,result)->begin
     open("checkpoint-$idx.bin", "w") do io
         serialize(io, collect(result))
     end
@@ -64,7 +64,7 @@ end, restore=(thunk)->begin
     open("checkpoint-$idx.bin", "r") do io
         Dagger.tochunk(deserialize(io))
     end
-end))(chunk) for (idx,chunk) in enumerate(X.chunks)]
+end)(chunk) for (idx,chunk) in enumerate(X.chunks)]
 inner(x...) = sqrt(sum(x))
 Z = delayed(inner)(Y...)
 z = collect(Z)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,32 +2,34 @@
 
 ## Usage
 
-The main function for using Dagger is `spawn`:
+The main entrypoint to Dagger is `@spawn`:
 
-`Dagger.spawn(f, args...; options...)`
+`Dagger.@spawn [option=value]... f(args...; kwargs...)`
 
-or `@spawn` for the more convenient macro form:
+or `spawn` if it's more convenient:
 
-`Dagger.@spawn [option=value]... f(args...)`
+`Dagger.spawn(f, Dagger.Options(options), args...; kwargs...)`
 
 When called, it creates an `EagerThunk` (also known as a "thunk" or "task")
-object representing a call to function `f` with the arguments `args`. If it is
-called with other thunks as inputs, such as in `Dagger.@spawn f(Dagger.@spawn
-g())`, then the function `f` gets passed the results of those input thunks. If
-those thunks aren't yet finished executing, then the execution of `f` waits on
-all of its input thunks to complete before executing.
+object representing a call to function `f` with the arguments `args` and
+keyword arguments `kwargs`. If it is called with other thunks as args/kwargs,
+such as in `Dagger.@spawn f(Dagger.@spawn g())`, then the function `f` gets
+passed the results of those input thunks, once they're available. If those
+thunks aren't yet finished executing, then the execution of `f` waits on all of
+its input thunks to complete before executing.
 
 The key point is that, for each argument to a thunk, if the argument is an
 `EagerThunk`, it'll be executed before this node and its result will be passed
 into the function `f`. If the argument is *not* an `EagerThunk` (instead, some
 other type of Julia object), it'll be passed as-is to the function `f`.
 
-Thunks don't accept regular keyword arguments for the function `f`. Instead,
-the `options` kwargs are passed to the scheduler to control its behavior:
+The `Options` struct in the second argument position is optional; if provided,
+it is passed to the scheduler to control its behavior. `Options` contains a
+`NamedTuple` of option key-value pairs, which can be any of:
 - Any field in `Dagger.Sch.ThunkOptions` (see [Scheduler and Thunk options](@ref))
 - `meta::Bool` -- Pass the input `Chunk` objects themselves to `f` and not the value contained in them
 
-There are also some extra kwargs that can be passed, although they're considered advanced options to be used only by developers or library authors:
+There are also some extra optionss that can be passed, although they're considered advanced options to be used only by developers or library authors:
 - `get_result::Bool` -- return the actual result to the scheduler instead of `Chunk` objects. Used when `f` explicitly constructs a Chunk or when return value is small (e.g. in case of reduce)
 - `persist::Bool` -- the result of this Thunk should not be released after it becomes unused in the DAG
 - `cache::Bool` -- cache the result of this Thunk such that if the thunk is evaluated again, one can just reuse the cached value. If it’s been removed from cache, recompute the value.
@@ -133,10 +135,10 @@ via `@par` or `delayed`. The above computation can be executed with the lazy
 API by substituting `@spawn` with `@par` and `fetch` with `collect`:
 
 ```julia
-p = @par add1(4)
-q = @par add2(p)
-r = @par add1(3)
-s = @par combine(p, q, r)
+p = Dagger.@par add1(4)
+q = Dagger.@par add2(p)
+r = Dagger.@par add1(3)
+s = Dagger.@par combine(p, q, r)
 
 @assert collect(s) == 16
 ```
@@ -144,7 +146,7 @@ s = @par combine(p, q, r)
 or similarly, in block form:
 
 ```julia
-s = @par begin
+s = Dagger.@par begin
     p = add1(4)
     q = add2(p)
     r = add1(3)
@@ -159,7 +161,7 @@ operation, you can call `compute` on the thunk. This will return a `Chunk`
 object which references the result (see [Chunks](@ref) for more details):
 
 ```julia
-x = @par 1+2
+x = Dagger.@par 1+2
 cx = compute(x)
 cx::Chunk
 @assert collect(cx) == 3
@@ -207,7 +209,7 @@ Scheduler options can be constructed and passed to `collect()` or `compute()`
 as the keyword argument `options` for lazy API usage:
 
 ```julia
-t = @par 1+2
+t = Dagger.@par 1+2
 opts = Dagger.Sch.SchedulerOptions(;single=1) # Execute on worker 1
 
 compute(t; options=opts)
@@ -221,10 +223,9 @@ Thunk options can be passed to `@spawn/spawn`, `@par`, and `delayed` similarly:
 # Execute on worker 1
 
 Dagger.@spawn single=1 1+2
-Dagger.spawn(+, 1, 2; single=1)
+Dagger.spawn(+, Dagger.Options(;single=1), 1, 2)
 
-opts = Dagger.Sch.ThunkOptions(;single=1)
-delayed(+)(1, 2; options=opts)
+delayed(+; single=1)(1, 2)
 ```
 
 ### Core vs. Worker Schedulers

--- a/docs/src/propagation.md
+++ b/docs/src/propagation.md
@@ -1,6 +1,6 @@
 # Option Propagation
 
-Most options passed to Dagger are passed via `delayed` or `Dagger.@spawn`
+Most options passed to Dagger are passed via `@spawn/spawn` or `delayed`
 directly. This works well when an option only needs to be set for a single
 thunk, but is cumbersome when the same option needs to be set on multiple
 thunks, or set recursively on thunks spawned within other thunks. Thankfully,

--- a/src/array/darray.jl
+++ b/src/array/darray.jl
@@ -251,7 +251,7 @@ function thunkize(ctx::Context, c::DArray; persist=true)
         if persist
             foreach(persist!, thunks)
         end
-        Thunk(thunks...; meta=true) do results...
+        Thunk(map(thunk->nothing=>thunk, thunks)...; meta=true) do results...
             t = eltype(results[1])
             DArray(t, dmn, dmnchunks,
                                   reshape(Union{Chunk,Thunk}[results...], sz))

--- a/src/array/matrix.jl
+++ b/src/array/matrix.jl
@@ -17,10 +17,10 @@ function size(x::Transpose)
 end
 
 transpose(x::ArrayOp) = Transpose(transpose, x)
-transpose(x::Union{Chunk, Thunk}) = Thunk(transpose, x)
+transpose(x::Union{Chunk, Thunk}) = Thunk(transpose, nothing=>x)
 
 adjoint(x::ArrayOp) = Transpose(adjoint, x)
-adjoint(x::Union{Chunk, Thunk}) = Thunk(adjoint, x)
+adjoint(x::Union{Chunk, Thunk}) = Thunk(adjoint, nothing=>x)
 
 function adjoint(x::ArrayDomain{2})
     d = indexes(x)
@@ -91,8 +91,8 @@ function (+)(a::ArrayDomain, b::ArrayDomain)
     a
 end
 
-(*)(a::Union{Chunk, Thunk}, b::Union{Chunk, Thunk}) = Thunk(*, a,b)
-(+)(a::Union{Chunk, Thunk}, b::Union{Chunk, Thunk}) = Thunk(+, a,b)
+(*)(a::Union{Chunk, Thunk}, b::Union{Chunk, Thunk}) = Thunk(*, nothing=>a, nothing=>b)
+(+)(a::Union{Chunk, Thunk}, b::Union{Chunk, Thunk}) = Thunk(+, nothing=>a, nothing=>b)
 
 # we define our own matmat and matvec multiply
 # for computing the new domains and thunks.
@@ -211,7 +211,7 @@ end
 function _scale(l, r)
     res = similar(r, Any)
     for i=1:length(l)
-        res[i,:] = map(x->Thunk((a,b) -> Diagonal(a)*b, l[i], x), r[i,:])
+        res[i,:] = map(x->Thunk((a,b) -> Diagonal(a)*b, nothing=>l[i], nothing=>x), r[i,:])
     end
     res
 end

--- a/src/array/operators.jl
+++ b/src/array/operators.jl
@@ -107,7 +107,7 @@ Base.@deprecate mappart(args...) mapchunk(args...)
 function stage(ctx::Context, node::MapChunk)
     inputs = map(x->cached_stage(ctx, x), node.input)
     thunks = map(map(chunks, inputs)...) do ps...
-        Thunk(node.f, ps...)
+        Thunk(node.f, map(p->nothing=>p, ps)...)
     end
 
     DArray(Any, domain(inputs[1]), domainchunks(inputs[1]), thunks)

--- a/src/array/setindex.jl
+++ b/src/array/setindex.jl
@@ -35,7 +35,7 @@ function stage(ctx::Context, sidx::SetIndex)
         local_dmn = ArrayDomain(map(x->x[2], idx_and_dmn))
         s = subdmns[idx...]
         part_to_set = sidx.val
-        ps[idx...] = Thunk(ps[idx...]) do p
+        ps[idx...] = Thunk(nothing=>ps[idx...]) do p
             q = copy(p)
             q[indexes(project(s, local_dmn))...] .= part_to_set
             q

--- a/src/compute.jl
+++ b/src/compute.jl
@@ -97,7 +97,7 @@ function dependents(node::Thunk)
         if !haskey(deps, next)
             deps[next] = Set{Thunk}()
         end
-        for inp in inputs(next)
+        for (_, inp) in next.inputs
             if istask(inp) || (inp isa Chunk)
                 s = get!(()->Set{Thunk}(), deps, inp)
                 push!(s, next)
@@ -165,7 +165,7 @@ function order(node::Thunk, ndeps)
         haskey(output, next) && continue
         s += 1
         output[next] = s
-        parents = filter(istask, inputs(next))
+        parents = filter(istask, map(last, next.inputs))
         if !isempty(parents)
             # If parents is empty, sort! should be a no-op, but raises an ambiguity error
             # when InlineStrings.jl is loaded (at least, version 1.1.0), because InlineStrings

--- a/src/processor.jl
+++ b/src/processor.jl
@@ -31,11 +31,11 @@ function delete_processor_callback!(name::Symbol)
 end
 
 """
-    execute!(proc::Processor, f, args...) -> Any
+    execute!(proc::Processor, f, args...; kwargs...) -> Any
 
-Executes the function `f` with arguments `args` on processor `proc`. This
-function can be overloaded by `Processor` subtypes to allow executing function
-calls differently than normal Julia.
+Executes the function `f` with arguments `args` and keyword arguments `kwargs`
+on processor `proc`. This function can be overloaded by `Processor` subtypes to
+allow executing function calls differently than normal Julia.
 """
 function execute! end
 
@@ -154,12 +154,12 @@ end
 iscompatible(proc::ThreadProc, opts, f, args...) = true
 iscompatible_func(proc::ThreadProc, opts, f) = true
 iscompatible_arg(proc::ThreadProc, opts, x) = true
-function execute!(proc::ThreadProc, @nospecialize(f), @nospecialize(args...))
+function execute!(proc::ThreadProc, @nospecialize(f), @nospecialize(args...); @nospecialize(kwargs...))
     tls = get_tls()
     task = Task() do
         set_tls!(tls)
         TimespanLogging.prof_task_put!(tls.sch_handle.thunk_id.id)
-        @invokelatest f(args...)
+        @invokelatest f(args...; kwargs...)
     end
     task.sticky = true
     ret = ccall(:jl_set_task_tid, Cint, (Any, Cint), task, proc.tid-1)

--- a/src/sch/dynamic.jl
+++ b/src/sch/dynamic.jl
@@ -144,7 +144,7 @@ function _register_future!(ctx, state, task, tid, (future, id, check)::Tuple{Thu
                 if t == target
                     return true
                 end
-                for input in t.inputs
+                for (_, input) in t.inputs
                     # N.B. Skips expired tasks
                     input = Dagger.unwrap_weak(input)
                     istask(input) || continue
@@ -195,13 +195,13 @@ function _get_dag_ids(ctx, state, task, tid, _)
 end
 
 "Adds a new Thunk to the DAG."
-add_thunk!(f, h::SchedulerHandle, args...; future=nothing, ref=nothing, kwargs...) =
-    exec!(_add_thunk!, h, f, args, kwargs, future, ref)
-function _add_thunk!(ctx, state, task, tid, (f, args, kwargs, future, ref))
+add_thunk!(f, h::SchedulerHandle, args...; future=nothing, ref=nothing, options...) =
+    exec!(_add_thunk!, h, f, args, options, future, ref)
+function _add_thunk!(ctx, state, task, tid, (f, args, options, future, ref))
     timespan_start(ctx, :add_thunk, tid, 0)
-    _args = map(arg->arg isa ThunkID ? state.thunk_dict[arg.id] : arg, args)
+    _args = map(pos_arg->pos_arg[1] => (pos_arg[2] isa ThunkID ? state.thunk_dict[pos_arg[2].id] : pos_arg[2]), args)
     GC.@preserve _args begin
-        thunk = Thunk(f, _args...; kwargs...)
+        thunk = Thunk(f, _args...; options...)
         # Create a `DRef` to `thunk` so that the caller can preserve it
         thunk_ref = poolset(thunk; size=64, device=MemPool.CPURAMDevice())
         thunk_id = ThunkID(thunk.id, thunk_ref)

--- a/src/sch/fault-handler.jl
+++ b/src/sch/fault-handler.jl
@@ -44,7 +44,7 @@ function handle_fault(ctx, state, deadproc)
     # Remove thunks from state.ready that have inputs on the deadlist
     for idx in length(state.ready):-1:1
         rt = state.ready[idx]
-        if any((input in deadlist) for input in rt.inputs)
+        if any((input in deadlist) for input in map(last, rt.inputs))
             deleteat!(state.ready, idx)
         end
     end

--- a/src/thunk.jl
+++ b/src/thunk.jl
@@ -1,4 +1,4 @@
-export Thunk, delayed, delayedmap
+export Thunk, delayed
 
 const ID_COUNTER = Threads.Atomic{Int}(1)
 next_id() = Threads.atomic_add!(ID_COUNTER, 1)
@@ -50,7 +50,7 @@ If omitted, options can also be specified by passing key-value pairs as
 """
 mutable struct Thunk
     f::Any # usually a Function, but could be any callable
-    inputs::Vector{Any} # TODO: Use `ImmutableArray` in 1.8
+    inputs::Vector{Pair{Union{Symbol,Nothing},Any}} # TODO: Use `ImmutableArray` in 1.8
     id::Int
     get_result::Bool # whether the worker should send the result or only the metadata
     meta::Bool
@@ -83,6 +83,7 @@ mutable struct Thunk
                         something(scope, DefaultScope()))
         end
         xs = Any[xs...]
+        @assert all(x->x isa Pair, xs)
         if options !== nothing
             @assert isempty(kwargs)
             new(f, xs, id, get_result, meta, persist, cache, cache_ref,
@@ -105,7 +106,7 @@ function affinity(t::Thunk)
         aff_vec = affinity(t.cache_ref)
     else
         aff = Dict{OSProc,Int}()
-        for inp in inputs(t)
+        for (_, inp) in t.inputs
            #if haskey(state.cache, inp)
            #    as = affinity(state.cache[inp])
            #    for a in as
@@ -130,17 +131,35 @@ function affinity(t::Thunk)
    #end
 end
 
-"""
-    delayed(f; kwargs...)(args...)
+struct Options
+    options::NamedTuple
+end
+Options(;options...) = Options((;options...))
+Options(options...) = Options((;options...))
 
-Creates a [`Thunk`](@ref) object which can be executed later, which will call
-`f` with `args`. `kwargs` controls various properties of the resulting `Thunk`.
-"""
-function delayed(f; kwargs...)
-    (args...) -> Thunk(f, args...; kwargs...)
+function args_kwargs_to_pairs(args, kwargs)
+    args_kwargs = Pair{Union{Symbol,Nothing},Any}[]
+    for arg in args
+        push!(args_kwargs, nothing => arg)
+    end
+    for kwarg in kwargs
+        push!(args_kwargs, kwarg[1] => kwarg[2])
+    end
+    return args_kwargs
 end
 
-delayedmap(f, xs...) = map(delayed(f), xs...)
+"""
+    delayed(f, options=Options())(args...; kwargs...) -> Thunk
+    delayed(f; options...)(args...; kwargs...) -> Thunk
+
+Creates a [`Thunk`](@ref) object which can be executed later, which will call
+`f` with `args` and `kwargs`. `options` controls various properties of the
+resulting `Thunk`.
+"""
+function delayed(f, options::Options)
+    (args...; kwargs...) -> Thunk(f, args_kwargs_to_pairs(args, kwargs)...; options.options...)
+end
+delayed(f; kwargs...) = delayed(f, Options(;kwargs...))
 
 "A future holding the result of a `Thunk`."
 struct ThunkFuture
@@ -209,7 +228,7 @@ function Base.showerror(io::IO, ex::ThunkFailedException)
             return "Thunk(?)"
         end
         Tinputs = Any[]
-        for input in t.inputs
+        for (_, input) in t.inputs
             input = unwrap_weak(input)
             if istask(input)
                 push!(Tinputs, "Thunk(id=$(input.id))")
@@ -218,11 +237,11 @@ function Base.showerror(io::IO, ex::ThunkFailedException)
             end
         end
         t_sig = if length(Tinputs) <= 4
-            "$(t.f)($(join(Tinputs, ", "))))"
+            "$(t.f)($(join(Tinputs, ", ")))"
         else
             "$(t.f)($(length(Tinputs)) inputs...)"
         end
-        return "Thunk(id=$(t.id), $t_sig"
+        return "Thunk(id=$(t.id), $t_sig)"
     end
     t_str = thunk_string(t)
     o_str = thunk_string(o)
@@ -281,20 +300,21 @@ end
 const EAGER_ID_COUNTER = Threads.Atomic{UInt64}(1)
 eager_next_id() = Threads.atomic_add!(EAGER_ID_COUNTER, one(UInt64))
 
-function _spawn(f, args...; options, kwargs...)
+function _spawn(f, options::Options, args...)
     Dagger.Sch.init_eager()
     for arg in args
-        @assert !isa(arg, Thunk) "Cannot use Thunks in spawn"
+        @assert !isa(last(arg), Thunk) "Cannot use Thunks in spawn"
     end
     uid = eager_next_id()
     future = ThunkFuture()
     finalizer_ref = poolset(EagerThunkFinalizer(uid); device=MemPool.CPURAMDevice())
     added_future = Future()
-    propagates = keys(options)
-    put!(Dagger.Sch.EAGER_THUNK_CHAN, (added_future, future, uid, finalizer_ref, f, (args...,), (;propagates, options..., kwargs...,)))
+    propagates = keys(options.options)
+    put!(Dagger.Sch.EAGER_THUNK_CHAN, (added_future, future, uid, finalizer_ref, f, (args...,), (;propagates, options.options...,)))
     thunk_ref = fetch(added_future)
     return (uid, future, finalizer_ref, thunk_ref)
 end
+
 """
     spawn(f, args...; kwargs...) -> EagerThunk
 
@@ -304,26 +324,34 @@ an `EagerThunk`. Uses a scheduler running in the background to execute code.
 Note that `kwargs` are passed to the `Thunk` constructor, and are documented in
 its docstring.
 """
-function spawn(f, args...; processor=nothing, scope=nothing, kwargs...)
+function spawn(f, args...; kwargs...)
     options = get_options()
+    if length(args) >= 1 && first(args) isa Options
+        options = merge(options, first(args).options)
+        args = args[2:end]
+    end
+    processor = haskey(options, :processor) ? options.processor : nothing
+    scope = haskey(options, :scope) ? options.scope : nothing
     if !isnothing(processor) || !isnothing(scope)
         f = tochunk(f,
                     something(processor, get_options(:processor, OSProc())),
                     something(scope, get_options(:scope, DefaultScope())))
     end
+    args_kwargs = args_kwargs_to_pairs(args, kwargs)
     uid, future, finalizer_ref, thunk_ref = if myid() == 1
-        _spawn(f, args...; options, kwargs...)
+        _spawn(f, Options(options), args_kwargs...)
     else
-        remotecall_fetch(_spawn, 1, f, args...; options, kwargs...)
+        remotecall_fetch(_spawn, 1, f, Options(options), args_kwargs...)
     end
     return EagerThunk(uid, future, finalizer_ref, thunk_ref)
 end
 
 """
-    @par [opts] f(args...) -> Thunk
+    @par [opts] f(args...; kwargs...) -> Thunk
 
-Convenience macro to call `Dagger.delayed` on `f` with arguments `args`.
-May also be called with a series of assignments like so:
+Convenience macro to call `Dagger.delayed` on `f` with arguments `args` and
+keyword arguments `kwargs`. May also be called with a series of assignments
+like so:
 
 ```julia
 x = @par begin
@@ -375,16 +403,24 @@ end
 function _par(ex::Expr; lazy=true, recur=true, opts=())
     if ex.head == :call && recur
         f = replace_broadcast(ex.args[1])
-        args = ex.args[2:end]
+        if length(ex.args) >= 2 && Meta.isexpr(ex.args[2], :parameters)
+            args = ex.args[3:end]
+            kwargs = ex.args[2]
+        else
+            args = ex.args[2:end]
+            kwargs = Expr(:parameters)
+        end
         opts = esc.(opts)
+        args_ex = _par.(args; lazy=lazy, recur=false)
+        kwargs_ex = _par.(kwargs.args; lazy=lazy, recur=false)
         if lazy
-            return :(Dagger.delayed($(esc(f)); $(opts...))($(_par.(args; lazy=lazy, recur=false)...)))
+            return :(Dagger.delayed($(esc(f)), $Options(;$(opts...)))($(args_ex...); $(kwargs_ex...)))
         else
             sync_var = esc(Base.sync_varname)
             @gensym result
             return quote
-                let args = ($(_par.(args; lazy=lazy, recur=false)...),)
-                    $result = $spawn($(esc(f)), args...; $(opts...))
+                let args = ($(args_ex...),)
+                    $result = $spawn($(esc(f)), $Options(;$(opts...)), args...; $(kwargs_ex...))
                     if $(Expr(:islocal, sync_var))
                         put!($sync_var, schedule(Task(()->wait($result))))
                     end
@@ -437,7 +473,15 @@ function Base.show(io::IO, z::Thunk)
     end
     print(io, "Thunk[$(z.id)]($f, ")
     if lvl > 0
-        show(IOContext(io, :lazy_level => lvl-1), z.inputs)
+        inputs = Any[]
+        for (pos, input) in z.inputs
+            if pos === nothing
+                push!(inputs, input)
+            else
+                push!(inputs, pos => input)
+            end
+        end
+        show(IOContext(io, :lazy_level => lvl-1), inputs)
     else
         print(io, "...")
     end

--- a/src/ui/graph.jl
+++ b/src/ui/graph.jl
@@ -142,8 +142,9 @@ write_edge(ctx, io, from::String, to::String) = println(io, "n_$from -> n_$to;")
 
 getargs!(d, t) = nothing
 function getargs!(d, t::Thunk)
-    d[t.id] = [filter(x->!istask(x[2]), collect(enumerate(t.inputs)))...,]
-    foreach(i->getargs!(d, i), t.inputs)
+    raw_inputs = map(last, t.inputs)
+    d[t.id] = [filter(x->!istask(x[2]), collect(enumerate(raw_inputs)))...,]
+    foreach(i->getargs!(d, i), raw_inputs)
 end
 function write_dag(io, logs::Vector, t=nothing)
     ctx = (proc_to_color = Dict{Processor,String}(),

--- a/test/scheduler.jl
+++ b/test/scheduler.jl
@@ -50,7 +50,7 @@ function dynamic_get_dag(x...)
 end
 function dynamic_add_thunk(x)
     h = sch_handle()
-    id = Dagger.Sch.add_thunk!(h, x) do y
+    id = Dagger.Sch.add_thunk!(h, nothing=>x) do y
         y+1
     end
     wait(h, id)
@@ -58,7 +58,7 @@ function dynamic_add_thunk(x)
 end
 function dynamic_add_thunk_self_dominated(x)
     h = sch_handle()
-    id = Dagger.Sch.add_thunk!(h, h.thunk_id, x) do y
+    id = Dagger.Sch.add_thunk!(h, nothing=>h.thunk_id, nothing=>x) do y
         y+1
     end
     return fetch(h, id)
@@ -205,7 +205,7 @@ end
                     # until we end up on a non-blocked worker
                     h = Dagger.Sch.sch_handle()
                     wkrs = Dagger.Sch.exec!(_list_workers, h)
-                    id = Dagger.Sch.add_thunk!(testfun, h, i)
+                    id = Dagger.Sch.add_thunk!(testfun, h, nothing=>i)
                     return fetch(h, id)
                 end
                 return myid()

--- a/test/thunk.jl
+++ b/test/thunk.jl
@@ -6,7 +6,7 @@ import Dagger: Chunk
 
     function dynamic_fib(n)
         n <= 1 && return n
-        t = Dagger.spawn(dynamic_fib, n-1)
+        t = Dagger.@spawn dynamic_fib(n-1)
         y = dynamic_fib(n-2)
         return (fetch(t)::Int) + y
     end
@@ -55,13 +55,22 @@ end
         a = @spawn x + x
         @test a isa Dagger.EagerThunk
         b = @spawn sum([x,1,2])
-        c = spawn(*, a, b)
+        c = @spawn a * b
         @test c isa Dagger.EagerThunk
         @test fetch(a) == 4
         @test fetch(b) == 5
         @test fetch(c) == 20
     end
     @test Dagger.Sch.EAGER_CONTEXT[] isa Context
+    @testset "keyword arguments" begin
+        A = rand(4, 4)
+        @test fetch(@spawn sum(A; dims=1)) ≈ sum(A; dims=1)
+
+        @test_throws_unwrap Dagger.ThunkFailedException fetch(@spawn sum(A; fakearg=2))
+
+        @test fetch(@spawn reduce(+, A; dims=1, init=2.0)) ≈
+              reduce(+, A; dims=1, init=2.0)
+    end
     @testset "broadcast" begin
         A, B = rand(4), rand(4)
         @test fetch(@spawn A .+ B) ≈ A .+ B
@@ -161,7 +170,7 @@ end
         end
     end
     @testset "remote spawn" begin
-        a = fetch(Distributed.@spawnat 2 Dagger.spawn(+, 1, 2))
+        a = fetch(Distributed.@spawnat 2 Dagger.@spawn 1+2)
         @test Dagger.Sch.EAGER_INIT[]
         @test fetch(Distributed.@spawnat 2 !(Dagger.Sch.EAGER_INIT[]))
         @test a isa Dagger.EagerThunk
@@ -227,19 +236,19 @@ end
             end
         end
         @testset "eager API" begin
-            _a = Dagger.spawn(+, 1, 2; scope=NodeScope())
+            _a = Dagger.@spawn scope=NodeScope() 1+2
             a = Dagger.Sch._find_thunk(_a)
             @test a.f isa Chunk
             @test a.f.processor isa OSProc
             @test a.f.scope isa NodeScope
 
-            _a = Dagger.spawn(+, 1, 2; processor=Dagger.ThreadProc(1,1))
+            _a = Dagger.@spawn processor=Dagger.ThreadProc(1,1) 1+2
             a = Dagger.Sch._find_thunk(_a)
             @test a.f isa Chunk
             @test a.f.processor isa Dagger.ThreadProc
             @test a.f.scope == DefaultScope()
 
-            _a = Dagger.spawn(+, 1, 2; processor=Dagger.ThreadProc(1,1), scope=NodeScope())
+            _a = Dagger.@spawn processor=Dagger.ThreadProc(1,1) scope=NodeScope() 1+2
             a = Dagger.Sch._find_thunk(_a)
             @test a.f isa Chunk
             @test a.f.processor isa Dagger.ThreadProc
@@ -251,12 +260,12 @@ end
 
         s = p -> p == Dagger.ThreadProc(1, 1)
         f = (x) -> 10 + x
-        g = (x) -> fetch(Dagger.spawn(f, x; proclist=s))
-        fetch(Dagger.spawn(g, 10; proclist=s))
+        g = (x) -> fetch(Dagger.@spawn proclist=s f(x))
+        fetch(Dagger.@spawn proclist=s g(10))
     end
     @testset "no cross-scheduler Thunk usage" begin
         a = delayed(+)(1,2)
-        @test_throws Exception Dagger.spawn(identity, a)
+        @test_throws Exception Dagger.@spawn identity(a)
     end
     @testset "@sync support" begin
         result = Dagger.@spawn sleep(1)


### PR DESCRIPTION
APIs like `delayed` and `spawn` assumed that passed kwargs were to be treated as options to the scheduler, which is both somewhat confusing for users, and precludes passing kwargs to user functions.

This PR changes those APIs, as well as `@spawn`, to instead pass kwargs directly to the user's function. Options are now passed in an `Options` struct to `delayed` and `spawn` as the second argument (the first being the function), while `@spawn` still keeps them before the call (which is generally more convenient).

Internally, `Thunk`'s `inputs` field is now a
`Vector{Pair{Union{Symbol,Nothing},Any}}`, where the second element of each pair is the argument, while the first element is a position; if `nothing`, it's a positional argument, and if a `Symbol`, then it's a kwarg.