### PR TITLE
Add support for limiting the evaluations of a streaming DAG

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,8 @@
     sandbox_capable: "true"
     os: linux
     arch: x86_64
-  command: "julia --project -e 'using Pkg; Pkg.develop(;path=\"lib/TimespanLogging\")'"
+  command: "julia --project -e 'using Pkg; Pkg.develop(;path=\"lib/TimespanLogging\"); Pkg.add(; url=\"https://github.com/JuliaData/MemPool.jl\", rev=\"jps/migration-helper\")'"
+
 .bench: &bench
   if: build.message =~ /\[run benchmarks\]/
   agents:
@@ -14,6 +15,7 @@
     os: linux
     arch: x86_64
     num_cpus: 16
+
 steps:
   - label: Julia 1.8
     timeout_in_minutes: 90
@@ -25,6 +27,7 @@ steps:
           julia_args: "--threads=1"
       - JuliaCI/julia-coverage#v1:
           codecov: true
+
   - label: Julia 1.9
     timeout_in_minutes: 90
     <<: *test
@@ -35,6 +38,7 @@ steps:
           julia_args: "--threads=1"
       - JuliaCI/julia-coverage#v1:
           codecov: true
+
   - label: Julia 1.10
     timeout_in_minutes: 90
     <<: *test
@@ -45,6 +49,7 @@ steps:
           julia_args: "--threads=1"
       - JuliaCI/julia-coverage#v1:
           codecov: true
+
   - label: Julia nightly
     timeout_in_minutes: 90
     <<: *test
@@ -55,6 +60,7 @@ steps:
           julia_args: "--threads=1"
       - JuliaCI/julia-coverage#v1:
           codecov: true
+
   - label: Julia 1.8 (macOS)
     timeout_in_minutes: 90
     <<: *test
@@ -69,6 +75,7 @@ steps:
           julia_args: "--threads=1"
       - JuliaCI/julia-coverage#v1:
           codecov: true
+
   - label: Julia 1.8 - TimespanLogging
     timeout_in_minutes: 20
     <<: *test
@@ -78,6 +85,7 @@ steps:
       - JuliaCI/julia-coverage#v1:
           codecov: true
     command: "julia --project -e 'using Pkg; Pkg.instantiate(); Pkg.develop(;path=\"lib/TimespanLogging\"); Pkg.test(\"TimespanLogging\")'"
+
   - label: Julia 1.8 - DaggerWebDash
     timeout_in_minutes: 20
     <<: *test
@@ -87,6 +95,7 @@ steps:
       - JuliaCI/julia-coverage#v1:
           codecov: true
     command: "julia -e 'using Pkg; Pkg.develop(;path=pwd()); Pkg.develop(;path=\"lib/TimespanLogging\"); Pkg.develop(;path=\"lib/DaggerWebDash\"); include(\"lib/DaggerWebDash/test/runtests.jl\")'"
+
   - label: Benchmarks
     timeout_in_minutes: 120
     <<: *bench
@@ -103,6 +112,7 @@ steps:
       BENCHMARK_SCALE: "5:5:50"
     artifacts:
       - benchmarks/result*
+
   - label: DTables.jl stability test
     timeout_in_minutes: 20
     plugins:

--- a/src/sch/Sch.jl
+++ b/src/sch/Sch.jl
@@ -253,9 +253,11 @@ end
 Combine `SchedulerOptions` and `ThunkOptions` into a new `ThunkOptions`.
 """
 function Base.merge(sopts::SchedulerOptions, topts::ThunkOptions)
-    single = topts.single !== nothing ? topts.single : sopts.single
-    allow_errors = topts.allow_errors !== nothing ? topts.allow_errors : sopts.allow_errors
-    proclist = topts.proclist !== nothing ? topts.proclist : sopts.proclist
+    select_option = (sopt, topt) -> isnothing(topt) ? sopt : topt
+
+    single = select_option(sopts.single, topts.single)
+    allow_errors = select_option(sopts.allow_errors, topts.allow_errors)
+    proclist = select_option(sopts.proclist, topts.proclist)
     ThunkOptions(single,
                  proclist,
                  topts.time_util,


### PR DESCRIPTION
This is useful for testing and benchmarking.

BTW I added the `stream_max_evals` option to `SchedulerOptions` and `ThunkOptions`, but I see that the other streaming options are sort of used adhoc and filtered out before being passed upwards. Is that just for quick prototyping? Or should the streaming options go somewhere else?