### PR TITLE
Add task/scheduler cancellation API

### DIFF
--- a/src/Dagger.jl
+++ b/src/Dagger.jl
@@ -55,6 +55,7 @@ include("thunk.jl")
 include("submission.jl")
 include("chunks.jl")
 include("memory-spaces.jl")
+include("cancellation.jl")
 
 # Task scheduling
 include("compute.jl")

--- a/src/cancellation.jl
+++ b/src/cancellation.jl
@@ -1,0 +1,128 @@
+"""
+    cancel!(task::DTask; force::Bool=false, halt_sch::Bool=false)
+
+Cancels `task` at any point in its lifecycle, causing the scheduler to abandon
+it. If `force` is `true`, the task will be interrupted with an
+`InterruptException` (not recommended, this is unsafe). If `halt_sch` is
+`true`, the scheduler will be halted after the task is cancelled (it will
+restart automatically upon the next `@spawn`/`spawn` call).
+
+As an example, the following code will cancel task `t` before it finishes
+executing:
+
+```julia
+t = Dagger.@spawn sleep(1000)
+# We're bored, let's cancel `t`
+Dagger.cancel!(t)
+```
+
+Cancellation allows the scheduler to free up execution resources for other
+tasks which are waiting to run. Using `cancel!` is generally a much safer
+alternative to Ctrl+C, as it cooperates with the scheduler and runtime and
+avoids unintended side effects.
+"""
+function cancel!(task::DTask; force::Bool=false, halt_sch::Bool=false)
+    tid = lock(Dagger.Sch.EAGER_ID_MAP) do id_map
+        id_map[task.uid]
+    end
+    cancel!(tid; force, halt_sch)
+end
+function cancel!(tid::Union{Int,Nothing}=nothing;
+                 force::Bool=false, halt_sch::Bool=false)
+    remotecall_fetch(1, tid, force, halt_sch) do tid, force, halt_sch
+        state = Sch.EAGER_STATE[]
+        state === nothing && return
+        @lock state.lock _cancel!(state, tid, force, halt_sch)
+    end
+end
+function _cancel!(state, tid, force, halt_sch)
+    @assert islocked(state.lock)
+
+    # Get the scheduler uid
+    sch_uid = state.uid
+
+    # Cancel ready tasks
+    for task in state.ready
+        tid !== nothing && task.id != tid && continue
+        @dagdebug tid :cancel "Cancelling ready task"
+        state.cache[task] = InterruptException()
+        state.errored[task] = true
+        Sch.set_failed!(state, task)
+    end
+    empty!(state.ready)
+
+    # Cancel waiting tasks
+    for task in keys(state.waiting)
+        tid !== nothing && task.id != tid && continue
+        @dagdebug tid :cancel "Cancelling waiting task"
+        state.cache[task] = InterruptException()
+        state.errored[task] = true
+        Sch.set_failed!(state, task)
+    end
+    empty!(state.waiting)
+
+    # Cancel running tasks at the processor level
+    wids = unique(map(root_worker_id, values(state.running_on)))
+    for wid in wids
+        remotecall_fetch(wid, tid, sch_uid, force) do _tid, sch_uid, force
+            Dagger.Sch.proc_states(sch_uid) do states
+                for (proc, state) in states
+                    istate = state.state
+                    any_cancelled = false
+                    @lock istate.queue begin
+                        for (tid, task) in istate.tasks
+                            _tid !== nothing && tid != _tid && continue
+                            task_spec = istate.task_specs[tid]
+                            Tf = task_spec[6]
+                            Tf === typeof(Sch.eager_thunk) && continue
+                            istaskdone(task) && continue
+                            any_cancelled = true
+                            @dagdebug tid :cancel "Cancelling running task ($Tf)"
+                            if force
+                                @dagdebug tid :cancel "Interrupting running task ($Tf)"
+                                Threads.@spawn Base.throwto(task, InterruptException())
+                            else
+                                # Tell the processor to just drop this task
+                                task_occupancy = task_spec[4]
+                                time_util = task_spec[2]
+                                istate.proc_occupancy[] -= task_occupancy
+                                istate.time_pressure[] -= time_util
+                                push!(istate.cancelled, tid)
+                                to_proc = istate.proc
+                                put!(istate.return_queue, (myid(), to_proc, tid, (InterruptException(), nothing)))
+                            end
+                        end
+                    end
+                    if any_cancelled
+                        notify(istate.reschedule)
+                    end
+                end
+            end
+            return
+        end
+    end
+
+    if halt_sch
+        unlock(state.lock)
+        try
+            # Give tasks a moment to be processed
+            sleep(0.5)
+
+            # Halt the scheduler
+            @dagdebug nothing :cancel "Halting the scheduler"
+            notify(state.halt)
+            put!(state.chan, (1, nothing, nothing, (Sch.SchedulerHaltedException(), nothing)))
+
+            # Wait for the scheduler to halt
+            @dagdebug nothing :cancel "Waiting for scheduler to halt"
+            while Sch.EAGER_INIT[]
+                sleep(0.1)
+            end
+            @dagdebug nothing :cancel "Scheduler halted"
+        finally
+            lock(state.lock)
+        end
+    end
+
+    return
+end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -49,4 +49,5 @@
     yield()
     @assert isempty(Sch.WORKER_MONITOR_CHANS)
     @assert isempty(Sch.WORKER_MONITOR_TASKS)
