### PR TITLE
Hash `USER` environment variable during system_uuid fallback

### DIFF
--- a/src/utils/system_uuid.jl
+++ b/src/utils/system_uuid.jl
@@ -2,7 +2,7 @@ const SYSTEM_UUIDS = Dict{Int,UUID}()
 
 function system_uuid_fallback()
     get!(SYSTEM_UUIDS, myid()) do
-        username = get(ENV, "USER", "__global")
+        username = hash(get(ENV, "USER", "__global"))
         uuid_file = joinpath(tempdir(), "dagger-system-uuid-$username")
         if !isfile(uuid_file)
             temp_uuid_file, temp_io = mktemp(; cleanup=false)


### PR DESCRIPTION
I recently encountered a system where the `USER` environment variable got set to "domain/user". Such a name then gets interpreted as a filepath which breaks the `system_uuid_fallback` logic.

As a workaround this PR hashes the variable before using it in the filepath creation. Same user names should still result in the same hash values