### PR TITLE
add documentation for Task / Thread occupancy

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -26,4 +26,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
-        run: julia --project=docs/ docs/make.jl
+        run: julia -t=auto --project=docs/ docs/make.jl

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -26,4 +26,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
-        run: julia -t=auto --project=docs/ docs/make.jl
+        run: julia --threads=auto --project=docs/ docs/make.jl

--- a/docs/src/task-spawning.md
+++ b/docs/src/task-spawning.md
@@ -187,7 +187,7 @@ Note that, as a legacy API, usage of the lazy API is generally discouraged for m
 - Distinct schedulers don't share runtime metrics or learned parameters, thus causing the scheduler to act less intelligently
 - Distinct schedulers can't share work or data directly
 
-### Scheduler and Thunk options
+## Scheduler and Thunk options
 
 While Dagger generally "just works", sometimes one needs to exert some more
 fine-grained control over how the scheduler allocates work. There are two
@@ -221,7 +221,7 @@ Dagger.spawn(+, Dagger.Options(;single=1), 1, 2)
 delayed(+; single=1)(1, 2)
 ```
 
-### Changing the thread occupancy for low-utilization tasks
+## Changing the thread occupancy
 
 One of the supported [`Sch.ThunkOptions`](@ref) is the `occupancy` keyword.
 The basic usage looks like this:

--- a/docs/src/task-spawning.md
+++ b/docs/src/task-spawning.md
@@ -29,8 +29,8 @@ it'll be passed as-is to the function `f` (with some exceptions).
 
 !!! note "Task / thread occupancy"
     By default, `Dagger` assumes that tasks saturate the thread they are running on and does not try to schedule other tasks on the thread.
-    This default can be controlled by specifying [`Sch.ThunkOptions`](@ref) (more details can be found under [Scheduler and Thunk options](@ref)).\
-    The section [Changing the thread occupancy for low-utilization tasks](@ref) shows a runnable example of how to achieve this.
+    This default can be controlled by specifying [`Sch.ThunkOptions`](@ref) (more details can be found under [Scheduler and Thunk options](@ref)).
+    The section [Changing the thread occupancy](@ref) shows a runnable example of how to achieve this.
 
 ## Options
 


### PR DESCRIPTION
This PR adds a section to the Task Spawning documentation page to explain the behavior observed in #548.