### PR TITLE
Sch: Disable CHUNK_CACHE evictions for now

### DIFF
--- a/src/sch/Sch.jl
+++ b/src/sch/Sch.jl
@@ -933,7 +933,7 @@ function finish_task!(ctx, state, node, thunk_failed)
     if haskey(state.waiting_data, node) && isempty(state.waiting_data[node])
         delete!(state.waiting_data, node)
     end
-    evict_all_chunks!(ctx, to_evict)
+    #evict_all_chunks!(ctx, to_evict)
 end
 
 function delete_unused_tasks!(state)


### PR DESCRIPTION
Since we've disabled `CHUNK_CACHE` on master