### PR TITLE
Replace all uses of @async with Threads.@spawn

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -40,7 +40,7 @@
         for (name, t) in tracked
             if t.state == :runnable
                 @warn "Waiting on $name"
-                @async Base.throwto(t, InterruptException())
+                Threads.@spawn Base.throwto(t, InterruptException())
             end
         end
     end


### PR DESCRIPTION
~~- Use `errormonitor_tracked()` for executing `DTask`'s~~
~~- Set `allow_errors=false` by default in the eager scheduler.~~

~~I don't know why we had `allow_errors=true` originally but it seems way too permissive, it caused some internal exceptions to not be logged when I was working on the streaming branch.~~