### PR TITLE
precompile: Switch task cleanup assert to warn

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -17,7 +17,9 @@
         GC.gc()
         yield()
     end
-    @assert length(state.thunk_dict) == 1
+    if length(state.thunk_dict) > 1
+        @warn "Precompile failed to clean up all tasks"
+    end
 
     # Halt scheduler
     notify(state.halt)


### PR DESCRIPTION
Should temporarily fix #598, although I don't like that we're suddenly now failing to clean up tasks during precompile.