### PR TITLE
Reference Dagger.EAGER_THUNK_STREAMS explicitly

### DIFF
--- a/src/sch/eager.jl
+++ b/src/sch/eager.jl
@@ -117,7 +117,7 @@ function eager_cleanup(state, uid)
         delete!(state.thunk_dict, tid)
     end
     remotecall_wait(1, uid) do uid
-        lock(EAGER_THUNK_STREAMS) do global_streams
+        lock(Dagger.EAGER_THUNK_STREAMS) do global_streams
             if haskey(global_streams, uid)
                 delete!(global_streams, uid)
             end

--- a/src/submission.jl
+++ b/src/submission.jl
@@ -186,7 +186,7 @@ end
 function EagerThunkMetadata(spec::EagerTaskSpec)
     f = chunktype(spec.f).instance
     arg_types = ntuple(i->chunktype(spec.args[i][2]), length(spec.args))
-    return_type = Base._return_type(f, Base.to_tuple_type(arg_types))
+    return_type = Base.promote_op(f, arg_types...)
     return EagerThunkMetadata(return_type)
 end
 chunktype(t::EagerThunk) = t.metadata.return_type


### PR DESCRIPTION
A lot of tests failed when I was running them locally because that variable is defined in the `Dagger` module rather than `Dagger.Sch`. Though a lot still fail for me with this error:
```julia
  Got exception outside of a @test                                                                                                                                                                                                             
  On worker 2:                                                                                                                                                                                                                                 
  Tuple field type cannot be Union{}
```

I think we're running into https://github.com/JuliaLang/julia/issues/52385 :grimacing: I'll try to look into that in a few days.

(P.S.: I configured the PR to merge into #463 instead of `master`)