### PR TITLE
DArray: Figure out correct eltype

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,6 @@
     queue: "juliaecosystem"
     sandbox_capable: "true"
     os: linux
-    arch: x86_64
   command: "julia --project -e 'using Pkg; Pkg.develop(;path=\"lib/TimespanLogging\")'"
 .bench: &bench
   if: build.message =~ /\[run benchmarks\]/

--- a/src/array/map-reduce.jl
+++ b/src/array/map-reduce.jl
@@ -19,9 +19,10 @@ function stage(ctx::Context, node::Map)
     f = node.f
     for i=eachindex(domains)
         inps = map(x->chunks(x)[i], inputs)
-        thunks[i] = Dagger.@spawn map(f, inps...) 
+        thunks[i] = Dagger.@spawn map(f, inps...)
     end
-    DArray(Any, domain(primary), domainchunks(primary), thunks)
+    RT = Base.promote_op(node.f, map(eltype, node.inputs)...)
+    return DArray(RT, domain(primary), domainchunks(primary), thunks)
 end
 
 map(f, x::ArrayOp, xs::ArrayOp...) = Map(f, (x, xs...))

--- a/test/array.jl
+++ b/test/array.jl
@@ -13,6 +13,7 @@ end
 @testset "DArray constructor" begin
     x = fetch(rand(Blocks(2,2), 3,3))
     @test collect(x) == DArray{Float64, 2}(x.domain, x.subdomains, x.chunks) |> collect
+    @test x isa DArray{Float64, 2}
 end
 
 @testset "rand" begin
@@ -37,6 +38,13 @@ end
     R = rand(Blocks(10), 20)
     r = collect(R)
     @test r[1:10] != r[11:20]
+end
+
+@testset "map" begin
+    X1 = fetch(ones(Blocks(10, 10), 100, 100))
+    X2 = fetch(map(x->x+1, X1))
+    @test typeof(X1) === typeof(X2)
+    @test collect(X1) .+ 1 == collect(X2)
 end
 
 @testset "sum" begin


### PR DESCRIPTION
Previously it would fallback to `Any`, which breaks uses of `eltype(::DArray)`