### PR TITLE
DArray: Fixes and improvements for mapreduce operations

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,16 @@
 
 julia_version = "1.8.5"
 manifest_format = "2.0"
-project_hash = "63ad89f514e49fbb0061c336a95c9098f89440c9"
+project_hash = "a446c2aa03be8655c840a608e485a224c517212f"
+
+[[deps.AbstractTrees]]
+git-tree-sha1 = "2d9c9a55f9c93e8887ad391fbae72f8ef55e1177"
+uuid = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+version = "0.4.5"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.1"
 
 [[deps.ArnoldiMethod]]
 deps = ["LinearAlgebra", "Random", "StaticArrays"]
@@ -16,11 +25,17 @@ uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
+[[deps.Calculus]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "f641eb0a4f00c343bbc32346e1217b86f3ce9dad"
+uuid = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
+version = "0.5.1"
+
 [[deps.ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "0d12ee16b3f62e4e33c3277773730a5b21a74152"
+git-tree-sha1 = "575cd02e080939a33b6df6c5853d14924c08e35b"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.20.0"
+version = "1.23.0"
 
 [[deps.ChangesOfVariables]]
 deps = ["InverseFunctions", "LinearAlgebra", "Test"]
@@ -30,9 +45,9 @@ version = "0.1.8"
 
 [[deps.Compat]]
 deps = ["Dates", "LinearAlgebra", "TOML", "UUIDs"]
-git-tree-sha1 = "75bd5b6fc5089df449b5d35fa501c846c9b6549b"
+git-tree-sha1 = "c955881e3c981181362ae4088b35995446298b80"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.12.0"
+version = "4.14.0"
 
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -46,23 +61,55 @@ version = "1.16.0"
 
 [[deps.DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "ac67408d9ddf207de5cfa9a97e114352430f01ed"
+git-tree-sha1 = "0f4b5d62a88d8f59003e43c25a8a90de9eb76317"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.16"
+version = "0.18.18"
 
 [[deps.Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
+[[deps.DensityInterface]]
+deps = ["InverseFunctions", "Test"]
+git-tree-sha1 = "80c3e8639e3353e5d2912fb3a1916b8455e2494b"
+uuid = "b429d917-457f-4dbc-8f4c-0cc954292b1d"
+version = "0.4.0"
+
 [[deps.Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[deps.Distributions]]
+deps = ["ChainRulesCore", "DensityInterface", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SpecialFunctions", "Statistics", "StatsAPI", "StatsBase", "StatsFuns", "Test"]
+git-tree-sha1 = "7c302d7a5fec5214eb8a5a4c466dcf7a51fcf169"
+uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
+version = "0.25.107"
 
 [[deps.DocStringExtensions]]
 deps = ["LibGit2"]
 git-tree-sha1 = "2fb1e02f2b635d0845df5d7c167fec4dd739b00d"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 version = "0.9.3"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.6.0"
+
+[[deps.DualNumbers]]
+deps = ["Calculus", "NaNMath", "SpecialFunctions"]
+git-tree-sha1 = "5837a837389fccf076445fce071c8ddaea35a566"
+uuid = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"
+version = "0.6.8"
+
+[[deps.FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+
+[[deps.FillArrays]]
+deps = ["LinearAlgebra", "PDMats", "Random", "SparseArrays", "Statistics"]
+git-tree-sha1 = "5b93957f6dcd33fc343044af3d48c215be2562f1"
+uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
+version = "1.9.3"
 
 [[deps.Graphs]]
 deps = ["ArnoldiMethod", "Compat", "DataStructures", "Distributed", "Inflate", "LinearAlgebra", "Random", "SharedArrays", "SimpleTraits", "SparseArrays", "Statistics"]
@@ -74,6 +121,12 @@ version = "1.9.0"
 git-tree-sha1 = "2eaa69a7cab70a52b9687c8bf950a5a93ec895ae"
 uuid = "076d061b-32b6-4027-95e0-9a2c6f6d7e74"
 version = "0.2.0"
+
+[[deps.HypergeometricFunctions]]
+deps = ["DualNumbers", "LinearAlgebra", "OpenLibm_jll", "SpecialFunctions"]
+git-tree-sha1 = "f218fe3736ddf977e0e772bc9a586b2383da2685"
+uuid = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
+version = "0.3.23"
 
 [[deps.Inflate]]
 git-tree-sha1 = "ea8031dea4aff6bd41f1df8f2fdfb25b33626381"
@@ -95,9 +148,30 @@ git-tree-sha1 = "630b497eafcc20001bba38a4651b327dcfc491d2"
 uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
 version = "0.2.2"
 
+[[deps.JLLWrappers]]
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "7e5d6779a1e09a36db2a7b6cff50942a0a7d0fca"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.5.0"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.3"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "7.84.0+0"
+
 [[deps.LibGit2]]
 deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.10.2+0"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -108,9 +182,9 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[deps.LogExpFunctions]]
 deps = ["ChainRulesCore", "ChangesOfVariables", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
-git-tree-sha1 = "7d6dd4e9212aebaeed356de34ccf262a3cd415aa"
+git-tree-sha1 = "18144f3e9cbe9b15b070288eef858f71b291ce37"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.3.26"
+version = "0.3.27"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -124,6 +198,11 @@ version = "0.5.13"
 [[deps.Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[deps.MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.28.0+0"
 
 [[deps.MemPool]]
 deps = ["DataStructures", "Distributed", "Mmap", "Random", "ScopedValues", "Serialization", "Sockets"]
@@ -140,31 +219,75 @@ version = "1.1.0"
 [[deps.Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2022.2.1"
+
+[[deps.NaNMath]]
+deps = ["OpenLibm_jll"]
+git-tree-sha1 = "0877504529a3e5c3343c6f8b4c0381e57e4387e4"
+uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
+version = "1.0.2"
+
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 version = "1.2.0"
+
+[[deps.OnlineStats]]
+deps = ["AbstractTrees", "Dates", "Distributions", "LinearAlgebra", "OnlineStatsBase", "OrderedCollections", "Random", "RecipesBase", "SpecialFunctions", "Statistics", "StatsBase", "StatsFuns"]
+git-tree-sha1 = "d3f41f18b9abaa2c64e8e0c43921df9b61ec8d02"
+uuid = "a15396b6-48d5-5d58-9928-6d29437db91e"
+version = "1.6.3"
+
+[[deps.OnlineStatsBase]]
+deps = ["AbstractTrees", "Dates", "LinearAlgebra", "OrderedCollections", "Statistics", "StatsBase"]
+git-tree-sha1 = "6aa22dda15d3387639210d382fafc4f2a84b4fb9"
+uuid = "925886fa-5bf2-5e8e-b522-a9147a512338"
+version = "1.6.3"
 
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
 version = "0.3.20+0"
 
+[[deps.OpenLibm_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
+version = "0.8.1+0"
+
+[[deps.OpenSpecFun_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "13652491f6856acfd2db29360e1bbcd4565d04f1"
+uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
+version = "0.5.5+0"
+
 [[deps.OrderedCollections]]
 git-tree-sha1 = "dfdf5519f235516220579f949664f1bf44e741c5"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.6.3"
 
+[[deps.PDMats]]
+deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
+git-tree-sha1 = "949347156c25054de2db3b166c52ac4728cbad65"
+uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
+version = "0.11.31"
+
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.8.0"
+
 [[deps.PrecompileTools]]
 deps = ["Preferences"]
-git-tree-sha1 = "03b4c25b43cb84cee5c90aa9b5ea0a78fd848d2f"
+git-tree-sha1 = "5aa36f7049a63a1528fe8f7c3f2113413ffd4e1f"
 uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-version = "1.2.0"
+version = "1.2.1"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "00805cd429dcb4870060ff49ef443486c262e38e"
+git-tree-sha1 = "9306f6085165d270f7e3db02af26a400d580f5c6"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.4.1"
+version = "1.4.3"
 
 [[deps.Printf]]
 deps = ["Unicode"]
@@ -174,15 +297,48 @@ uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 deps = ["Printf"]
 uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 
+[[deps.QuadGK]]
+deps = ["DataStructures", "LinearAlgebra"]
+git-tree-sha1 = "9b23c31e76e333e6fb4c1595ae6afa74966a729e"
+uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
+version = "2.9.4"
+
+[[deps.REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
 [[deps.Random]]
 deps = ["SHA", "Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[deps.RecipesBase]]
+deps = ["PrecompileTools"]
+git-tree-sha1 = "5c3d09cc4f31f5fc6af001c250bf1278733100ff"
+uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+version = "1.3.4"
+
+[[deps.Reexport]]
+git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "1.2.2"
 
 [[deps.Requires]]
 deps = ["UUIDs"]
 git-tree-sha1 = "838a3a4188e2ded87a4f9f184b4b0d78a1e91cb7"
 uuid = "ae029012-a4dd-5104-9daa-d747884805df"
 version = "1.3.0"
+
+[[deps.Rmath]]
+deps = ["Random", "Rmath_jll"]
+git-tree-sha1 = "f65dcb5fa46aee0cf9ed6274ccbd597adc49aa7b"
+uuid = "79098fc4-a85e-5d69-aa6a-4863f24498fa"
+version = "0.7.1"
+
+[[deps.Rmath_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "6ed52fdd3382cf21947b15e8870ac0ddbff736da"
+uuid = "f50d1b31-88e8-58de-be2c-1cc44531875f"
+version = "0.4.0+0"
 
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -220,11 +376,17 @@ version = "1.2.1"
 deps = ["LinearAlgebra", "Random"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
+[[deps.SpecialFunctions]]
+deps = ["ChainRulesCore", "IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
+git-tree-sha1 = "e2cfc4012a19088254b3950b85c3c1d8882d864d"
+uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
+version = "2.3.1"
+
 [[deps.StaticArrays]]
 deps = ["LinearAlgebra", "PrecompileTools", "Random", "StaticArraysCore", "Statistics"]
-git-tree-sha1 = "f68dd04d131d9a8a8eb836173ee8f105c360b0c5"
+git-tree-sha1 = "bf074c045d3d5ffd956fa0a461da38a44685d6b2"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.9.1"
+version = "1.9.3"
 
 [[deps.StaticArraysCore]]
 git-tree-sha1 = "36b3d696ce6366023a0ea192b4cd442268995a0d"
@@ -247,10 +409,25 @@ git-tree-sha1 = "1d77abd07f617c4868c33d4f5b9e1dbb2643c9cf"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 version = "0.34.2"
 
+[[deps.StatsFuns]]
+deps = ["ChainRulesCore", "HypergeometricFunctions", "InverseFunctions", "IrrationalConstants", "LogExpFunctions", "Reexport", "Rmath", "SpecialFunctions"]
+git-tree-sha1 = "cef0472124fab0695b58ca35a77c6fb942fdab8a"
+uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
+version = "1.3.1"
+
+[[deps.SuiteSparse]]
+deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
+uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
+
 [[deps.TOML]]
 deps = ["Dates"]
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 version = "1.0.0"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.1"
 
 [[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
@@ -269,7 +446,22 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 [[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.2.12+3"
+
 [[deps.libblastrampoline_jll]]
 deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
 uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
 version = "5.1.1+0"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.48.0+0"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.4.0+0"

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 MemPool = "f9f48841-c794-520a-933b-121f7ba6ed94"
+OnlineStats = "a15396b6-48d5-5d58-9928-6d29437db91e"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -27,6 +28,7 @@ DataStructures = "0.18"
 Graphs = "1"
 MacroTools = "0.5"
 MemPool = "0.4.6"
+OnlineStats = "1"
 PrecompileTools = "1.2"
 Requires = "1"
 ScopedValues = "1.1"
@@ -41,4 +43,4 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Colors", "Test", "Pkg"]
+test = ["Colors", "Pkg", "Test"]

--- a/docs/src/darray.md
+++ b/docs/src/darray.md
@@ -210,3 +210,18 @@ julia> collect(DZ)
 A variety of other operations exist on the `DArray`, and it should generally
 behavior otherwise similar to any other `AbstractArray` type. If you find that
 it's missing an operation that you need, please file an issue!
+
+### Known Supported Operations
+
+This list is not exhaustive, but documents operations which are known to work well with the `DArray`:
+
+From `Base`:
+- Broadcasting
+- `map`/`reduce`/`mapreduce`
+- `sum`/`prod`
+- `minimum`/`maximum`/`extrema`
+
+From `Statistics`:
+- `mean`
+- `var`
+- `std`

--- a/src/array/alloc.jl
+++ b/src/array/alloc.jl
@@ -31,12 +31,8 @@ function stage(ctx, a::AllocateArray)
 end
 
 function Base.rand(p::Blocks, eltype::Type, dims)
-    s = rand(UInt)
-    f = function (idx, x...)
-        rand(MersenneTwister(s+idx), x...)
-    end
     d = ArrayDomain(map(x->1:x, dims))
-    a = AllocateArray(eltype, f, d, partition(p, d), p)
+    a = AllocateArray(eltype, (_, x...) -> rand(x...), d, partition(p, d), p)
     return _to_darray(a)
 end
 
@@ -44,16 +40,14 @@ Base.rand(p::Blocks, t::Type, dims::Integer...) = rand(p, t, dims)
 Base.rand(p::Blocks, dims::Integer...) = rand(p, Float64, dims)
 Base.rand(p::Blocks, dims::Tuple) = rand(p, Float64, dims)
 
-function Base.randn(p::Blocks, dims)
-    s = rand(UInt)
-    f = function (idx, x...)
-        randn(MersenneTwister(s+idx), x...)
-    end
+function Base.randn(p::Blocks, eltype::Type, dims)
     d = ArrayDomain(map(x->1:x, dims))
-    a = AllocateArray(Float64, f, d, partition(p, d), p)
+    a = AllocateArray(Float64, (_, x...) -> randn(x...), d, partition(p, d), p)
     return _to_darray(a)
 end
+Base.randn(p::Blocks, t::Type, dims::Integer...) = randn(p, t, dims)
 Base.randn(p::Blocks, dims::Integer...) = randn(p, dims)
+Base.randn(p::Blocks, dims::Tuple) = randn(p, Float64, dims)
 
 function Base.ones(p::Blocks, eltype::Type, dims)
     d = ArrayDomain(map(x->1:x, dims))

--- a/src/array/map-reduce.jl
+++ b/src/array/map-reduce.jl
@@ -1,6 +1,5 @@
-import Base: reduce, map, mapreduce
-
 #### Map
+
 struct Map{T,N} <: ArrayOp{T,N}
     f::Function
     inputs::Tuple
@@ -11,7 +10,7 @@ Map(f, inputs::Tuple) = Map{Any, ndims(inputs[1])}(f, inputs)
 
 function stage(ctx::Context, node::Map)
     inputs = Any[stage(ctx, n) for n in node.inputs]
-    primary = inputs[1] # all others will align to this guy
+    primary = inputs[1] # all others will align to this
     domains = domainchunks(primary)
     thunks = similar(domains, Any)
     partitioning = primary.partitioning
@@ -25,78 +24,72 @@ function stage(ctx::Context, node::Map)
     return DArray(RT, domain(primary), domainchunks(primary), thunks, partitioning, concat)
 end
 
-map(f, x::ArrayOp, xs::ArrayOp...) = _to_darray(Map(f, (x, xs...)))
+Base.map(f, x::DArray, xs::DArray...) = _to_darray(Map(f, (x, xs...)))
 
-#### Reduce
+#### MapReduce
 
-import Base.reduce
-import Statistics: sum, prod, mean
-
-struct ReduceBlock <: Computation
-    op::Function
-    op_master::Function
-    input::ArrayOp
-    get_result::Bool
+struct MapReduce{T,N} <: ArrayOp{T,N}
+    f::Function
+    op_inner::Union{Function,Nothing}
+    op_outer::Function
+    input::DArray
+    dims::Union{Tuple,Nothing}
+    init
+end
+function MapReduce(f, op_inner, op_outer, input::DArray{T,N}, dims, init) where {T,N}
+    T_new = Base._return_type(op_outer, Tuple{T, T})
+    if T_new === Union{}
+        T_new = Any
+    end
+    _dims = dims === nothing ? ntuple(identity, N) : Tuple(dims)
+    N_new = N - length(_dims)
+    return MapReduce{T_new,N_new}(f, op_inner, op_outer, input, dims, init)
 end
 
-function stage(ctx::Context, r::ReduceBlock)
+function stage(ctx::Context, r::MapReduce{T,N}) where {T,N}
     inp = stage(ctx, r.input)
-    reduced_parts = map(x -> (Dagger.@spawn get_result=r.get_result r.op(x)), chunks(inp))
-    r_op_master(args...,) = r.op_master(args)
-    Dagger.@spawn meta=true r_op_master(reduced_parts...)
-end
 
-reduceblock_async(f, x::ArrayOp; get_result=true) = ReduceBlock(f, f, x, get_result)
-reduceblock_async(f, g::Function, x::ArrayOp; get_result=true) = ReduceBlock(f, g, x, get_result)
-
-reduceblock(f, x::ArrayOp) = fetch(reduceblock_async(f, x))
-reduceblock(f, g::Function, x::ArrayOp) = fetch(reduceblock_async(f, g, x))
-
-reduce_async(f::Function, x::ArrayOp) = reduceblock_async(xs->reduce(f,xs), xs->reduce(f,xs), x)
-
-_reduce_maybeblock(f::Function, _::Function, x, dims::Nothing) = reduceblock(f, f, x)
-_reduce_maybeblock(_::Function, f::Function, x, dims::Int) = reduce(f, x; dims)
-
-sum(x::ArrayOp; dims::Union{Int,Nothing} = nothing) =
-    _reduce_maybeblock(sum, Base.add_sum, x, dims)
-sum(f::Function, x::ArrayOp) = reduceblock(a->sum(f, a), sum, x)
-
-prod(x::ArrayOp; dims::Union{Int,Nothing} = nothing) =
-    _reduce_maybeblock(prod, Base.mul_prod, x, dims)
-prod(f::Function, x::ArrayOp) = reduceblock(a->prod(f, a), prod, x)
-
-mean(x::ArrayOp; dims::Union{Int,Nothing} = nothing) =
-    _reduce_maybeblock(mean, mean, x, dims)
-mean(f::Function, x::ArrayOp) = reduceblock(a->mean(f, a), mean, x)
-
-mapreduce(f::Function, g::Function, x::ArrayOp) = reduce(g, map(f, x))
-
-function mapreducebykey_seq(f, op, itr, dict=Dict())
-    for x in itr
-        y = f(x)
-        if haskey(dict, y[1])
-            dict[y[1]] = op(dict[y[1]], y[2])
+    # Reduce partitions individually
+    dims = r.dims === nothing ? Colon() : r.dims
+    reduced_parts = map(chunks(inp)) do part
+        if r.op_inner !== nothing
+            Dagger.@spawn r.op_inner(r.f, part; dims, init=r.init)
         else
-            dict[y[1]] = y[2]
+            Dagger.@spawn mapreduce(r.f, r.op_outer, part; dims=dims, init=r.init)
         end
     end
-    dict
+
+    # Tree-reduce intermediate reductions
+    dims_materialized = dims === Colon() ? ntuple(identity, ndims(inp)) : dims
+    treered_f(op, x, y) = op.(x, y)
+    thunks = treereducedim(reduced_parts, dims_materialized) do x, y
+        Dagger.@spawn treered_f(r.op_outer, x, y)
+    end
+
+    c = domainchunks(inp)
+    colons = Any[Colon() for x in size(c)]
+    nd = ndims(domain(inp))
+    colons[[Iterators.filter(d->d<=nd, dims_materialized)...]] .= 1
+    dmn = c[colons...]
+    d = reduce(domain(inp); dims=dims_materialized)
+    ds = reduce(domainchunks(inp); dims=dims_materialized)
+    return DArray(T, d, ds, thunks, inp.partitioning, inp.concat)
 end
 
-function merge_reducebykey(op)
-    xs -> reduce((d,x) -> reducebykey_seq(op, x, d), Dict(), xs)
+# Async reduction
+_mapreduce_maybesync(f, op_inner, op_outer, x, dims::Int, init) =
+    _to_darray(MapReduce(f, op_inner, op_outer, x, (dims,), init))
+_mapreduce_maybesync(f, op_inner, op_outer, x, dims::Tuple, init) =
+    _to_darray(MapReduce(f, op_inner, op_outer, x, dims, init))
+# Sync reduction
+_mapreduce_maybesync(f, op_inner, op_outer, x, ::Colon, init) =
+    _mapreduce_maybesync(f, op_inner, op_outer, x, nothing, init)
+function _mapreduce_maybesync(f, op_inner, op_outer, x::DArray{T,N}, dims::Nothing, init) where {T,N}
+    Dx = _to_darray(MapReduce(f, op_inner, op_outer, x, dims, init))
+    return collect(Dx)
 end
-reducebykey_seq(op, itr,dict=Dict()) = mapreducebykey_seq(Base.IdFun(), op, itr, dict)
-reducebykey(op, input) = reduceblock(itr->reducebykey_seq(op, itr), merge_reducebykey(op), input)
 
-
-struct Reducedim{T,N} <: ArrayOp{T,N}
-    op::Function
-    input::ArrayOp
-    dims::Tuple
-end
-
-function Base.size(r::Reducedim)
+function Base.size(r::MapReduce)
     sz = size(r.input)
     ntuple(length(sz)) do i
         if i in r.dims
@@ -115,36 +108,72 @@ function Base.reduce(dom::ArrayDomain; dims)
     end
 end
 
-function Reducedim(op, input, dims)
-    T = eltype(input)
-    Reducedim{T,ndims(input)}(op, input, dims)
-end
+#### High-Level MapReduce
 
-function Base.reduce(f::Function, x::ArrayOp; dims = nothing)
-    if dims === nothing
-        return fetch(reduce_async(f,x))
-    elseif dims isa Int
-        dims = (dims,)
-    end
-    return _to_darray(Reducedim(f, x, dims::Tuple))
-end
+import Statistics: mean, var, std
+import OnlineStats
 
-function stage(ctx::Context, r::Reducedim)
-    inp = stage(ctx, r.input)
-    thunks = let op = r.op, dims=r.dims
-        # do reducedim on each block
-        tmp = map(p->Dagger.spawn(b->reduce(op,b,dims=dims), p), chunks(inp))
-        # combine the results in tree fashion
-        treereducedim(tmp, r.dims) do x,y
-            Dagger.@spawn op(x,y)
+Base.mapreduce(f::Function, op::Function, x::DArray; dims=nothing, init=Base._InitialValue()) =
+    _mapreduce_maybesync(f, nothing, op, x, dims, init)
+
+Base.sum(x::DArray; dims=nothing, init=Base._InitialValue()) =
+    sum(identity, x; dims, init)
+Base.sum(f::Function, x::DArray; dims=nothing, init=Base._InitialValue()) =
+    _mapreduce_maybesync(f, sum, Base.add_sum, x, dims, init)
+
+Base.prod(x::DArray; dims=nothing, init=Base._InitialValue()) =
+    prod(identity, x; dims, init)
+Base.prod(f::Function, x::DArray; dims=nothing, init=Base._InitialValue()) =
+    _mapreduce_maybesync(f, prod, Base.mul_prod, x, dims, init)
+
+Base.extrema(x::DArray; dims=nothing, init=Base._InitialValue()) =
+    extrema(identity, x; dims, init)
+function Base.extrema(f::Function, x::DArray; dims=nothing, init=Base._InitialValue())
+    if length(x) == 0
+        if init == Base._InitialValue()
+            # Throws an appropriate error
+            Base.reduce_empty(extrema, eltype(x))
+        else
+            return init
         end
     end
-    c = domainchunks(inp)
-    colons = Any[Colon() for x in size(c)]
-    nd = ndims(domain(inp))
-    colons[[Iterators.filter(d->d<=nd, r.dims)...]] .= 1
-    dmn = c[colons...]
-    d = reduce(domain(inp), dims=r.dims)
-    ds = reduce(domainchunks(inp), dims=r.dims)
-    return DArray(eltype(inp), d, ds, thunks, inp.partitioning, inp.concat)
+    result = _mapreduce_maybesync(f, _extrema_inner, _extrema_outer, x, dims, init)
+    return map(x->(x.min, x.max), result)
 end
+# We need a custom type because the `Tuple` return type of `extrema` should
+# really act as a `Number`
+struct Extrema{T} <: Number
+    min::T
+    max::T
+end
+Extrema(minmax::NTuple{2,T}) where T = Extrema{T}(minmax[1], minmax[2])
+function _extrema_inner(f, X; dims, init)
+    result = extrema(f, X; dims, init)
+    if dims === Colon()
+        return Extrema(result)
+    else
+        return map(Extrema, result)
+    end
+end
+_extrema_outer(x::Extrema, y::Extrema) =
+    Extrema(min(x.min, y.min), max(x.max, y.max))
+
+function _onlinestats_mapreduce(f, x::DArray{T}, stat; dims=nothing) where T
+    _f(x) = fit!(stat(T), f(x))
+    init = stat(T)
+    return _onlinestats_finish(mapreduce(_f, merge, x; dims, init), dims)
+end
+_onlinestats_finish(result, ::Union{Nothing,Colon}) = OnlineStats.value(result)
+_onlinestats_finish(result, ::Union{Int,Dims}) = map(OnlineStats.value, result)
+
+mean(x::DArray; dims=nothing) = mean(identity, x; dims)
+mean(f::Function, x::DArray; dims=nothing) =
+    _onlinestats_mapreduce(f, x, OnlineStats.Mean; dims)
+
+var(x::DArray; dims=nothing) = var(identity, x; dims)
+var(f::Function, x::DArray; dims=nothing) =
+    _onlinestats_mapreduce(f, x, OnlineStats.Variance; dims)
+
+std(x::DArray; dims=nothing) = std(identity, x; dims)
+std(f::Function, x::DArray; dims=nothing) =
+    map(sqrt, var(f, x; dims))


### PR DESCRIPTION
Improves the behavior of operations based on `mapreduce`, and adds `var`, `std`, and `extrema` operations, while enhancing tests for these and existing operations.

Fixes #475 