### PR TITLE
Cleanup imports with ExplicitImports.jl

### DIFF
--- a/ext/GraphVizExt.jl
+++ b/ext/GraphVizExt.jl
@@ -9,7 +9,7 @@ end
 import Dagger
 import Dagger: EagerThunk, Chunk, Processor
 import Dagger.TimespanLogging: Timespan
-using Dagger.Graphs
+import Graphs: SimpleDiGraph, add_edge!, add_vertex!, inneighbors, outneighbors, vertices, is_directed, edges, nv
 
 function pretty_time(t; digits=3)
     r(t) = round(t; digits)

--- a/src/Dagger.jl
+++ b/src/Dagger.jl
@@ -1,16 +1,20 @@
 module Dagger
 
-using Distributed, SharedArrays, Serialization
+import Serialization
+import Serialization: AbstractSerializer, serialize, deserialize
+import SparseArrays: sprand, SparseMatrixCSC
 
-using MemPool
+import MemPool
+import MemPool: DRef, FileRef, poolget, poolset
 
-import Base: collect, adjoint, reduce
-import Distributed: procs
+import Base: collect, reduce
+import Distributed
+import Distributed: Future, RemoteChannel, myid, workers, nworkers, procs, remotecall, remotecall_wait, remotecall_fetch
 
-using LinearAlgebra
-import LinearAlgebra: transpose
+import LinearAlgebra
+import LinearAlgebra: Adjoint, BLAS, Diagonal, LAPACK, LowerTriangular, PosDefException, Transpose, UpperTriangular, diagind, ishermitian, issymmetric
 
-using UUIDs
+import UUIDs: UUID, uuid4
 
 if !isdefined(Base, :ScopedValues)
     import ScopedValues: ScopedValue, with
@@ -22,8 +26,8 @@ if !isdefined(Base, :get_extension)
 using Requires
 end
 
-using MacroTools
-using TimespanLogging
+import TimespanLogging
+import TimespanLogging: timespan_start, timespan_finish
 
 include("lib/util.jl")
 include("utils/dagdebug.jl")
@@ -31,6 +35,8 @@ include("utils/dagdebug.jl")
 # Distributed data
 include("utils/locked-object.jl")
 include("utils/tasks.jl")
+
+import MacroTools: @capture
 include("options.jl")
 include("processor.jl")
 include("threadproc.jl")
@@ -85,7 +91,7 @@ include("utils/logging-events.jl")
 include("utils/logging.jl")
 
 # Precompilation
-using PrecompileTools
+import PrecompileTools: @compile_workload
 include("precompile.jl")
 
 function __init__()

--- a/src/array/alloc.jl
+++ b/src/array/alloc.jl
@@ -1,6 +1,5 @@
 import Base: cat
-using SparseArrays, Random
-import SparseArrays: sprand
+import Random: MersenneTwister
 export partition
 
 mutable struct AllocateArray{T,N} <: ArrayOp{T,N}

--- a/src/array/darray.jl
+++ b/src/array/darray.jl
@@ -1,6 +1,4 @@
 import Base: ==, fetch
-using Serialization
-import Serialization: serialize, deserialize
 
 ###### Array Domains ######
 

--- a/src/array/indexing.jl
+++ b/src/array/indexing.jl
@@ -1,4 +1,4 @@
-using TaskLocalValues
+import TaskLocalValues: TaskLocalValue
 
 ### getindex
 

--- a/src/array/operators.jl
+++ b/src/array/operators.jl
@@ -1,10 +1,3 @@
-import Base: exp, expm1, log, log10, log1p, sqrt, cbrt, exponent,
-             significand, sin, sinpi, cos, cospi, tan, sec, cot, csc,
-             sinh, cosh, tanh, coth, sech, csch,
-             asin, acos, atan, acot, asec, acsc,
-             asinh, acosh, atanh, acoth, asech, acsch, sinc, cosc,
-             +, -, %, &, *
-
 import Base: broadcast
 import Base: Broadcast
 import Base.Broadcast: Broadcasted, BroadcastStyle, combine_eltypes

