### PR TITLE
parser: Assorted improvements

### DIFF
--- a/src/thunk.jl
+++ b/src/thunk.jl
@@ -365,8 +365,14 @@ end
 function _par(ex::Expr; lazy=true, recur=true, opts=())
     f = nothing
     body = nothing
-    if recur && @capture(ex, f_(allargs__)) || @capture(ex, f_(allargs__) do cargs_ body_ end) || @capture(ex, allargs__->body_)
+    arg1 = nothing
+    if recur && @capture(ex, f_(allargs__)) || @capture(ex, f_(allargs__) do cargs_ body_ end) || @capture(ex, allargs__->body_) || @capture(ex, arg1_[allargs__])
         f = replace_broadcast(f)
+        if arg1 !== nothing
+            # Indexing (A[2,3])
+            f = Base.getindex
+            pushfirst!(allargs, arg1)
+        end
         args = filter(arg->!Meta.isexpr(arg, :parameters), allargs)
         kwargs = filter(arg->Meta.isexpr(arg, :parameters), allargs)
         if !isempty(kwargs)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,7 @@ if PROGRAM_FILE != "" && realpath(PROGRAM_FILE) == @__FILE__
     pushfirst!(LOAD_PATH, joinpath(@__DIR__, ".."))
     using Pkg
     Pkg.activate(@__DIR__)
+    Pkg.instantiate()
 
     using ArgParse
     s = ArgParseSettings(description = "Dagger Testsuite")

--- a/test/thunk.jl
+++ b/test/thunk.jl
@@ -118,6 +118,23 @@ end
         @test t isa Dagger.DTask
         @test fetch(t) == sum(A; dims=1)
     end
+    @testset "getindex" begin
+        A = rand(4, 4)
+
+        t = @spawn A[1, 2]
+        @test t isa Dagger.DTask
+        @test fetch(t) == A[1, 2]
+
+        B = Dagger.@spawn rand(4, 4)
+        t = @spawn B[1, 2]
+        @test t isa Dagger.DTask
+        @test fetch(t) == fetch(B)[1, 2]
+
+        R = Ref(42)
+        t = @spawn R[]
+        @test t isa Dagger.DTask
+        @test fetch(t) == 42
+    end
     @testset "invalid expression" begin
         @test_throws LoadError eval(:(@spawn 1))
         @test_throws LoadError eval(:(@spawn begin 1 end))

--- a/test/thunk.jl
+++ b/test/thunk.jl
@@ -107,6 +107,17 @@ end
         @test t isa Dagger.DTask
         @test fetch(t) == 43
     end
+    @testset "anonymous direct call" begin
+        A = rand(4)
+
+        t = @spawn A->sum(A)
+        @test t isa Dagger.DTask
+        @test fetch(t) == sum(A)
+
+        t = @spawn A->sum(A; dims=1)
+        @test t isa Dagger.DTask
+        @test fetch(t) == sum(A; dims=1)
+    end
     @testset "invalid expression" begin
         @test_throws LoadError eval(:(@spawn 1))
         @test_throws LoadError eval(:(@spawn begin 1 end))

--- a/test/thunk.jl
+++ b/test/thunk.jl
@@ -79,6 +79,10 @@ end
         @test fetch(@spawn A .+ B) ≈ A .+ B
         @test fetch(@spawn A .* B) ≈ A .* B
     end
+    @testset "inner macro" begin
+        A = rand(4)
+        @test fetch(@spawn sum(@view A[2:3])) ≈ sum(@view A[2:3])
+    end
     @testset "waiting" begin
         a = @spawn sleep(1)
         @test !isready(a)


### PR DESCRIPTION
Uses MacroTools' `@capture` in the `@spawn` parser to parse calls, and in the process adds support for do-block syntax and direct calls to anonymous functions:

```julia
# Do-block syntax
Dagger.@spawn sum(A) do a
  return a+1
end

# Direct call to anonymous function
Dagger.@spawn A->sum(A; dims=1)+2
```

This should make it easier for users to apply `Dagger.@spawn` to arbitrary calls. Note that I am not tackling #514, as that is significantly more difficult to do (it requires finding and transforming all values which might be a `DTask`).

Fixes #480 
Fixes #479
Fixes #421 