### PR TITLE
DArray:  Tile QR, UndefInitializer, and parallel trapezoidal wrappers

### DIFF
--- a/src/Dagger.jl
+++ b/src/Dagger.jl
@@ -7,12 +7,12 @@ import SparseArrays: sprand, SparseMatrixCSC
 import MemPool
 import MemPool: DRef, FileRef, poolget, poolset
 
-import Base: collect, reduce
+import Base: collect, reduce, require_one_based_indexing
 import Distributed
 import Distributed: Future, RemoteChannel, myid, workers, nworkers, procs, remotecall, remotecall_wait, remotecall_fetch
 
 import LinearAlgebra
-import LinearAlgebra: Adjoint, BLAS, Diagonal, LAPACK, LowerTriangular, PosDefException, Transpose, UpperTriangular, diagind, ishermitian, issymmetric
+import LinearAlgebra: Adjoint, BLAS, Diagonal, LAPACK, LowerTriangular, PosDefException, Transpose, UpperTriangular, diagind, ishermitian, issymmetric, chkstride1
 
 import UUIDs: UUID, uuid4
 
@@ -77,8 +77,12 @@ include("array/setindex.jl")
 include("array/matrix.jl")
 include("array/sparse_partition.jl")
 include("array/sort.jl")
+
+# Linear algebra
 include("array/linalg.jl")
 include("array/mul.jl")
+include("array/trapezoidal.jl")
+include("array/triangular.jl")
 include("array/cholesky.jl")
 
 # Visualization

--- a/src/Dagger.jl
+++ b/src/Dagger.jl
@@ -84,6 +84,7 @@ include("array/mul.jl")
 include("array/trapezoidal.jl")
 include("array/triangular.jl")
 include("array/cholesky.jl")
+include("array/qr.jl")
 
 # Visualization
 include("visualization.jl")

--- a/src/array/alloc.jl
+++ b/src/array/alloc.jl
@@ -31,6 +31,22 @@ end
 
 const BlocksOrAuto = Union{Blocks{N} where N, AutoBlocks}
 
+function DArray{T}(::UndefInitializer, p::Blocks, dims) where {T}
+    d = ArrayDomain(map(x->1:x, dims))
+    part = partition(p, d)
+    f = function (_, T, sz)
+        Array{T, length(sz)}(undef, sz...)
+    end
+    a = AllocateArray(T, f, d, part, p)
+    return _to_darray(a)
+end
+
+DArray(::UndefInitializer, p::BlocksOrAuto, dims::Integer...) = DArray{Float64}(undef, p, dims)
+DArray(::UndefInitializer, p::BlocksOrAuto, dims::Tuple) = DArray{Float64}(undef, p, dims)
+DArray{T}(::UndefInitializer, p::BlocksOrAuto, dims::Integer...) where {T} = DArray{T}(undef, p, dims)
+DArray{T}(::UndefInitializer, p::BlocksOrAuto, dims::Tuple) where {T} = DArray{T}(undef, p, dims)
+DArray{T}(::UndefInitializer, p::AutoBlocks, dims::Tuple) where {T} = DArray{T}(undef, auto_blocks(dims), dims)
+
 function Base.rand(p::Blocks, eltype::Type, dims::Dims)
     d = ArrayDomain(map(x->1:x, dims))
     a = AllocateArray(eltype, (_, x...) -> rand(x...), d, partition(p, d), p)

--- a/src/array/coreblas/coreblas_gemm.jl
+++ b/src/array/coreblas/coreblas_gemm.jl
@@ -1,0 +1,21 @@
+using libblastrampoline_jll
+using LinearAlgebra
+using libcoreblas_jll
+
+for (gemm, T) in
+    ((:coreblas_dgemm, Float64), 
+     (:coreblas_sgemm, Float32),
+     (:coreblas_cgemm, ComplexF32),
+     (:coreblas_zgemm, ComplexF64))
+    @eval begin
+        function coreblas_gemm!(transa::Int64,  transb::Int64, 
+            alpha::$T, A::AbstractMatrix{$T}, B::AbstractMatrix{$T}, beta::$T, C::AbstractMatrix{$T})
+            m, k = size(A)
+            k, n = size(B)
+            ccall(($gemm, "libcoreblas.so"), Cvoid,
+                    (Int64, Int64, Int64, Int64, Int64, $T, Ptr{$T}, Int64, Ptr{$T}, Int64, 
+                    $T,  Ptr{$T}, Int64),
+                    transa, transb, m, n, k, alpha, A, m, B, k, beta, C, m)
+        end
+    end
+end

--- a/src/array/coreblas/coreblas_geqrt.jl
+++ b/src/array/coreblas/coreblas_geqrt.jl
@@ -1,0 +1,32 @@
+for (geqrt, T) in 
+    ((:coreblas_dgeqrt, Float64),
+    (:coreblas_sgeqrt, Float32),
+    (:coreblas_cgeqrt, ComplexF32),
+    (:coreblas_zgeqrt, ComplexF64))
+    @eval begin
+        function coreblas_geqrt!(A::AbstractMatrix{$T},
+                Tau::AbstractMatrix{$T}) 
+            require_one_based_indexing(A, Tau)
+            chkstride1(A)
+            m, n = size(A)
+            ib, nb = size(Tau)
+            lda = max(1, stride(A,2))
+            ldt = max(1, stride(Tau,2))
+            work = Vector{$T}(undef, (ib)*n)
+            ttau = Vector{$T}(undef, n)
+
+            err = ccall(($(QuoteNode(geqrt)), libcoreblas), Int64,
+                (Int64, Int64, Int64,
+                Ptr{$T}, Int64, Ptr{$T}, Int64, 
+                Ptr{$T}, Ptr{$T}),
+                m, n, ib, 
+                A, lda, 
+                Tau, ldt, 
+                ttau, work)
+            if err != 0
+                throw(ArgumentError("coreblas_geqrt failed. Error number: $err"))
+            end 
+        end
+    end
+end
+

