### PR TITLE
at-mutable: Add remote execution like shard

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -104,6 +104,12 @@ A = Dagger.spawn() do
 end
 ```
 
+or by specifying the `worker` argument to `@mutable`:
+
+```julia
+A = Dagger.@mutable worker=2 rand(1000, 1000)
+```
+
 ### Parallel reduction
 
 Reductions are often parallelized by reducing a set of partitions on each


### PR DESCRIPTION
Makes `@mutable` much more useful for distributed computing. Also breaks the multi-argument forms of `@mutable` to allow passing options as key-value pairs before the expression to evaluate.