### PR TITLE
Sch: Temporarily disable chunk cache

### DIFF
--- a/src/sch/Sch.jl
+++ b/src/sch/Sch.jl
@@ -1508,6 +1508,7 @@ function do_task(to_proc, task_desc)
     fetch_tasks = map(Iterators.zip(_data,_ids)) do (x, id)
         @async begin
             timespan_start(ctx, :move, (;thunk_id, id), (;f, id, data=x))
+            #= FIXME: This isn't valid if x is written to
             x = if x isa Chunk
                 value = lock(TASK_SYNC) do
                     if haskey(CHUNK_CACHE, x)
@@ -1548,8 +1549,9 @@ function do_task(to_proc, task_desc)
                     _x
                 end
             else
-                @invokelatest move(to_proc, x)
-            end
+            =#
+            x = @invokelatest move(to_proc, x)
+            #end
             @dagdebug thunk_id :move "Moved argument $id to $to_proc: $x"
             timespan_finish(ctx, :move, (;thunk_id, id), (;f, id, data=x); tasks=[Base.current_task()])
             return x

--- a/test/scheduler.jl
+++ b/test/scheduler.jl
@@ -487,9 +487,13 @@ function testevicted(x)
     x
 end
 end
+
+@test_skip "Chunk Caching"
+#=
 @testset "Chunk Caching" begin
     compute(delayed(testevicted)(delayed(testpresent)(c1,c2)))
 end
+=#
 
 @testset "MemPool.approx_size" begin
     for (obj, size) in [


### PR DESCRIPTION
The scheduler chunk cache has been around for a while, but unfortunately was never really correct in the face of mutating data. If data is mutated by any Dagger task, Dagger's chunk cache may still serve the stale, non-mutated data copy. This issue has come up in a number of places, and so it needs to be resolved now before causing further issues. A proper fix is still in the works (as part of a larger set of changes), but in the meantime, this hotfix will have to do.