### PR TITLE
ThunkFailedException: Scrub out Thunk

### DIFF
--- a/test/thunk.jl
+++ b/test/thunk.jl
@@ -181,6 +181,13 @@ end
 
         # Mild stress-test
         @test dynamic_fib(10) == 55
+
+        # Errors on remote are correctly scrubbed (#430)
+        t2 = remotecall_fetch(2) do
+            t1 = Dagger.@spawn 1+"fail"
+            Dagger.@spawn t1+1
+        end
+        @test_throws_unwrap Dagger.ThunkFailedException fetch(t2)
     end
     @testset "undefined function" begin
         # Issues #254, #255


### PR DESCRIPTION
We previously were capturing `Thunk`s in `ThunkFailedException`, which is a totally wrong thing to do (since `Thunk`s aren't safe to serialize, but errors should be serializable everywhere). Now we convert `Thunk` to `ThunkSummary` objects which summarize the relevant details contained in the original `Thunk`, for printing and analysis purposes.

Fixes #430 