### PR TITLE
logging/viz: Some fixes, and more docstrings

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,7 +1,10 @@
 [deps]
 Dagger = "d58978e5-989f-55fb-8d15-ea34adc7bf54"
 DaggerWebDash = "cfc5aa84-1a2a-41ab-b391-ede92ecae40c"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+GraphViz = "f526b714-d49f-11e8-06ff-31ed36ee7ee0"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 TimespanLogging = "a526e669-04d3-4846-9525-c66122c55f63"
 
 [compat]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,9 +1,11 @@
-using Dagger, TimespanLogging, DaggerWebDash
+using Dagger, TimespanLogging, DaggerWebDash, GraphViz, Plots, DataFrames
+const GraphVizExt = something(Base.get_extension(Dagger, :GraphVizExt))
+const PlotsExt = something(Base.get_extension(Dagger, :PlotsExt))
 using Documenter
 import Documenter.Remotes: GitHub
 
 makedocs(;
-    modules = [Dagger, TimespanLogging, DaggerWebDash],
+    modules = [Dagger, TimespanLogging, DaggerWebDash, GraphVizExt, PlotsExt],
     authors = "JuliaParallel and contributors",
     repo = GitHub("JuliaParallel", "Dagger.jl"),
     sitename = "Dagger.jl",

--- a/docs/src/api-timespanlogging/functions.md
+++ b/docs/src/api-timespanlogging/functions.md
@@ -12,7 +12,6 @@ Pages = ["functions.md"]
 timespan_start
 timespan_finish
 get_logs!
-make_timespan
 ```
 
 ## Logging Metric Functions

--- a/docs/src/api-timespanlogging/types.md
+++ b/docs/src/api-timespanlogging/types.md
@@ -14,11 +14,6 @@ LocalEventLog
 NoOpLog
 ```
 
-## Event Types
-```@docs
-Event
-```
-
 ## Built-in Event Types
 ```@docs
 Events.CoreMetrics
@@ -30,5 +25,4 @@ Events.MemoryFree
 Events.EventSaturation
 Events.DebugMetrics
 Events.LogWindow
-```
 ```

--- a/docs/src/logging-visualization.md
+++ b/docs/src/logging-visualization.md
@@ -15,8 +15,7 @@ by libraries or directly by the user, using multiple dispatch on
 identifying the rendering mode to use. From the user's perspective, `show_logs`
 and `render_logs` take not a `Val` but a raw `Symbol`, which will be internally
 converted to a `Val` for dispatch purposes
-(i.e. `render_logs(logs::Dict, :myrenderer)` -> 
-`render_logs(logs, Val{:myrenderer}())`).
+(i.e. `render_logs(logs::Dict, :myrenderer)` -> `render_logs(logs, Val{:myrenderer}())`).
 
 Built-in rendering support exists for:
 - `render_logs(logs, :graphviz)` to generate a graph diagram of executed tasks and their dependencies

--- a/ext/GraphVizExt.jl
+++ b/ext/GraphVizExt.jl
@@ -9,7 +9,7 @@ end
 import Dagger
 import Dagger: EagerThunk, Chunk, Processor
 import Dagger.TimespanLogging: Timespan
-import Graphs: SimpleDiGraph, add_edge!, add_vertex!, inneighbors, outneighbors, vertices, is_directed, edges, nv
+import Graphs: SimpleDiGraph, add_edge!, add_vertex!, inneighbors, outneighbors, vertices, is_directed, edges, nv, src, dst
 
 function pretty_time(t; digits=3)
     r(t) = round(t; digits)

--- a/ext/GraphVizExt.jl
+++ b/ext/GraphVizExt.jl
@@ -23,6 +23,23 @@ function pretty_time(t; digits=3)
         "$(r(t)) ns"
     end
 end
+
+"""
+    Dagger.render_logs(logs::Dict, ::Val{:graphviz}; disconnected=false,
+                       color_by=:fn, layout_engine="dot",
+                       times::Bool=true, times_digits::Integer=3)
+
+Render a graph of the task dependencies and data dependencies in `logs` using GraphViz.
+
+Requires the following events enabled in `enable_logging!`: `taskdeps`, `tasknames`, `taskargs`, `taskargmoves`
+
+Options:
+- `disconnected`: If `true`, render disconnected vertices (tasks or arguments without upstream/downstream dependencies)
+- `color_by`: How to color tasks; if `:fn`, then color by unique function name, if `:proc`, then color by unique processor
+- `layout_engine`: The layout engine to use for GraphViz
+- `times`: If `true`, annotate each task with its start and finish times
+- `times_digits`: Number of digits to display in the time annotations
+"""
 function Dagger.render_logs(logs::Dict, ::Val{:graphviz}; disconnected=false,
                             color_by=:fn, layout_engine="dot",
                             times::Bool=true, times_digits::Integer=3)

--- a/ext/PlotsExt.jl
+++ b/ext/PlotsExt.jl
@@ -67,6 +67,11 @@ end
 
 # Implementation adapted from:
 # https://discourse.julialang.org/t/how-to-make-a-gantt-plot-with-plots-jl/95165/7
+"""
+    Dagger.render_logs(logs::Dict, ::Val{:plots_gantt}; kwargs...)
+
+Render a Gantt chart of task execution in `logs` using Plots. `kwargs` are passed to `plot` directly.
+"""
 function Dagger.render_logs(logs::Dict, ::Val{:plots_gantt}; kwargs...)
     df = logs_to_df(logs)
 

--- a/src/sch/dynamic.jl
+++ b/src/sch/dynamic.jl
@@ -7,6 +7,7 @@ struct ThunkID
     ref::Union{DRef,Nothing}
 end
 ThunkID(id::Int) = ThunkID(id, nothing)
+Dagger.istask(::ThunkID) = true
 
 "A handle to the scheduler, used by dynamic thunks."
 struct SchedulerHandle

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -1,7 +1,22 @@
 # Printable representation
 
-show_logs(io::IO, t, vizmode::Symbol; options...) =
-    show_logs(io, t, Val{vizmode}(); options...)
+"""
+    show_logs(io::IO, logs, vizmode::Symbol; options...)
+    show_logs(io::IO, t, logs, vizmode::Symbol; options...)
+
+Displays the logs of a task `t` and/or logs object `logs` using the visualization mode `vizmode`, which is written to the given IO stream `io`. `options` are specific to the visualization mode.
+
+---
+
+    show_logs(logs, vizmode::Symbol; options...)
+    show_logs(t, logs, vizmode::Symbol; options...)
+
+Returns a string representation of the logs of a task `t` and/or logs object `logs` using the visualization mode `vizmode`. `options` are specific to the visualization mode.
+"""
+function show_logs end
+
+show_logs(io::IO, logs, vizmode::Symbol; options...) =
+    show_logs(io, logs, Val{vizmode}(); options...)
 show_logs(io::IO, t, logs, vizmode::Symbol; options...) =
     show_logs(io, t, Val{vizmode}(); options...)
 show_logs(io::IO, ::T, ::Val{vizmode}; options...) where {T,vizmode} =
@@ -9,11 +24,11 @@ show_logs(io::IO, ::T, ::Val{vizmode}; options...) where {T,vizmode} =
 show_logs(io::IO, ::T, ::Logs, ::Val{vizmode}; options...) where {T,Logs,vizmode} =
     throw(ArgumentError("show_logs: Task type `$T` and logs type `$Logs` not supported for visualization mode `$(repr(vizmode))`"))
 
-show_logs(t, vizmode::Symbol; options...) =
-    show_logs(t, Val{vizmode}(); options...)
+show_logs(logs, vizmode::Symbol; options...) =
+    show_logs(logs, Val{vizmode}(); options...)
 show_logs(t, logs, vizmode::Symbol; options...) =
     show_logs(t, logs, Val{vizmode}(); options...)
-function show_logs(t, ::Val{vizmode}; options...) where vizmode
+function show_logs(logs, ::Val{vizmode}; options...) where vizmode
     iob = IOBuffer()
     show_logs(iob, t, Val{vizmode}(); options...)
     return String(take!(iob))
@@ -26,10 +41,18 @@ end
 
 # Displayable representation
 
-render_logs(t, vizmode::Symbol; options...) =
-    render_logs(t, Val{vizmode}(); options...)
+"""
+    render_logs(logs, vizmode::Symbol; options...)
+    render_logs(t, logs, vizmode::Symbol; options...)
+
+Returns a displayable representation of the logs of a task `t` and/or logs object `logs` using the visualization mode `vizmode`. `options` are specific to the visualization mode.
+"""
+function render_logs end
+
+render_logs(logs, vizmode::Symbol; options...) =
+    render_logs(logs, Val{vizmode}(); options...)
 render_logs(t, logs, vizmode::Symbol; options...) =
-    render_logs(t, Val{vizmode}(); options...)
+    render_logs(t, logs, Val{vizmode}(); options...)
 render_logs(::T, ::Val{vizmode}; options...) where {T,vizmode} =
     throw(ArgumentError("render_logs: Task/logs type `$T` not supported for visualization mode `$(repr(vizmode))`"))
 render_logs(::T, ::Logs, ::Val{vizmode}; options...) where {T,Logs,vizmode} =


### PR DESCRIPTION
Addresses a bug and missing documentation reported in https://github.com/JuliaParallel/Dagger.jl/issues/512. I'm having trouble getting the `GraphVizExt` and `PlotsExt` docstrings to show up in the docs without errors during cross-reference, so this will have to suffice until we figure that out.