### PR TITLE
Update path splitting rule in Dagger.File / Dagger.tofile

### DIFF
--- a/src/file-io.jl
+++ b/src/file-io.jl
@@ -30,11 +30,9 @@ function File(path::AbstractString;
         # FIXME: Once MemPool better propagates errors, this check won't be necessary
         throw(ArgumentError("`Dagger.File` expected file to exist at \"$path\""))
     end
-    if isabspath(path)
-        dir, file = dirname(path), basename(path)
-    else
-        dir, file = pwd(), basename(path)
-    end
+    dir, file = dirname(path), basename(path)
+    # if dir is empty, use the current working directory
+    dir = isempty(dir) ? pwd() : dir
     Tdevice = GenericFileDevice{serialize, deserialize, use_io, mmap}
     device = Tdevice(dir)
     leaf_tag = MemPool.Tag(Tdevice=>file)
@@ -61,11 +59,9 @@ function tofile(@nospecialize(data), path::AbstractString;
                 deserialize::Base.Callable=deserialize,
                 use_io::Bool=true,
                 mmap::Bool=false)
-    if isabspath(path)
-        dir, file = dirname(path), basename(path)
-    else
-        dir, file = pwd(), basename(path)
-    end
+    dir, file = dirname(path), basename(path)
+    # if dir is empty, use the current working directory
+    dir = isempty(dir) ? pwd() : dir
     Tdevice = GenericFileDevice{serialize, deserialize, use_io, mmap}
     device = Tdevice(dir)
     chunk = Dagger.tochunk(data, OSProc(), ProcessScope();

--- a/test/file-io.jl
+++ b/test/file-io.jl
@@ -3,31 +3,41 @@ using Serialization
 @testset "File IO" begin
     @testset "File" begin
         data = [1,2,3]
-        data_path = joinpath(tempdir(), "jl_" * join(rand('a':'z', 8)) * ".jls")
-        atexit() do
-            @assert isfile(data_path)
-            rm(data_path)
+        # test both absolute and relative paths
+        dir_abs = tempdir()
+        dir_rel = splitpath(mktempdir(pwd()))[end]
+        for dir in [dir_abs, dir_rel]
+            data_path = joinpath(dir, "jl_" * join(rand('a':'z', 8)) * ".jls")
+            atexit() do
+                @assert isfile(data_path)
+                rm(data_path)
+            end
+            serialize(data_path, data)
+
+            data_c = Dagger.File(data_path)::Dagger.File
+            @test fetch(data_c) == data
+            @test fetch(Dagger.@spawn identity(data_c)) == data
+
+            @test isfile(data_path)
         end
-        serialize(data_path, data)
-
-        data_c = Dagger.File(data_path)::Dagger.File
-        @test fetch(data_c) == data
-        @test fetch(Dagger.@spawn identity(data_c)) == data
-
-        @test isfile(data_path)
     end
     @testset "tofile" begin
         data = [4,5,6]
-        data_path = joinpath(tempdir(), "jl_" * join(rand('a':'z', 8)) * ".jls")
-        atexit() do
-            @assert isfile(data_path)
-            rm(data_path)
+        # test both absolute and relative paths
+        dir_abs = tempdir()
+        dir_rel = splitpath(mktempdir(pwd()))[end]
+        for dir in [dir_abs, dir_rel]
+            data_path = joinpath(dir, "jl_" * join(rand('a':'z', 8)) * ".jls")
+            atexit() do
+                @assert isfile(data_path)
+                rm(data_path)
+            end
+
+            data_c = Dagger.tofile(data, data_path)::Dagger.File
+            @test fetch(data_c) == data
+            @test fetch(Dagger.@spawn identity(data_c)) == data
+
+            @test isfile(data_path)
         end
-
-        data_c = Dagger.tofile(data, data_path)::Dagger.File
-        @test fetch(data_c) == data
-        @test fetch(Dagger.@spawn identity(data_c)) == data
-
-        @test isfile(data_path)
     end
 end


### PR DESCRIPTION
This PR proposes a fix to a potential bug discovered in https://github.com/JuliaParallel/DTables.jl/issues/35

**Behaviour:** When using relative paths (eg, `Dagger.tofile(data, "data_processed/obj_$i.arrow", ...)`, the directories would be ignored and files would be saved directly in pwd().

**Reason:** Path splitting was done with `isabspath` (see [link](https://github.com/JuliaParallel/Dagger.jl/blob/04e2466a92927faecb9d1c27cf50f5b93bc8df3b/src/file-io.jl#L33), but that doesn't work for relative paths.

Example:
```julia
path = "data_output/out.arrow"
isabspath(path) # false! not helpful if we want to know if we need to use pwd() to set directory!
```

Proposed change:
```julia
dir, file = dirname(path), basename(path)
dir = isempty(dir) ? pwd() : dir
```

I've also added a test case for the relative paths to prevent future regressions. Current testing used `tempdir()`, which provides an absolute path; hence, the bug wasn't observed.