--- a/src/array/coreblas/coreblas_ormqr.jl
+++ b/src/array/coreblas/coreblas_ormqr.jl
@@ -1,0 +1,45 @@
+for (geormqr, T) in
+    ((:coreblas_dormqr, Float64), 
+    (:coreblas_sormqr, Float32),
+    (:coreblas_zunmqr, ComplexF64),
+    (:coreblas_cunmqr, ComplexF32))
+    @eval begin
+        function coreblas_ormqr!(side::Char, trans::Char, A::AbstractMatrix{$T}, 
+             Tau::AbstractMatrix{$T}, C::AbstractMatrix{$T})
+
+            m, n = size(C)
+            ib, nb = size(Tau)
+            k = nb
+            if $T <: Complex
+                transnum = trans == 'N' ? 111 : 113
+            else
+                transnum = trans == 'N' ? 111 : 112
+            end
+            sidenum = side == 'L' ? 141 : 142
+
+            lda = max(1, stride(A,2))
+            ldt = max(1, stride(Tau,2))
+            ldc = max(1, stride(C,2))
+            ldwork = side == 'L' ? n : m
+            work = Vector{$T}(undef, ib*nb)
+
+                
+            err = ccall(($(QuoteNode(geormqr)), libcoreblas), Int64,
+                (Int64, Int64, Int64, Int64, 
+                Int64, Int64, 
+                Ptr{$T}, Int64, Ptr{$T}, Int64, 
+                Ptr{$T}, Int64, Ptr{$T}, Int64),
+                sidenum, transnum, 
+                m, n, 
+                k, ib, 
+                A, lda, 
+                Tau, ldt, 
+                C, ldc,
+                work, ldwork)
+            if err != 0
+                throw(ArgumentError("coreblas_ormqr failed. Error number: $err"))
+            end 
+        end
+    end
+end
+

--- a/src/array/coreblas/coreblas_tsmqr.jl
+++ b/src/array/coreblas/coreblas_tsmqr.jl
@@ -1,0 +1,49 @@
+for (getsmqr, T) in 
+    ((:coreblas_dtsmqr, Float64),
+     (:coreblas_ctsmqr, ComplexF32),
+     (:coreblas_ztsmqr, ComplexF64),
+     (:coreblas_stsmqr, Float32))
+    @eval begin
+        function coreblas_tsmqr!(side::Char, trans::Char, A1::AbstractMatrix{$T}, 
+                A2::AbstractMatrix{$T}, V::AbstractMatrix{$T}, Tau::AbstractMatrix{$T}) 
+            m1, n1 = size(A1)
+            m2, n2 = size(A2)
+            ib, nb = size(Tau)
+            k = nb
+            
+            if $T <: Complex
+                transnum = trans == 'N' ? 111 : 113
+            else
+                transnum = trans == 'N' ? 111 : 112
+            end
+
+            sidenum = side == 'L' ? 141 : 142
+
+            lda1 = max(1, stride(A1,2))
+            lda2 = max(1, stride(A2,2))
+            ldv = max(1, stride(V,2))
+            ldt = max(1, stride(Tau,2))
+            ldwork = side == 'L' ? ib : m1
+            work = Vector{$T}(undef, ib*nb)
+
+                
+            err = ccall(($(QuoteNode(getsmqr)), libcoreblas), Int64,
+                (Int64, Int64, Int64, Int64, 
+                Int64, Int64, Int64, Int64,
+                Ptr{$T}, Int64, Ptr{$T}, Int64, 
+                Ptr{$T}, Int64, Ptr{$T}, Int64, Ptr{$T}, Int64),
+                sidenum, transnum, 
+                m1, n1,
+                m2, n2,
+                k, ib, 
+                A1, lda1, 
+                A2, lda2,
+                V, ldv,
+                Tau, ldt, 
+                work, ldwork)
+            if err != 0
+                throw(ArgumentError("coreblas_tsmqr failed. Error number: $err"))
+            end 
+        end
+    end
+end

--- a/src/array/coreblas/coreblas_tsqrt.jl
+++ b/src/array/coreblas/coreblas_tsqrt.jl
@@ -1,0 +1,35 @@
+
+for (getsqrt,T) in 
+    ((:coreblas_dtsqrt, Float64), 
+    (:coreblas_stsqrt, Float32), 
+    (:coreblas_ctsqrt, ComplexF32), 
+    (:coreblas_ztsqrt, ComplexF64))
+    @eval begin
+        function coreblas_tsqrt!(A1::AbstractMatrix{$T}, A2::AbstractMatrix{$T}, 
+                Tau::AbstractMatrix{$T})
+            m = size(A2)[1]
+            n = size(A1)[2]
+            ib, nb = size(Tau)
+            lda1 = max(1, stride(A1,2))
+            lda2 = max(1, stride(A2,2))
+            ldt = max(1, stride(Tau,2))
+            work = Vector{$T}(undef, (ib)*n)
+            ttau = Vector{$T}(undef, n)
+
+            err = ccall(($(QuoteNode(getsqrt)), libcoreblas), Int64,
+                (Int64, Int64, Int64,
+                Ptr{$T}, Int64, Ptr{$T}, Int64, 
+                Ptr{$T}, Int64, Ptr{$T}, Ptr{$T}),
+                m, n, ib, 
+                A1, lda1, 
+                A2, lda2, 
+                Tau, ldt, 
+                ttau, work)
+            if err != 0
+                throw(ArgumentError("coreblas_tsqrt failed. Error number: $err"))
+            end 
+        end
+    end
+end
+
+

--- a/src/array/coreblas/coreblas_ttmqr.jl
+++ b/src/array/coreblas/coreblas_ttmqr.jl
@@ -1,0 +1,51 @@
+using libcoreblas_jll
+for (gettmqr, T) in 
+    ((:coreblas_dttmqr, Float64), 
+     (:coreblas_sttmqr, Float32),
+     (:coreblas_cttmqr, ComplexF32),
+     (:coreblas_zttmqr, ComplexF64))
+    @eval begin
+        function coreblas_ttmqr!(side::Char, trans::Char, A1::AbstractMatrix{$T}, 
+                A2::AbstractMatrix{$T}, V::AbstractMatrix{$T}, Tau::AbstractMatrix{$T})
+            m1, n1 = size(A1)
+            m2, n2 = size(A2)
+            ib, nb = size(Tau)
+            k=nb
+            if $T <: Complex
+                transnum = trans == 'N' ? 111 : 113
+            else
+                transnum = trans == 'N' ? 111 : 112
+            end
+
+            sidenum = side == 'L' ? 141 : 142
+
+            ldv = max(1, stride(V,2))
+            ldt = max(1, stride(Tau,2))
+            lda1 = max(1, stride(A1,2))
+            lda2 = max(1, stride(A2,2))
+            ldwork = side == 'L' ? max(1,ib) : max(1,m1)
+            workdim = side == 'L' ? n1 : ib
+            work = Vector{$T}(undef, ldwork*workdim)
+                
+            err = ccall(($(QuoteNode(gettmqr)), libcoreblas), Int64,
+                (Int64, Int64, Int64, Int64, 
+                Int64, Int64, Int64, Int64,
+                Ptr{$T}, Int64, Ptr{$T}, Int64, 
+                Ptr{$T}, Int64, Ptr{$T}, Int64, 
+                Ptr{$T}, Int64),
+                sidenum, transnum, 
+                m1, n1, 
+                m2, n2, 
+                k, ib, 
+                A1, lda1, 
+                A2, lda2, 
+                V, ldv, 
+                Tau, ldt, 
+                work, ldwork)
+            if err != 0
+                throw(ArgumentError("coreblas_ttmqr, failed. Error number: $err"))
+            end 
+        end
+    end
+end
+

