### PR TITLE
@spawn: Properly rethrow in @sync

### DIFF
--- a/src/thunk.jl
+++ b/src/thunk.jl
@@ -402,7 +402,7 @@ function _par(ex::Expr; lazy=true, recur=true, opts=())
                 let
                     $result = $spawn($f, $Options(;$(opts...)), $(args...); $(kwargs...))
                     if $(Expr(:islocal, sync_var))
-                        put!($sync_var, schedule(Task(()->wait($result))))
+                        put!($sync_var, schedule(Task(()->fetch($result; raw=true))))
                     end
                     $result
                 end

--- a/test/thunk.jl
+++ b/test/thunk.jl
@@ -348,5 +348,9 @@ end
             result = Dagger.@spawn sleep(1)
         end
         @test isready(result)
+
+        @test_throws Exception @sync begin
+            Dagger.@spawn error()
+        end
     end
 end


### PR DESCRIPTION
We need to make sure to throw an error if the launched `DTask`s error.