--- a/src/array/sort.jl
+++ b/src/array/sort.jl
@@ -1,7 +1,7 @@
-import Base.Sort: Forward, Ordering, Algorithm, lt
-using Distributed
+import Base.Sort: Forward, Ordering, lt
+import SharedArrays: SharedArray
 
-using StatsBase
+import StatsBase: fit!, sample
 
 
 function getmedians(x, n)

--- a/src/array/sparse_partition.jl
+++ b/src/array/sparse_partition.jl
@@ -1,5 +1,4 @@
 export partition_sparse
-using SparseArrays
 
 function partition_sparse(colptr, nnz, sz, nparts)
     nnz_per_chunk = nnz/nparts

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -1,5 +1,3 @@
-using Serialization
-
 export domain, UnitDomain, project, alignfirst, ArrayDomain
 
 import Base: isempty, getindex, intersect, ==, size, length, ndims

--- a/src/datadeps.jl
+++ b/src/datadeps.jl
@@ -1,4 +1,4 @@
-using Graphs
+import Graphs: SimpleDiGraph, add_edge!, add_vertex!, inneighbors, outneighbors, nv
 
 export In, Out, InOut, spawn_datadeps
 

--- a/src/sch/Sch.jl
+++ b/src/sch/Sch.jl
@@ -1,16 +1,15 @@
 module Sch
 
-using Distributed
+import Distributed: Future, ProcessExitedException, RemoteChannel, RemoteException, myid, remote_do, remotecall_fetch, remotecall_wait, workers
 import MemPool
 import MemPool: DRef, StorageResource
-import MemPool: poolset, storage_available, storage_capacity, storage_utilized, externally_varying
-import Statistics: mean
+import MemPool: poolset, storage_capacity, storage_utilized
 import Random: randperm
 import Base: @invokelatest
 
 import ..Dagger
 import ..Dagger: Context, Processor, Thunk, WeakThunk, ThunkFuture, ThunkFailedException, Chunk, WeakChunk, OSProc, AnyScope, DefaultScope, LockedObject
-import ..Dagger: order, dependents, noffspring, istask, inputs, unwrap_weak_checked, affinity, tochunk, timespan_start, timespan_finish, procs, move, chunktype, processor, default_enabled, get_processors, get_parent, execute!, rmprocs!, addprocs!, thunk_processor, constrain, cputhreadtime
+import ..Dagger: order, dependents, noffspring, istask, inputs, unwrap_weak_checked, affinity, tochunk, timespan_start, timespan_finish, procs, move, chunktype, processor, get_processors, get_parent, execute!, rmprocs!, thunk_processor, constrain, cputhreadtime
 import ..Dagger: @dagdebug, @safe_lock_spin1
 import DataStructures: PriorityQueue, enqueue!, dequeue_pair!, peek
 
@@ -1473,7 +1472,7 @@ function do_task(to_proc, task_desc)
                 break
             end
             if est_alloc_util + real_alloc_util > storage_cap
-                if externally_varying(to_storage)
+                if MemPool.externally_varying(to_storage)
                     debug_storage("WARN: Insufficient space and allocation behavior is externally varying on $to_storage_name, proceeding anyway")
                     break
                 end

--- a/src/utils/logging-events.jl
+++ b/src/utils/logging-events.jl
@@ -3,9 +3,8 @@ module Events
 import ..Dagger
 import ..Dagger: Context, Chunk
 
-using ..TimespanLogging
+import ..TimespanLogging
 import .TimespanLogging: Event, init_similar
-import .TimespanLogging.Events: EventSaturation
 
 TimespanLogging.log_sink(ctx::Context) = ctx.log_sink
 TimespanLogging.profile(ctx::Context, category, id, tl) =


### PR DESCRIPTION
TL;DR:
- Replaced all uses of `using` with explicit imports
- Removed old imports

This should be a purely cosmetic change.