### PR TITLE
Fix import of ScopedValues in Julia v1.11

### DIFF
--- a/src/Dagger.jl
+++ b/src/Dagger.jl
@@ -12,8 +12,10 @@ import LinearAlgebra: transpose
 
 using UUIDs
 
-if !isdefined(Base, :with)
-using ScopedValues
+if !isdefined(Base, :ScopedValues)
+    import ScopedValues: ScopedValue, with
+else
+    import Base.ScopedValues: ScopedValue, with
 end
 
 using Requires


### PR DESCRIPTION
Previously `ScopedValues.with` was exported from `Base` but that was changed recently, so the ScopedValues check was failing. Now we check if the module is present instead.

Should fix #488. I still this warning when running the tests:
```julia
┌ ScopedValues                                                                                                                                                                                                                                 
│  WARNING: could not import ScopedValues.current_scope into ScopedValues                                                                                                                                                                      
└    
```
But we don't use `current_scope()` anywhere so I assume it's coming from `Base` :shrug: 