### PR TITLE
`@spawn`: Support NamedTuple construction and access

### DIFF
--- a/src/thunk.jl
+++ b/src/thunk.jl
@@ -366,12 +366,23 @@ function _par(ex::Expr; lazy=true, recur=true, opts=())
     f = nothing
     body = nothing
     arg1 = nothing
-    if recur && @capture(ex, f_(allargs__)) || @capture(ex, f_(allargs__) do cargs_ body_ end) || @capture(ex, allargs__->body_) || @capture(ex, arg1_[allargs__])
+    arg2 = nothing
+    if recur && @capture(ex, f_(allargs__)) ||
+                @capture(ex, f_(allargs__) do cargs_ body_ end) ||
+                @capture(ex, allargs__->body_) ||
+                @capture(ex, arg1_[allargs__]) ||
+                @capture(ex, arg1_.arg2_)
         f = replace_broadcast(f)
         if arg1 !== nothing
-            # Indexing (A[2,3])
-            f = Base.getindex
-            pushfirst!(allargs, arg1)
+            if arg2 !== nothing
+                # Getproperty (A.B)
+                f = Base.getproperty
+                allargs = Any[arg1, QuoteNode(arg2)]
+            else
+                # Indexing (A[2,3])
+                f = Base.getindex
+                pushfirst!(allargs, arg1)
+            end
         end
         args = filter(arg->!Meta.isexpr(arg, :parameters), allargs)
         kwargs = filter(arg->Meta.isexpr(arg, :parameters), allargs)

--- a/test/thunk.jl
+++ b/test/thunk.jl
@@ -129,7 +129,7 @@ end
         @test t isa Dagger.DTask
         @test fetch(t) == A[2]
 
-        B = Dagger.@spawn rand(4, 4)
+        B = @spawn rand(4, 4)
         t = @spawn B[1, 2]
         @test t isa Dagger.DTask
         @test fetch(t) == fetch(B)[1, 2]
@@ -139,12 +139,26 @@ end
         @test t isa Dagger.DTask
         @test fetch(t) == 42
     end
+    @testset "NamedTuple" begin
+        t = @spawn (;a=1, b=2)
+        @test t isa Dagger.DTask
+        @test fetch(t) == (;a=1, b=2)
+
+        t = @spawn (;)
+        @test t isa Dagger.DTask
+        @test fetch(t) == (;)
+    end
     @testset "getproperty" begin
         nt = (;a=1, b=2)
 
         t = @spawn nt.b
         @test t isa Dagger.DTask
         @test fetch(t) == nt.b
+
+        nt2 = @spawn (;a=1, b=3)
+        t = @spawn nt2.b
+        @test t isa Dagger.DTask
+        @test fetch(t) == fetch(nt2).b
     end
     @testset "invalid expression" begin
         @test_throws LoadError eval(:(@spawn 1))

--- a/test/thunk.jl
+++ b/test/thunk.jl
@@ -125,6 +125,10 @@ end
         @test t isa Dagger.DTask
         @test fetch(t) == A[1, 2]
 
+        t = @spawn A[2]
+        @test t isa Dagger.DTask
+        @test fetch(t) == A[2]
+
         B = Dagger.@spawn rand(4, 4)
         t = @spawn B[1, 2]
         @test t isa Dagger.DTask
@@ -134,6 +138,13 @@ end
         t = @spawn R[]
         @test t isa Dagger.DTask
         @test fetch(t) == 42
+    end
+    @testset "getproperty" begin
+        nt = (;a=1, b=2)
+
+        t = @spawn nt.b
+        @test t isa Dagger.DTask
+        @test fetch(t) == nt.b
     end
     @testset "invalid expression" begin
         @test_throws LoadError eval(:(@spawn 1))


### PR DESCRIPTION
Allows for doing things like:
- `Dagger.@spawn (;a=1, b=2)`
- `Dagger.@spawn a.x`