--- a/src/array/coreblas/coreblas_ttqrt.jl
+++ b/src/array/coreblas/coreblas_ttqrt.jl
@@ -1,0 +1,32 @@
+
+for (gettqrt, T) in 
+    ((:coreblas_dttqrt, Float64), 
+     (:coreblas_sttqrt, Float32),
+     (:coreblas_cttqrt, ComplexF32),
+     (:coreblas_zttqrt, ComplexF64))
+    @eval begin
+        function coreblas_ttqrt!(A1::AbstractMatrix{$T}, 
+            A2::AbstractMatrix{$T}, triT::AbstractMatrix{$T})
+            m1, n1 = size(A1)
+            m2, n2 = size(A2)
+            ib, nb = size(triT)
+
+            lwork = nb + ib*nb
+            tau = Vector{$T}(undef, nb)
+            work = Vector{$T}(undef, (ib+1)*nb)
+            lda1 = max(1, stride(A1, 2))
+            lda2 = max(1, stride(A2, 2))
+            ldt = max(1, stride(triT, 2))
+
+
+            err = ccall(($(QuoteNode(gettqrt)), libcoreblas), Int64,
+                    (Int64, Int64, Int64, Ptr{$T}, Int64, Ptr{$T}, Int64,
+                    Ptr{$T}, Int64, Ptr{$T}, Ptr{$T}),
+                    m1, n1, ib, A1, lda1, A2, lda2, triT, ldt, tau, work)
+            
+            if err != 0
+                throw(ArgumentError("coreblas_ttqrt failed. Error number: $err"))
+            end    
+        end
+    end
+end

--- a/src/array/darray.jl
+++ b/src/array/darray.jl
@@ -63,6 +63,10 @@ ArrayDomain((1:15), (1:80))
 alignfirst(a::ArrayDomain) =
     ArrayDomain(map(r->1:length(r), indexes(a)))
 
+alignfirst(a::CartesianIndices{N}) where N =
+    ArrayDomain(map(r->1:length(r), a.indices))
+
+
 function size(a::ArrayDomain, dim)
     idxs = indexes(a)
     length(idxs) < dim ? 1 : length(idxs[dim])
@@ -351,7 +355,7 @@ function group_indices(cumlength, idxs::AbstractRange)
 end
 
 _cumsum(x::AbstractArray) = length(x) == 0 ? Int[] : cumsum(x)
-function lookup_parts(A::DArray, ps::AbstractArray, subdmns::DomainBlocks{N}, d::ArrayDomain{N}) where N
+function lookup_parts(A::DArray, ps::AbstractArray, subdmns::DomainBlocks{N}, d::ArrayDomain{N}; slice::Bool=false) where N
     groups = map(group_indices, subdmns.cumlength, indexes(d))
     sz = map(length, groups)
     pieces = Array{Any}(undef, sz)