+    ID_COUNTER[] = 1
 end

--- a/src/threadproc.jl
+++ b/src/threadproc.jl
@@ -26,6 +26,12 @@ function execute!(proc::ThreadProc, @nospecialize(f), @nospecialize(args...); @n
         fetch(task)
         return result[]
     catch err
+        if err isa InterruptException
+            if !istaskdone(task)
+                # Propagate cancellation signal
+                Threads.@spawn Base.throwto(task, InterruptException())
+            end
+        end
         err, frames = Base.current_exceptions(task)[1]
         rethrow(CapturedException(err, frames))
     end

--- a/src/utils/dagdebug.jl
+++ b/src/utils/dagdebug.jl
@@ -2,7 +2,7 @@ function istask end
 function task_id end
 
 const DAGDEBUG_CATEGORIES = Symbol[:global, :submit, :schedule, :scope,
-                                   :take, :execute, :move, :processor]
+                                   :take, :execute, :move, :processor, :cancel]
 macro dagdebug(thunk, category, msg, args...)
     cat_sym = category.value
     @gensym id

--- a/test/scheduler.jl
+++ b/test/scheduler.jl
@@ -535,3 +535,14 @@ end
         end
     end
 end
+
+@testset "Cancellation" begin
+    t = Dagger.@spawn scope=Dagger.scope(worker=1, thread=1) sleep(100)
+    start_time = time_ns()
+    Dagger.cancel!(t)
+    @test_throws_unwrap Dagger.DTaskFailedException fetch(t)
+    t = Dagger.@spawn scope=Dagger.scope(worker=1, thread=1) yield()
+    fetch(t)
+    finish_time = time_ns()
+    @test (finish_time - start_time) * 1e-9 < 100
+end


### PR DESCRIPTION
It's a frequent situation where a task runs for a really long time, or just hangs (maybe due to a bug, or intentionally), and we just want to stop the task and move on with life. You might think that using Ctrl+C is the right way to do this, but you'll find that with Julia (and many other languages) that this frequently does not do what you want, and is just as likely to hang or crash your Julia process. This is because the request to "cancel" some running code isn't targeted, and so Julia just interrupts whatever task is running currently, which is frequently not the task that you actually wanted to cancel.

This PR adds a new function, `Dagger.cancel!`, which allows for cancelling Dagger `DTask`s in a safe way. Unlike Ctrl+C, this doesn't force the underlying task to stop (that is generally considered unsafe and impossible to always do safely and in a timely manner), but instead just "abandons" the task and lets Dagger's runtime and scheduler move on to working on other queued tasks. This releases any calls to `wait` or `fetch` that were waiting on the cancelled `DTask`, and unblocks the processor queues so that other tasks may run.

It also provides a way to halt the scheduler and allow it to restart automatically, which can prove useful for automated testing and when certain kinds of hangs occur within the scheduler.

It's expected that this functionality will eventually be wired up to a smarter Ctrl-C, so that users can regain control of a seemingly unresponsive system, or to allow prototyping algorithms in the REPL which may run for a really long time.