### PR TITLE
tests: Test for previous option preservation

### DIFF
--- a/src/options.jl
+++ b/src/options.jl
@@ -13,7 +13,8 @@ scope. Note that setting an option here will propagate its value across Julia
 or Dagger tasks spawned by `f()` or its callees (i.e. the options propagate).
 """
 function with_options(f, options::NamedTuple)
-    with(options_context => options) do
+    prev_options = options_context[]
+    with(options_context => merge(prev_options, options)) do
         f()
     end
 end

--- a/test/options.jl
+++ b/test/options.jl
@@ -50,6 +50,16 @@ end
         end
     end
 
+    # Test previous option preservation
+    Dagger.with_options(scope=Dagger.scope(worker=last_wid)) do
+        Dagger.with_options(meta=true) do
+            @test haskey(Dagger.get_options(), :meta)
+            @test Dagger.get_options(:meta) == true
+            @test haskey(Dagger.get_options(), :scope)
+            @test Dagger.get_options(:scope) == Dagger.scope(worker=last_wid)
+        end
+    end
+
     # Test scope/single is applied
     for wid in workers()
         for (option, value) in [


### PR DESCRIPTION
An unfortunate bug that was missed in the initial options implementation: options should be merged when nesting `with_options` :scream: 