### PR TITLE
Add closure parsing to at-spawn

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -3,6 +3,12 @@
 julia_version = "1.7.3"
 manifest_format = "2.0"
 
+[[deps.Adapt]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "195c5505521008abea5aee4f96930717958eac6f"
+uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+version = "3.4.0"
+
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "d58978e5-989f-55fb-8d15-ea34adc7bf54"
 version = "0.18.1"
 
 [deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 ContextVariablesX = "6add18c4-b38d-439d-96f6-d6bc489c04c5"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
@@ -21,6 +22,7 @@ TimespanLogging = "a526e669-04d3-4846-9525-c66122c55f63"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
+Adapt = "1, 2, 3"
 ContextVariablesX = "0.1"
 DataStructures = "0.18"
 MacroTools = "0.5"

--- a/src/Dagger.jl
+++ b/src/Dagger.jl
@@ -14,12 +14,14 @@ using UUIDs
 
 import ContextVariablesX
 
+import Adapt
 using Requires
 using MacroTools
 using TimespanLogging
 
 include("lib/util.jl")
 include("utils/dagdebug.jl")
+include("utils/find-thunk.jl")
 
 # Distributed data
 include("options.jl")

--- a/src/utils/find-thunks.jl
+++ b/src/utils/find-thunks.jl
@@ -1,0 +1,6 @@
+struct RecordAdaptor
+    tasks::Set{Any}
+end
+struct FetchAdaptor end
+Adapt.adapt_storage(ra::RecordAdaptor, t::Thunk) = (push!(ra.tasks, t); t)
+Adapt.adapt_storage(::FetchAdaptor, t::Thunk) = fetch(t)


### PR DESCRIPTION
This PR brings `Dagger.@spawn` closer to `Threads.@spawn` by allowing an alternative parsing mode when `begin ... end` blocks are encountered; specifically, such blocks are treated as a function without any arguments, which closes over any captured values.

Todo:
- [ ] Detect closed-over variables (if possible) and pass them as arguments, in case they're thunks/chunks
- [ ] (Alternative) Recurse into closure at runtime to find thunks/chunks and replace them during move
- [ ] (Optional) Implement recursive parsing mode
- [ ] Add tests
- [ ] Add docs

Fixes #421 