@@ -359,20 +363,30 @@ function lookup_parts(A::DArray, ps::AbstractArray, subdmns::DomainBlocks{N}, d:
         idx_and_dmn = map(getindex, groups, i.I)
         idx = map(x->x[1], idx_and_dmn)
         dmn = ArrayDomain(map(x->x[2], idx_and_dmn))
-        pieces[i] = Dagger.@spawn getindex(ps[idx...], project(subdmns[idx...], dmn))
+        if slice
+            pieces[i] = Dagger.@spawn getindex(ps[idx...], project(subdmns[idx...], dmn))
+        else
+            pieces[i] = Dagger.@spawn view(ps[idx...], project(subdmns[idx...], dmn).indexes...)
+        end
     end
     out_cumlength = map(g->_cumsum(map(x->length(x[2]), g)), groups)
     out_dmn = DomainBlocks(ntuple(x->1,Val(N)), out_cumlength)
     return pieces, out_dmn
 end
-function lookup_parts(A::DArray, ps::AbstractArray, subdmns::DomainBlocks{N}, d::ArrayDomain{S}) where {N,S}
+function lookup_parts(A::DArray, ps::AbstractArray, subdmns::DomainBlocks{N}, d::ArrayDomain{S}; slice::Bool=false) where {N,S}
     if S != 1
         throw(BoundsError(A, d.indexes))
     end
     inds = CartesianIndices(A)[d.indexes...]
     new_d = ntuple(i->first(inds).I[i]:last(inds).I[i], N)
-    return lookup_parts(A, ps, subdmns, ArrayDomain(new_d))
+    return lookup_parts(A, ps, subdmns, ArrayDomain(new_d); slice)
 end
+
+function lookup_parts(A::DArray, ps::AbstractArray, subdmns::DomainBlocks{N}, d::CartesianIndices; slice::Bool=false) where N
+    return lookup_parts(A, ps, subdmns, ArrayDomain(d.indices); slice)
+end
+
+
 
 """
     Base.fetch(c::DArray)

--- a/src/array/qr.jl
+++ b/src/array/qr.jl
@@ -1,0 +1,241 @@
+export geqrf!, porgqr!, pormqr!, cageqrf!
+import LinearAlgebra: QRCompactWY, AdjointQ, BlasFloat, QRCompactWYQ, AbstractQ, StridedVecOrMat, I
+import Base.:*
+include("coreblas/coreblas_ormqr.jl")
+include("coreblas/coreblas_ttqrt.jl")
+include("coreblas/coreblas_ttmqr.jl")
+include("coreblas/coreblas_geqrt.jl")
+include("coreblas/coreblas_tsqrt.jl")
+include("coreblas/coreblas_tsmqr.jl")
+
+(*)(Q::QRCompactWYQ{T, M}, b::Number) where {T<:Number, M<:DMatrix{T}} = DMatrix(Q) * b
+(*)(b::Number, Q::QRCompactWYQ{T, M}) where {T<:Number, M<:DMatrix{T}} = DMatrix(Q) * b
+
+(*)(Q::AdjointQ{T, QRCompactWYQ{T, M, C}}, b::Number) where {T<:Number, M<:DMatrix{T}, C<:LowerTrapezoidal{T, M}} = DMatrix(Q) * b
+(*)(b::Number, Q::AdjointQ{T, QRCompactWYQ{T, M, C}}) where {T<:Number, M<:DMatrix{T}, C<:LowerTrapezoidal{T, M}} = DMatrix(Q) * b
+
+LinearAlgebra.lmul!(B::QRCompactWYQ{T, M}, A::M) where {T, M<:DMatrix{T}} = pormqr!('L', 'N', B.factors, B.T, A)
+function LinearAlgebra.lmul!(B::AdjointQ{T, <:QRCompactWYQ{T, M}}, A::M) where {T, M<:Dagger.DMatrix{T}}
+    trans = T <: Complex ? 'C' : 'T'
+    pormqr!('L', trans, B.Q.factors, B.Q.T, A)
+end
+
+LinearAlgebra.rmul!(A::Dagger.DMatrix{T}, B::QRCompactWYQ{T, M}) where {T, M<:Dagger.DMatrix{T}} = pormqr!('R', 'N', B.factors, B.T, A)
+function LinearAlgebra.rmul!(A::Dagger.DArray{T,2}, B::AdjointQ{T, <:QRCompactWYQ{T, M}}) where {T, M<:Dagger.DMatrix{T}} 
+    trans = T <: Complex ? 'C' : 'T'
+    pormqr!('R', trans, B.Q.factors, B.Q.T, A)
+end
+
+function Dagger.DMatrix(Q::QRCompactWYQ{T, <:Dagger.DArray{T, 2}}) where {T}
+    DQ = distribute(Matrix(I*one(T), size(Q.factors)[1], size(Q.factors)[1]), Q.factors.partitioning)
+    porgqr!('N', Q.factors, Q.T, DQ)
+    return DQ
+end
+
+function Dagger.DMatrix(AQ::AdjointQ{T, <:QRCompactWYQ{T, <:Dagger.DArray{T, 2}}}) where {T}
+    DQ = distribute(Matrix(I*one(T), size(AQ.Q.factors)[1], size(AQ.Q.factors)[1]), AQ.Q.factors.partitioning)
+    trans = T <: Complex ? 'C' : 'T'
+    porgqr!(trans, AQ.Q.factors, AQ.Q.T, DQ)
+    return DQ
+end
+
+Base.collect(Q::QRCompactWYQ{T, <:Dagger.DArray{T, 2}}) where {T} = collect(Dagger.DMatrix(Q))
+Base.collect(AQ::AdjointQ{T, <:QRCompactWYQ{T, <:Dagger.DArray{T, 2}}}) where {T} = collect(Dagger.DMatrix(AQ))
+
+function pormqr!(side::Char, trans::Char, A::Dagger.DArray{T, 2}, Tm::LowerTrapezoidal{T, <:Dagger.DMatrix{T}}, C::Dagger.DArray{T, 2}) where {T<:Number}
+    m, n = size(C)
+    Ac = A.chunks
+    Tc = Tm.data.chunks
+    Cc = C.chunks
+
+    Amt, Ant = size(Ac)
+    Tmt, Tnt = size(Tc)
+    Cmt, Cnt = size(Cc)
+    minMT = min(Amt, Ant)
+
+    Dagger.spawn_datadeps() do
+        if side == 'L'
+            if (trans == 'T' || trans == 'C')
+                for k in 1:minMT
+                    for n in 1:Cnt
+                        Dagger.@spawn coreblas_ormqr!(side, trans, In(Ac[k, k]), In(Tc[k, k]), InOut(Cc[k,n]))   
+                    end
+                    for m in k+1:Cmt, n in 1:Cnt
+                        Dagger.@spawn coreblas_tsmqr!(side, trans, InOut(Cc[k, n]), InOut(Cc[m, n]), In(Ac[m, k]), In(Tc[m, k]))  
+                    end
+                end
+            end
+            if trans == 'N'
+                for k in minMT:-1:1
+                    for m in Cmt:-1:k+1, n in 1:Cnt
+                        Dagger.@spawn coreblas_tsmqr!(side, trans, InOut(Cc[k, n]), InOut(Cc[m, n]),  In(Ac[m, k]), In(Tc[m, k]))
+                    end
+                    for n in 1:Cnt
+                        Dagger.@spawn coreblas_ormqr!(side, trans, In(Ac[k, k]), In(Tc[k, k]), InOut(Cc[k, n]))
+                    end
+                end
+            end
+        else 
+            if side == 'R'
+                if trans == 'T' || trans == 'C'
+                    for k in minMT:-1:1
+                        for n in Cmt:-1:k+1, m in 1:Cmt
+                            Dagger.@spawn coreblas_tsmqr!(side, trans, InOut(Cc[m, k]), InOut(Cc[m, n]), In(Ac[n, k]), In(Tc[n, k]))
+                        end
+                        for m in 1:Cmt
+                            Dagger.@spawn coreblas_ormqr!(side, trans, In(Ac[k, k]), In(Tc[k, k]), InOut(Cc[m, k]))
+                        end
+                    end
+                end
+                if trans == 'N'
+                    for k in 1:minMT
+                        for m in 1:Cmt
+                            Dagger.@spawn coreblas_ormqr!(side, trans, In(Ac[k, k]), In(Tc[k, k]), InOut(Cc[m, k]))
+                        end
+                        for n in k+1:Cmt, m in 1:Cmt
+                            Dagger.@spawn coreblas_tsmqr!(side, trans, InOut(Cc[m, k]), InOut(Cc[m, n]), In(Ac[n, k]), In(Tc[n, k]))
+                        end
+                    end
+                end
+            end
+        end
+    end
+    return C
+end
+
+function cageqrf!(A::Dagger.DArray{T, 2}, Tm::LowerTrapezoidal{T, <:Dagger.DMatrix{T}}; static::Bool=true, traversal::Symbol=:inorder, p::Int64=1) where {T<: Number}
+    if p == 1 
+        return geqrf!(A, Tm; static, traversal)
+    end
+    Ac = A.chunks
+    mt, nt = size(Ac)
+    @assert mt % p == 0 "Number of tiles must be divisible by the number of domains"
+    mtd = Int64(mt/p)
+    Tc = Tm.data.chunks
+    proot = 1
+    nxtmt = mtd
+    trans = T <: Complex ? 'C' : 'T'
+    Dagger.spawn_datadeps(;static, traversal) do
+        for k in 1:min(mt, nt)
+            if k > nxtmt
+                proot += 1
+                nxtmt += mtd
+            end
+            for pt in proot:p
+                ibeg = 1 + (pt-1) * mtd
+                if pt == proot
+                    ibeg = k 
+                end
+                Dagger.@spawn coreblas_geqrt!(InOut(Ac[ibeg, k]), Out(Tc[ibeg,k]))
+                for n in k+1:nt
+                    Dagger.@spawn coreblas_ormqr!('L', trans, In(Ac[ibeg, k]), In(Tc[ibeg,k]), InOut(Ac[ibeg, n]))
+                end
+                for m in ibeg+1:(pt * mtd)
+                    Dagger.@spawn coreblas_tsqrt!(InOut(Ac[ibeg, k]), InOut(Ac[m, k]), Out(Tc[m,k]))
+                    for n in k+1:nt
+                         Dagger.@spawn coreblas_tsmqr!('L', trans, InOut(Ac[ibeg, n]), InOut(Ac[m, n]), In(Ac[m, k]), In(Tc[m,k]))
+                    end
+                end
+            end
+            for m in 1:ceil(Int64, log2(p-proot+1))
+                p1 = proot
+                p2 = p1 + 2^(m-1)
+                while p2 ≤ p
+                    i1 = 1 + (p1-1) * mtd
+                    i2 = 1 + (p2-1) * mtd
+                    if p1 == proot
+                        i1 = k
+                    end
+                    Dagger.@spawn coreblas_ttqrt!(InOut(Ac[i1, k]), InOut(Ac[i2, k]), Out(Tc[i2, k]))
+                    for n in k+1:nt
+                        Dagger.@spawn coreblas_ttmqr!('L', trans, InOut(Ac[i1, n]), InOut(Ac[i2, n]), In(Ac[i2, k]), In(Tc[i2, k]))
+                    end
+                    p1 += 2^m
+                    p2 += 2^m
+                end
+            end
+        end
+    end
+end
+
+function geqrf!(A::Dagger.DArray{T, 2}, Tm::LowerTrapezoidal{T, <:Dagger.DMatrix{T}}; static::Bool=true, traversal::Symbol=:inorder) where {T<: Number}
+    Ac = A.chunks
+    mt, nt = size(Ac)
+    Tc = Tm.data.chunks
+    trans = T <: Complex ? 'C' : 'T'
+
+    Ccopy = Dagger.DArray{T}(undef, A.partitioning, A.partitioning.blocksize[1], min(mt, nt) * A.partitioning.blocksize[2])
+    Cc = Ccopy.chunks
+    Dagger.spawn_datadeps(;static, traversal) do
+        for k in 1:min(mt, nt) 
+            Dagger.@spawn coreblas_geqrt!(InOut(Ac[k, k]), Out(Tc[k,k]))
+            # FIXME: This is a hack to avoid aliasing
+            Dagger.@spawn copyto!(InOut(Cc[1,k]), In(Ac[k, k]))
+            for n in k+1:nt
+                #FIXME: Change Cc[1,k] to upper triangular of Ac[k,k]
+                Dagger.@spawn coreblas_ormqr!('L', trans, In(Cc[1, k]), In(Tc[k,k]), InOut(Ac[k, n]))
+            end
+            for m in k+1:mt
+                Dagger.@spawn coreblas_tsqrt!(InOut(Ac[k, k]), InOut(Ac[m, k]), Out(Tc[m,k])) 
+                for n in k+1:nt
+                    Dagger.@spawn coreblas_tsmqr!('L', trans, InOut(Ac[k, n]), InOut(Ac[m, n]), In(Ac[m, k]), In(Tc[m,k]))
+                end
+            end
+        end
+    end
+end
+
+function porgqr!(trans::Char, A::Dagger.DArray{T, 2}, Tm::LowerTrapezoidal{T, <:Dagger.DMatrix{T}}, Q::Dagger.DArray{T, 2}; static::Bool=true, traversal::Symbol=:inorder) where {T<:Number} 
+    Ac = A.chunks
+    Tc = Tm.data.chunks
+    Qc = Q.chunks
+    mt, nt = size(Ac)
+    qmt, qnt = size(Qc)
+    
+    Dagger.spawn_datadeps(;static, traversal) do
+        if trans == 'N'
+            for k in min(mt, nt):-1:1
+                for m in qmt:-1:k + 1, n in k:qnt
+                        Dagger.@spawn coreblas_tsmqr!('L', trans, InOut(Qc[k, n]), InOut(Qc[m, n]), In(Ac[m, k]), In(Tc[m, k]))
+                end
+                for n in k:qnt
+                    Dagger.@spawn coreblas_ormqr!('L', trans, In(Ac[k, k]), 
+                    In(Tc[k, k]), InOut(Qc[k, n]))
+                end
+            end
+        else
+            for k in 1:min(mt, nt)
+                for n in 1:k
+                    Dagger.@spawn coreblas_ormqr!('L', trans, In(Ac[k, k]), 
+                    In(Tc[k, k]), InOut(Qc[k, n]))
+                end
+                for m in k+1:qmt, n in 1:qnt
+                        Dagger.@spawn coreblas_tsmqr!('L', trans, InOut(Qc[k, n]), InOut(Qc[m, n]), In(Ac[m, k]), In(Tc[m, k]))
+                end
+            end
+        end
+    end
+end
+
+function meas_ws(A::Dagger.DArray{T, 2}, ib::Int64) where {T<: Number}
+    mb, nb = A.partitioning.blocksize
+    m, n = size(A)
+    MT = (mod(m,nb)==0) ? floor(Int64, (m / mb)) : floor(Int64, (m / mb) + 1) 
+    NT = (mod(n,nb)==0) ? floor(Int64,(n / nb)) : floor(Int64, (n / nb) + 1) * 2 
+    lm = ib * MT;
+    ln = nb * NT;
+    lm, ln
+end
+
+function LinearAlgebra.qr!(A::Dagger.DArray{T, 2}; ib::Int64=1, p::Int64=1) where {T<:Number}   
+    lm, ln = meas_ws(A, ib)
+    Ac = A.chunks
+    nb = A.partitioning.blocksize[2]
+    mt, nt = size(Ac)
+    st = nb * (nt - 1)
+    Tm = LowerTrapezoidal(zeros, Blocks(ib, nb), T, st, lm, ln)
+    geqrf!(A, Tm)
+    return QRCompactWY(A, Tm);
+end
+
+

--- a/src/array/trapezoidal.jl
+++ b/src/array/trapezoidal.jl
@@ -1,0 +1,142 @@
+export LowerTrapezoidal, UnitLowerTrapezoidal, UpperTrapezoidal, UnitUpperTrapezoidal, trau!, trau, tral!, tral
+import LinearAlgebra: triu!, tril!, triu, tril
+abstract type AbstractTrapezoidal{T} <: AbstractMatrix{T} end
+
+# First loop through all methods that don't need special care for upper/lower and unit diagonal
+for t in (:LowerTrapezoidal, :UnitLowerTrapezoidal, :UpperTrapezoidal, :UnitUpperTrapezoidal)
+    @eval begin
+        struct $t{T,S<:AbstractMatrix{T}} <: AbstractTrapezoidal{T}
+            data::S
+
+            function $t{T,S}(data) where {T,S<:AbstractMatrix{T}}
+                Base.require_one_based_indexing(data)
+                new{T,S}(data)
+            end
+        end
+        $t(A::$t) = A
+        $t{T}(A::$t{T}) where {T} = A
+        $t(A::AbstractMatrix) = $t{eltype(A), typeof(A)}(A)
+        $t{T}(A::AbstractMatrix) where {T} = $t(convert(AbstractMatrix{T}, A))
+        $t{T}(A::$t) where {T} = $t(convert(AbstractMatrix{T}, A.data))
+
+        AbstractMatrix{T}(A::$t) where {T} = $t{T}(A)
+        AbstractMatrix{T}(A::$t{T}) where {T} = copy(A)
+
+        Base.size(A::$t) = size(A.data)
+        Base.axes(A::$t) = axes(A.data)
+
+        Base.similar(A::$t, ::Type{T}) where {T} = $t(similar(parent(A), T))
+        Base.similar(A::$t, ::Type{T}, dims::Dims{N}) where {T,N} = similar(parent(A), T, dims)
+        Base.parent(A::$t) = A.data
+
+        Base.copy(A::$t) = $t(copy(A.data))
+
+        Base.real(A::$t{<:Real}) = A
+        Base.real(A::$t{<:Complex}) = (B = real(A.data); $t(B))
+    end
+end
+
+Base.getindex(A::UnitLowerTrapezoidal{T}, i::Integer, j::Integer) where {T} =
+    i > j ? ifelse(A.data[i,j] == nothing, zero(eltype(A.data)), A.data[i,j]) : ifelse(i == j, oneunit(T), zero(T))
+Base.getindex(A::LowerTrapezoidal, i::Integer, j::Integer) =
+i >= j ? ifelse(A.data[i,j] == nothing, zero(eltype(A.data)), A.data[i,j]) : zero(eltype(A.data))
+Base.getindex(A::UnitUpperTrapezoidal{T}, i::Integer, j::Integer) where {T} =
+    i < j ? ifelse(A.data[i,j] == nothing, zero(eltype(A.data)), A.data[i,j]) : ifelse(i == j, oneunit(T), zero(T))
+Base.getindex(A::UpperTrapezoidal, i::Integer, j::Integer) =
+i <= j ?  ifelse(A.data[i,j] == nothing, zero(eltype(A.data)), A.data[i,j]) : zero(eltype(A.data))
+
+function _DiagBuild(blockdom::Tuple, alloc::AbstractMatrix{T}, diag::Vector{Tuple{Int,Int}}, transform::Function) where {T}
+    diagind = findfirst(x-> x[1] in blockdom[1] && x[2] in blockdom[2], diag)
+    blockind = (diag[diagind][1] - first(blockdom[1])  + 1, diag[diagind][2] - first(blockdom[2]) + 1) 
+    return Dagger.@spawn transform(alloc, blockind[2] - blockind[1])
+end
+
+function _GenericTrapezoidal(f::Union{Function, UndefInitializer}, p::Blocks{2}, eltype::Type, wrap, k::Integer, dims)
+    d = ArrayDomain(map(x->1:x, dims))
+    dc = partition(p, d)
+    if f isa UndefInitializer
+        f = (eltype, x...) -> Array{eltype}(undef, x...)
+    end
+    m, n = dims
+    if k < 0
+        diag = [(i-k, i) for i in 1:min(m, n)]
+    else
+        diag = [(i, i+k) for i in 1:min(m, n)]
+    end
+    thunks = []
+    alloc(sz) = f(eltype, sz)
+    transform = (wrap == LowerTrapezoidal) ? tril! : triu!
+    compar = (wrap == LowerTrapezoidal) ? (>) : (<)
+    for c in dc
+        sz = size(c)
+        if any(x -> x[1] in c.indexes[1] && x[2] in c.indexes[2], diag)
+            push!(thunks, _DiagBuild(c.indexes, alloc(sz), diag, transform))
+        else
+            mt, nt = k<0 ? (first(c.indexes[1]), first(c.indexes[2])-k) : (first(c.indexes[1])+k, first(c.indexes[2]))
+            if compar(mt, nt)
+                push!(thunks, Dagger.@spawn alloc(sz))
+            else
+                push!(thunks, Dagger.@spawn zeros(eltype, sz))
+            end
+        end
+    end
+    thunks = reshape(thunks, size(dc))
+    return wrap(Dagger.DArray(eltype, d, dc, thunks, p))
+end
+
+LowerTrapezoidal(f::Union{Function, UndefInitializer}, p::Blocks{2}, dims::Integer...) = _GenericTrapezoidal(f, p, eltype, LowerTrapezoidal, 0, dims)
+LowerTrapezoidal(f::Union{Function, UndefInitializer}, p::Blocks{2}, dims::Tuple) = _GenericTrapezoidal(f, p, eltype, LowerTrapezoidal, 0, dims)
+LowerTrapezoidal(f::Union{Function, UndefInitializer}, p::Blocks{2}, eltype::Type, dims::Integer...) = _GenericTrapezoidal(f, p, eltype, LowerTrapezoidal, 0, dims)
+LowerTrapezoidal(f::Union{Function, UndefInitializer}, p::Blocks{2}, eltype::Type, dims::Tuple) = _GenericTrapezoidal(f, p, eltype, LowerTrapezoidal, 0, dims)
+LowerTrapezoidal(f::Union{Function, UndefInitializer}, p::Blocks{2}, k::Integer, dims::Integer...) = _GenericTrapezoidal(f, p, eltype, LowerTrapezoidal, k, dims)
+LowerTrapezoidal(f::Union{Function, UndefInitializer}, p::Blocks{2}, k::Integer, dims::Tuple) = _GenericTrapezoidal(f, p, eltype, LowerTrapezoidal, k, dims)
+LowerTrapezoidal(f::Union{Function, UndefInitializer}, p::Blocks{2}, eltype::Type, k::Integer, dims::Integer...) = _GenericTrapezoidal(f, p, eltype, LowerTrapezoidal, k, dims)
+LowerTrapezoidal(f::Union{Function, UndefInitializer}, p::Blocks{2}, eltype::Type, k::Integer, dims::Tuple) = _GenericTrapezoidal(f, p, eltype, LowerTrapezoidal, k, dims)
+
+UpperTrapezoidal(f::Union{Function, UndefInitializer}, p::Blocks{2}, dims::Integer...) = _GenericTrapezoidal(f, p, eltype, UpperTrapezoidal, 0, dims)
+UpperTrapezoidal(f::Union{Function, UndefInitializer}, p::Blocks{2}, dims::Tuple) = _GenericTrapezoidal(f, p, eltype, UpperTrapezoidal, 0, dims)
+UpperTrapezoidal(f::Union{Function, UndefInitializer}, p::Blocks{2}, eltype::Type, dims::Integer...) = _GenericTrapezoidal(f, p, eltype, UpperTrapezoidal, 0, dims)
+UpperTrapezoidal(f::Union{Function, UndefInitializer}, p::Blocks{2}, eltype::Type, dims::Tuple) = _GenericTrapezoidal(f, p, eltype, UpperTrapezoidal, 0, dims)
+UpperTrapezoidal(f::Union{Function, UndefInitializer}, p::Blocks{2}, k::Integer, dims::Integer...) = _GenericTrapezoidal(f, p, eltype, UpperTrapezoidal, k, dims)
+UpperTrapezoidal(f::Union{Function, UndefInitializer}, p::Blocks{2}, k::Integer, dims::Tuple) = _GenericTrapezoidal(f, p, eltype, UpperTrapezoidal, k, dims)
+UpperTrapezoidal(f::Union{Function, UndefInitializer}, p::Blocks{2}, eltype::Type, k::Integer, dims::Integer...) = _GenericTrapezoidal(f, p, eltype, UpperTrapezoidal, k, dims)
+UpperTrapezoidal(f::Union{Function, UndefInitializer}, p::Blocks{2}, eltype::Type, k::Integer, dims::Tuple) = _GenericTrapezoidal(f, p, eltype, UpperTrapezoidal, k, dims)
+
+function _GenericTra!(A::Dagger.DArray{T, 2}, wrap::Function, k::Integer) where {T}
+    d = A.domain
+    dc = A.subdomains
+    Ac = A.chunks
+    m, n = size(A)
+    if k < 0
+        diag = [(i-k, i) for i in 1:min(m, n)]
+    else
+        diag = [(i, i+k) for i in 1:min(m, n)]
+    end
+    compar = (wrap == tril!) ? (≤) : (≥)
+    for ind in CartesianIndices(dc)
+        sz = size(dc[ind])
+        if any(x -> x[1] in dc[ind].indexes[1] && x[2] in dc[ind].indexes[2], diag)
+            Ac[ind] = _DiagBuild(dc[ind].indexes, fetch(Ac[ind]), diag, wrap)
+        else
+            mt, nt = k<0 ? (first(dc[ind].indexes[1]), first(dc[ind].indexes[2])-k) : (first(dc[ind].indexes[1])+k, first(dc[ind].indexes[2]))
+            if compar(mt, nt)
+                Ac[ind] = Dagger.@spawn zeros(T, sz)
+            end
+        end
+    end
+    return A
+end
+
+
+
+trau!(A::Dagger.DArray{T,2}, k::Integer) where {T} = _GenericTra!(A, triu!, k)
+trau!(A::Dagger.DArray{T,2}) where {T} = _GenericTra!(A, triu!, 0)
+trau(A::Dagger.DArray{T,2}) where {T} = trau!(copy(A))
+trau(A::Dagger.DArray{T,2}, k::Integer) where {T} = trau!(copy(A), k)
+
+tral!(A::Dagger.DArray{T,2}, k::Integer) where {T} = _GenericTra!(A, tril!, k)
+tral!(A::Dagger.DArray{T,2}) where {T} = _GenericTra!(A, tril!, 0)
+tral(A::Dagger.DArray{T,2}) where {T} = tral!(copy(A))
+tral(A::Dagger.DArray{T,2}, k::Integer) where {T} = tral!(copy(A), k)
+
+#TODO: map, reduce, sum, mean, prod, reducedim, collect, distribute

--- a/src/array/triangular.jl
+++ b/src/array/triangular.jl
@@ -1,0 +1,83 @@
+export LowerTriangular, UpperTriangular, tril, triu, tril!, triu!
+
+function _GenericTriangular(f::Union{Function, UndefInitializer}, p::Blocks{2}, eltype::Type, compar::Function, wrap, dims)
+    @assert dims[1] == dims[2] "matrix is not square: dimensions are $dims (try using trapezoidal)"
+    d = ArrayDomain(map(x->1:x, dims))
+    dc = partition(p, d)
+    if f isa UndefInitializer
+        f = (eltype, x...) -> Array{eltype}(undef, x...)
+    end
+    diag = [(i,i) for i in 1:min(size(d)...)]
+    thunks = []
+    alloc(sz) = f(eltype, sz)
+    transform = (wrap == LowerTrapezoidal) ? tril! : triu!
+    compar = (wrap == LowerTrapezoidal) ? (>) : (<)
+    for c in dc
+        sz = size(c)
+        if any(x -> x[1] in c.indexes[1] && x[2] in c.indexes[2], diag)
+            push!(thunks, _DiagBuild(c.indexes, alloc(sz), diag, transform))
+        else
+            if compar(first(c.indexes[1]), first(c.indexes[2]))
+                push!(thunks, Dagger.@spawn alloc(sz))
+            else
+                push!(thunks, Dagger.@spawn zeros(eltype, sz))
+            end
+        end
+    end
+    thunks = reshape(thunks, size(dc))
+    return wrap(Dagger.DArray(eltype, d, dc, thunks, p))
+end
+
+LinearAlgebra.LowerTriangular(f::Union{Function, UndefInitializer}, p::Blocks{2}, dims::Integer...) = _GenericTriangular(f, p, eltype, LowerTriangular, dims)
+LinearAlgebra.LowerTriangular(f::Union{Function, UndefInitializer}, p::Blocks{2}, dims::Tuple) = _GenericTriangular(f, p, eltype, LowerTriangular, dims)
+LinearAlgebra.LowerTriangular(f::Union{Function, UndefInitializer}, p::Blocks{2}, eltype::Type, dims::Integer...) = _GenericTriangular(f, p, eltype, LowerTriangular, dims)
+LinearAlgebra.LowerTriangular(f::Union{Function, UndefInitializer}, p::Blocks{2}, eltype::Type, dims::Tuple) = _GenericTriangular(f, p, eltype, LowerTriangular, dims)
+
+LinearAlgebra.UpperTriangular(f::Union{Function, UndefInitializer}, p::Blocks{2}, dims::Integer...) = _GenericTriangular(f, p, eltype, UpperTriangular, dims)
+LinearAlgebra.UpperTriangular(f::Union{Function, UndefInitializer}, p::Blocks{2}, dims::Tuple) = _GenericTriangular(f, p, eltype, UpperTriangular, dims)
+LinearAlgebra.UpperTriangular(f::Union{Function, UndefInitializer}, p::Blocks{2}, eltype::Type, dims::Integer...) = _GenericTriangular(f, p, eltype, UpperTriangular, dims)
+LinearAlgebra.UpperTriangular(f::Union{Function, UndefInitializer}, p::Blocks{2}, eltype::Type, dims::Tuple) = _GenericTriangular(f, p, eltype, UpperTriangular, dims)
+
+function _GenericTri!(A::Dagger.DArray{T, 2}, wrap) where {T}
+    LinearAlgebra.checksquare(A)
+    d = A.domain
+    dc = A.subdomains
+    Ac = A.chunks
+    diag = [(i,i) for i in 1:min(size(d)...)]
+    compar = (wrap == tril!) ? (>) : (<)
+    for ind in CartesianIndices(dc)
+        sz = size(dc[ind])
+        if any(x -> x[1] in dc[ind].indexes[1] && x[2] in dc[ind].indexes[2], diag)
+            Ac[ind] = _DiagBuild(dc[ind].indexes, fetch(Ac[ind]), diag, wrap)
+        else
+            if compar(first(dc[ind].indexes[2]), first(dc[ind].indexes[1]))
+                Ac[ind] = Dagger.@spawn zeros(T, sz)
+            end
+        end
+    end
+    return A
+end
+
+function LinearAlgebra.triu!(A::Dagger.DArray{T,2}) where {T}
+    if size(A, 1) != size(A, 2)
+        trau!(A)
+    else    
+        _GenericTri!(A, triu!)
+    end
+end
+LinearAlgebra.triu(A::Dagger.DArray{T,2}) where {T} = triu!(copy(A))
+
+function LinearAlgebra.tril!(A::Dagger.DArray{T,2}) where {T}
+    if size(A, 1) != size(A, 2)
+        tral!(A)
+    else
+        _GenericTri!(A, tril!)
+    end
+end
+LinearAlgebra.tril(A::Dagger.DArray{T,2}) where {T} = tril!(copy(A))
+
+#TODO: matmul
+
+
+
+

--- a/test/array/linalg/qr.jl
+++ b/test/array/linalg/qr.jl
@@ -1,0 +1,36 @@
+ @testset "Tile QR:  $T" for T in (Float32, Float64, ComplexF32, ComplexF64)
+     ## Square matrices
+     A = rand(T, 128, 128)
+     Q, R = qr(A)
+     DA = distribute(A, Blocks(32,32))
+     DQ, DR = qr!(DA)
+     @test abs.(DQ) ≈ abs.(Q)
+     @test abs.(DR) ≈ abs.(R)
+     @test DQ * DR ≈ A
+     @test DQ' * DQ ≈ I
+     @test I * abs.(DQ) ≈ abs.(Q)
+     @test I * abs.(DQ') ≈ abs.(Q')
+     
+     ## Rectangular matrices (block and element wise)
+     # Tall Element and Block
+     A = rand(T, 128, 64)
+     Q, R = qr(A)
+     DA = distribute(A, Blocks(32,32))
+     DQ, DR = qr!(DA)
+     @test abs.(DR) ≈ abs.(R)
+     @test DQ * DR ≈ A
+     @test DQ' * DQ ≈ I
+     @test I * DQ ≈ collect(DQ)
+     @test I * DQ' ≈ collect(DQ')
+ 
+     # Wide Element and Block
+     A = rand(T, 64, 128)
+     Q, R = qr(A)
+     DA = distribute(A, Blocks(16,16))
+     DQ, DR = qr!(DA)
+     @test abs.(DR) ≈ abs.(R)
+     @test DQ * DR ≈ A
+     @test DQ' * DQ ≈ I
+     @test I * DQ ≈ collect(DQ)
+     @test I * DQ' ≈ collect(DQ')
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,7 @@ tests = [
     ("Array - MapReduce", "array/mapreduce.jl"),
     ("Array - LinearAlgebra - Matmul", "array/linalg/matmul.jl"),
     ("Array - LinearAlgebra - Cholesky", "array/linalg/cholesky.jl"),
+    ("Array - LinearAlgebra - QR", "array/linalg/qr.jl"),
     ("Caching", "cache.jl"),
     ("Disk Caching", "diskcaching.jl"),
     ("File IO", "file-io.jl"),


### PR DESCRIPTION
This PR concerns the implementation of parallel Triangular and Trapezoidal wrappers. A parallel Tile QR implementation, and undefined initializers for DArrays. This gives ways for "zero-memory" allocation of trapezoidal and triangular DArrays in the future, let's us use Triangular and Trapezoidal wrappers without synchronization, creates undefined memory DArrays in parallel with respect to chunks, and gives way for an easy-to-use QR implementation. All methods follow patterns paved by LinearAlgebra.jl