### PR TITLE
Add num_processors helper

### DIFF
--- a/src/utils/scopes.jl
+++ b/src/utils/scopes.jl
@@ -6,7 +6,7 @@
 Returns the set of all processors (across all Distributed workers) that are
 compatible with the given scope.
 """
-function compatible_processors(scope::AbstractScope, ctx::Context=Sch.eager_context())
+function compatible_processors(scope::AbstractScope=get_options(:scope, DefaultScope()), ctx::Context=Sch.eager_context())
     compat_procs = Set{Processor}()
     for gproc in procs(ctx)
         # Fast-path in case entire process is incompatible
@@ -21,4 +21,21 @@ function compatible_processors(scope::AbstractScope, ctx::Context=Sch.eager_cont
         end
     end
     return compat_procs
+end
+
+"""
+    num_processors(scope::AbstractScope=DefaultScope(), all::Bool=false) -> Int
+
+Returns the number of processors available to Dagger by default, or if
+specified, according to `scope`. If `all=true`, instead returns the number of
+processors known to Dagger, whether or not they've been disabled by the user.
+Most users will want to use `num_processors()`.
+"""
+function num_processors(scope::AbstractScope=get_options(:scope, DefaultScope());
+                        all::Bool=false)
+    if all
+        return length(all_processors())
+    else
+        return length(compatible_processors(scope))
+    end
 end

--- a/test/processors.jl
+++ b/test/processors.jl
@@ -100,5 +100,6 @@ end
             w_procs = Dagger.get_processors(OSProc(w))
             @test all(proc->proc in all_procs, w_procs)
         end
+        @test Dagger.num_processors(;all=true) == length(all_procs)
     end
 end

--- a/test/scopes.jl
+++ b/test/scopes.jl
@@ -241,16 +241,19 @@
     @testset "compatible_processors" begin
         scope = Dagger.scope(workers=[])
         comp_procs = Dagger.compatible_processors(scope)
+        @test Dagger.num_processors(scope) == length(comp_procs)
         @test !any(proc->proc in comp_procs, Dagger.get_processors(OSProc(wid1)))
         @test !any(proc->proc in comp_procs, Dagger.get_processors(OSProc(wid2)))
 
         scope = Dagger.scope(worker=wid1)
         comp_procs = Dagger.compatible_processors(scope)
+        @test Dagger.num_processors(scope) == length(comp_procs)
         @test all(proc->proc in comp_procs, Dagger.get_processors(OSProc(wid1)))
         @test !any(proc->proc in comp_procs, Dagger.get_processors(OSProc(wid2)))
 
         scope = Dagger.scope(worker=wid1, thread=2)
         comp_procs = Dagger.compatible_processors(scope)
+        @test Dagger.num_processors(scope) == length(comp_procs)
         @test length(comp_procs) == 1
         @test !all(proc->proc in comp_procs, Dagger.get_processors(OSProc(wid1)))
         @test !all(proc->proc in comp_procs, Dagger.get_processors(OSProc(wid2)))
@@ -258,8 +261,12 @@
 
         scope = Dagger.scope(workers=[wid1, wid2])
         comp_procs = Dagger.compatible_processors(scope)
+        @test Dagger.num_processors(scope) == length(comp_procs)
         @test all(proc->proc in comp_procs, Dagger.get_processors(OSProc(wid1)))
         @test all(proc->proc in comp_procs, Dagger.get_processors(OSProc(wid2)))
+
+        comp_procs = Dagger.compatible_processors()
+        @test Dagger.num_processors() == length(comp_procs)
     end
 
     rmprocs([wid1, wid2])


### PR DESCRIPTION
Adds a `num_processors()` helper, to assist users and libraries with implementing Dagger-powered parallelism utilities.

Closes https://github.com/JuliaParallel/Dagger.jl/issues/474