### PR TITLE
Use `[sources]` to specify local deps for documentation

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -21,7 +21,7 @@ jobs:
           version: '1'
       - uses: julia-actions/cache@v2
       - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop([PackageSpec(path=pwd()), PackageSpec(path=pwd() * "/lib/TimespanLogging"), PackageSpec(path=pwd() * "/lib/DaggerWebDash")]); Pkg.instantiate()'
+        run: julia --project=docs/ -e 'using Pkg; Pkg.instantiate()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -9,3 +9,9 @@ TimespanLogging = "a526e669-04d3-4846-9525-c66122c55f63"
 
 [compat]
 Documenter = "1"
+julia = "1.11"
+
+[sources]
+Dagger = {path = ".."}
+DaggerWebDash = {path = "../lib/DaggerWebDash"}
+TimespanLogging = {path = "../lib/TimespanLogging"}


### PR DESCRIPTION
In julia 1.11 new section `[sources]` was added allowing for specifying dependencies to local or unregistered packages.
This can be used in the `docs` to specify dependencies to local packages, so the documentation can be build locally without extra tweaks

Closes #552