### PR TITLE
Fix error in documentation

### DIFF
--- a/docs/src/data-management.md
+++ b/docs/src/data-management.md
@@ -90,7 +90,7 @@ cs = Dagger.@shard Threads.Atomic{Int}(0)
 wait.([Dagger.@spawn Threads.atomic_add!(cs, 1) for i in 1:1000])
 
 # And let's fetch the total sum of all counters:
-@assert sum(fetch.(map(ctr->ctr[], cs))) == 1000
+@assert sum(fetch.(map(ctr->Dagger.spawn(getindex,ctr), cs))) == 1000
 ```
 
 Note that `map`, when used on a shard, will execute the provided function once

--- a/docs/src/data-management.md
+++ b/docs/src/data-management.md
@@ -90,7 +90,7 @@ cs = Dagger.@shard Threads.Atomic{Int}(0)
 wait.([Dagger.@spawn Threads.atomic_add!(cs, 1) for i in 1:1000])
 
 # And let's fetch the total sum of all counters:
-@assert sum(fetch.(map(ctr->Dagger.spawn(getindex,ctr), cs))) == 1000
+@assert sum(map(ctr->fetch(ctr)[], cs)) == 1000
 ```
 
 Note that `map`, when used on a shard, will execute the provided function once


### PR DESCRIPTION
On Dagger 0.18.2 for me copy/pasting the sharding example resulted in the error

````
ERROR: MethodError: no method matching getindex(::Dagger.Chunk{Base.Threads.Atomic{Int64}, MemPool.DRef, OSProc, ProcessScope})
Stacktrace:
 [1] (::var"#9#10")(ctr::Dagger.Chunk{Base.Threads.Atomic{Int64}, MemPool.DRef, OSProc, ProcessScope})
   @ Main ./REPL[6]:2
 [2] iterate
   @ ./generator.jl:47 [inlined]
 [3] collect(itr::Base.Generator{Dagger.Shard, var"#9#10"})
   @ Base ./array.jl:782
 [4] map(f::Function, A::Dagger.Shard)
   @ Base ./abstractarray.jl:3289
 [5] top-level scope
   @ REPL[6]:2
````

I don't know if my fix is the idiomatic way to do it, but this worked for me at least.