### PR TITLE
Include datadeps in API documentation

### DIFF
--- a/docs/src/api-dagger/functions.md
+++ b/docs/src/api-dagger/functions.md
@@ -30,6 +30,11 @@ mutable
 shard
 ```
 
+## Data Dependencies Functions
+```@docs
+spawn_datadeps
+```
+
 ## Scope Functions
 ```@docs
 scope

--- a/docs/src/api-dagger/types.md
+++ b/docs/src/api-dagger/types.md
@@ -26,6 +26,14 @@ Chunk
 Shard
 ```
 
+## Data Dependencies Types
+```@docs
+In
+Out
+InOut
+Deps
+```
+
 ## Processor Types
 ```@docs
 Processor

--- a/docs/src/datadeps.md
+++ b/docs/src/datadeps.md
@@ -6,8 +6,10 @@ linear algebra) hard to express efficiently in Dagger. Thankfully, there is a
 solution called "Datadeps" (short for "data dependencies"), accessible through
 the `spawn_datadeps` function. This function constructs a "datadeps region",
 within which tasks are allowed to write to their arguments, with parallelism
-controlled via dependencies specified via argument annotations. Let's look at a
-simple example to make things concrete:
+controlled via dependencies specified via argument annotations. At the end of
+the "datadeps region" the `spawn_datadeps` will wait for the completion of all
+the tasks launched within it. Let's look at a simple example to make things
+concrete:
 
 ```julia
 A = rand(1000)


### PR DESCRIPTION
The datadeps (`spawn_datadeps`, `In`, `Out`, etc.) have their own usage-page in the docs but weren't mention in the API documentation. The already provided docstrings can be used

I think it would be also useful to add a remark in the documentation that `spawn_datadeps` waits for all the tasks spawned. This part was unclear for me and I had to check the source code