### PR TITLE
DArray: Improve DiffEq support

### DIFF
--- a/src/array/alloc.jl
+++ b/src/array/alloc.jl
@@ -68,6 +68,14 @@ Base.zeros(p::Blocks, t::Type, dims::Integer...) = zeros(p, t, dims)
 Base.zeros(p::Blocks, dims::Integer...) = zeros(p, Float64, dims)
 Base.zeros(p::Blocks, dims::Tuple) = zeros(p, Float64, dims)
 
+function Base.zero(x::DArray{T,N}) where {T,N}
+    dims = ntuple(i->x.domain.indexes[i].stop, N)
+    sd = first(x.subdomains)
+    part_size = ntuple(i->sd.indexes[i].stop, N)
+    a = zeros(Blocks(part_size...), T, dims)
+    return cached_stage(Context(global_context()), a)
+end
+
 function sprand(p::Blocks, m::Integer, n::Integer, sparsity::Real)
     s = rand(UInt)
     f = function (idx, t,sz)

--- a/src/array/operators.jl
+++ b/src/array/operators.jl
@@ -1,4 +1,3 @@
-
 import Base: exp, expm1, log, log10, log1p, sqrt, cbrt, exponent,
              significand, sin, sinpi, cos, cospi, tan, sec, cot, csc,
              sinh, cosh, tanh, coth, sech, csch,
@@ -51,7 +50,7 @@ BroadcastStyle(::DaggerBroadcastStyle, ::BroadcastStyle) = DaggerBroadcastStyle(
 BroadcastStyle(::BroadcastStyle, ::DaggerBroadcastStyle) = DaggerBroadcastStyle()
 
 function Base.copy(b::Broadcast.Broadcasted{<:DaggerBroadcastStyle})
-    BCast(b)
+    cached_stage(Context(global_context()), BCast(b))::DArray
 end
 
 function stage(ctx::Context, node::BCast)


### PR DESCRIPTION
Adds explicit support for `zero`, `copy`, and `similar`, and changes broadcast to return a `DArray` instead of a `BCast`.