### PR TITLE
Add task affinity support with compute_scope and result_scope in Dagger.jl's `@spawn` macro

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,6 +20,7 @@ makedocs(;
             "Parallel Nested Loops" => "use-cases/parallel-nested-loops.md",
         ],
         "Task Spawning" => "task-spawning.md",
+        "Task Affinity" => "task-affinity.md",
         "Data Management" => "data-management.md",
         "Distributed Arrays" => "darray.md",
         "Streaming Tasks" => "streaming.md",

--- a/docs/src/task-affinity.md
+++ b/docs/src/task-affinity.md
@@ -1,0 +1,131 @@
+# Task Affinity 
+
+Dagger's allows for precise control over task placement and result availability using scopes. Tasks are assigned based on the combination of multiple scopes: `scope`/`compute_scope`, and `result_scope` (which can all be specified with `@spawn`), and additionally the scopes of any arguments to the task (in the form of a scope attached to a `Chunk` argument). Let's take a look at how to configure these scopes, and how they work together to direct task placement.
+
+For more information on how scopes work, see [Scopes](@ref).
+
+---
+
+## Task Scopes
+
+### Scope
+
+`scope` defines the general set of locations where a Dagger task can execute. If `scope` is not specified, the task falls back to `DefaultScope()`, allowing it to run wherever execution is possible. Execution occurs on any worker within the defined scope.
+
+**Example:**
+```julia
+g = Dagger.@spawn scope=Dagger.scope(worker=3) f(x,y)
+```
+Task `g` executes only on worker 3. Its result can be accessed by any worker.
+
+---
+
+### Compute Scope
+
+Like `scope`, `compute_scope` also specifies where a Dagger task can execute. The key difference is if both `compute_scope` and `scope` are provided, `compute_scope` takes precedence over `scope` for execution placement. If neither is specified, then they default to `DefaultScope()`. 
+
+**Example:**
+```julia
+g1 = Dagger.@spawn scope=Dagger.scope(worker=2,thread=3) compute_scope=Dagger.scope((worker=1, thread=2), (worker=3, thread=1))  f(x,y)
+g2 = Dagger.@spawn compute_scope=Dagger.scope((worker=1, thread=2), (worker=3, thread=1)) f(x,y)
+```
+Tasks `g1` and `g2` execute on either thread 2 of worker 1, or thread 1 of worker 3. The `scope` argument to `g1` is ignored. Their result can be accessed by any worker.
+
+---
+
+### Result Scope  
+
+The result_scope limits the processors from which a task's result can be accessed. This can be useful for managing data locality and minimizing transfers. If `result_scope` is not specified, it defaults to `AnyScope()`, meaning the result can be accessed by any processor (including those not default enabled for task execution, such as GPUs).
+
+**Example:**
+```julia
+g = Dagger.@spawn result_scope=Dagger.scope(worker=3, threads=[1, 3, 4]) f(x,y)
+```
+The result of `g` is accessible only from threads 1, 3 and 4 of worker process 3. The task's execution may happen anywhere on threads 1, 3 and 4 of worker 3.
+
+---
+
+## Interaction of `compute_scope` and `result_scope`
+
+When `scope`/`compute_scope` and `result_scope` are specified, the scheduler executes the task on the intersection of the effective compute scope (which will be `compute_scope` if provided, otherwise `scope`) and the `result_scope`. If the intersection is empty, then the scheduler throws a `Dagger.Sch.SchedulerException` error.
+
+**Example:**
+```julia
+g = Dagger.@spawn scope=Dagger.scope(worker=3,thread=2) compute_scope=Dagger.scope(worker=2) result_scope=Dagger.scope((worker=2, thread=2), (worker=4, thread=2)) f(x,y)
+```
+The task `g` computes on thread 2 of worker 2 (as it's the intersection of compute and result scopes), but accessng its result is restricted to thread 2 of worker 2 and thread 2 of worker 4.
+
+---
+
+## Function as a Chunk
+
+This section explains how `scope`/`compute_scope` and `result_scope` affect tasks when a `Chunk` is used to specify the function to be executed by `@spawn` (e.g. created via `Dagger.tochunk(...)` or by calling `fetch(task; raw=true)` on a task). This may seem strange (to use a `Chunk` to specify the function to be executed), but it can be useful with working with callable structs, such as closures or Flux.jl models.
+
+Assume `g` is some function, e.g. `g(x, y) = x * 2 + y * 3`, and `chunk_scope` is its defined affinity.
+
+When `Dagger.tochunk(...)` is used to pass a `Chunk` as the function to be executed by `@spawn`:
+- The result is accessible only on processors in `chunk_scope`.
+- Dagger validates that there is an intersection between `chunk_scope`, the effective `compute_scope` (derived from `@spawn`'s `compute_scope` or `scope`), and the `result_scope`. If no intersection exists, the scheduler throws an exception.
+
+!!! info While `chunk_proc` is currently required when constructing a chunk, it is only used to pick the most optimal processor for accessing the chunk; it does not affect which set of processors the task may execute on.
+
+**Usage:**
+```julia
+chunk_scope = Dagger.scope(worker=3)
+chunk_proc = Dagger.OSProc(3) # not important, just needs to be a valid processor
+g(x, y) = x * 2 + y * 3
+g_chunk = Dagger.tochunk(g, chunk_proc, chunk_scope)
+h1 = Dagger.@spawn scope=Dagger.scope(worker=3) g_chunk(10, 11)
+h2 = Dagger.@spawn compute_scope=Dagger.scope((worker=1, thread=2), (worker=3, thread=1)) g_chunk(20, 21)
+h3 = Dagger.@spawn scope=Dagger.scope(worker=2,thread=3) compute_scope=Dagger.scope((worker=1, thread=2), (worker=3, thread=1)) g_chunk(30, 31)
+h4 = Dagger.@spawn result_scope=Dagger.scope(worker=3) g_chunk(40, 41)
+h5 = Dagger.@spawn scope=Dagger.scope(worker=3,thread=2) compute_scope=Dagger.scope(worker=3) result_scope=Dagger.scope(worker=3,threads=[2,3]) g_chunk(50, 51)
+```
+In all these cases (`h1` through `h5`), the tasks get executed on any processor within `chunk_scope` and its result is accessible only within `chunk_scope`.
+
+---
+
+## Chunk arguments
+
+This section details behavior when some or all of a task's arguments are `Chunk`s.
+
+Assume `g(x, y) = x * 2 + y * 3`, and `arg = Dagger.tochunk(g(1, 2), arg_proc, arg_scope)`, where `arg_scope` is the argument's defined scope. Assume `arg_scope = Dagger.scope(worker=2)`.
+
+### Scope
+If `arg_scope` and `scope` do not intersect, the scheduler throws an exception. Execution occurs on the intersection of `scope` and `arg_scope`.
+
+```julia
+h = Dagger.@spawn scope=Dagger.scope(worker=2) g(arg, 11)
+```
+Task `h` executes on any worker within the intersection of `scope` and `arg_scope`. The result is accessible from any processor.
+
+---
+
+### Compute scope and Chunk argument scopes interaction 
+If `arg_scope` and `compute_scope` do not intersect, the scheduler throws an exception. Otherwise, execution happens on the intersection of the effective compute scope (which will be `compute_scope` if provided, otherwise `scope`) and `arg_scope`.
+
+```julia
+h1 = Dagger.@spawn compute_scope=Dagger.scope((worker=1, thread=2), (worker=2, thread=1)) g(arg, 11)
+h2 = Dagger.@spawn scope=Dagger.scope(worker=2,thread=3) compute_scope=Dagger.scope((worker=1, thread=2), (worker=2, thread=1)) g(arg, 21)
+```
+Tasks `h1` and `h2` execute on any processor within the intersection of the `compute_scope` and `arg_scope`. `scope` is ignored if `compute_scope` is specified. The result is accessible from any processor.
+
+---
+
+### Result scope and Chunk argument scopes interaction
+If only `result_scope` is specified, computation happens on any processor within the intersection of `arg_scope` and `result_scope`, and the result is only accessible within `result_scope`.
+
+```julia
+h = Dagger.@spawn result_scope=Dagger.scope(worker=2) g(arg, 11)
+```
+Task `h` executes on any processor within the intersection of `arg_scope` and `result_scope`. The result is accessible from only within `result_scope`.
+
+---
+
+### Compute, result, and chunk argument scopes interaction  
+When `scope`/`compute_scope`, `result_scope`, and `Chunk` argument scopes are all used, the scheduler executes the task on the intersection of `arg_scope`, the effective compute scope (which is `compute_scope` if provided, otherwise `scope`), and `result_scope`. If no intersection exists, the scheduler throws an exception.
+
+```julia
+h = Dagger.@spawn scope=Dagger.scope(worker=3,thread=2) compute_scope=Dagger.scope(worker=2) result_scope=Dagger.scope((worker=2, thread=2), (worker=4, thread=2)) g(arg, 31)
+```
+Task `h` computes on thread 2 of worker 2 (as it's the intersection of `arg_scope`, `compute_scope`, and `result_scope`), and its result access is restricted to thread 2 of worker 2 or thread 2 of worker 4.

--- a/src/sch/Sch.jl
+++ b/src/sch/Sch.jl
@@ -14,7 +14,7 @@ import Random: randperm
 import Base: @invokelatest
 
 import ..Dagger
-import ..Dagger: Context, Processor, Thunk, WeakThunk, ThunkFuture, DTaskFailedException, Chunk, WeakChunk, OSProc, AnyScope, DefaultScope, LockedObject
+import ..Dagger: Context, Processor, Thunk, WeakThunk, ThunkFuture, DTaskFailedException, Chunk, WeakChunk, OSProc, AnyScope, DefaultScope, InvalidScope, LockedObject
 import ..Dagger: order, dependents, noffspring, istask, inputs, unwrap_weak_checked, affinity, tochunk, timespan_start, timespan_finish, procs, move, chunktype, processor, get_processors, get_parent, execute!, rmprocs!, task_processor, constrain, cputhreadtime
 import ..Dagger: @dagdebug, @safe_lock_spin1
 import DataStructures: PriorityQueue, enqueue!, dequeue_pair!, peek
@@ -726,16 +726,25 @@ function schedule!(ctx, state, procs=procs_to_use(ctx))
         sig = signature(state, task)
 
         # Calculate scope
-        scope = if task.f isa Chunk
-            task.f.scope
-        else
-            if task.options.proclist !== nothing
-                # proclist overrides scope selection
-                AnyScope()
-            else
-                DefaultScope()
+        scope = constrain(task.compute_scope, task.result_scope)
+        if scope isa InvalidScope
+            ex = SchedulingException("compute_scope and result_scope are not compatible: $(scope.x), $(scope.y)")
+            state.cache[task] = ex
+            state.errored[task] = true
+            set_failed!(state, task)
+            @goto pop_task
+        end
+        if task.f isa Chunk
+            scope = constrain(scope, task.f.scope)
+            if scope isa InvalidScope
+                ex = SchedulingException("Current scope and function Chunk Scope are not compatible: $(scope.x), $(scope.y)")
+                state.cache[task] = ex
+                state.errored[task] = true
+                set_failed!(state, task)
+                @goto pop_task
             end
         end
+
         for (_,input) in task.inputs
             input = unwrap_weak_checked(input)
             chunk = if istask(input)
@@ -747,8 +756,8 @@ function schedule!(ctx, state, procs=procs_to_use(ctx))
             end
             chunk isa Chunk || continue
             scope = constrain(scope, chunk.scope)
-            if scope isa Dagger.InvalidScope
-                ex = SchedulingException("Scopes are not compatible: $(scope.x), $(scope.y)")
+            if scope isa InvalidScope
+                ex = SchedulingException("Current scope and argument Chunk scope are not compatible: $(scope.x), $(scope.y)")
                 state.cache[task] = ex
                 state.errored[task] = true
                 set_failed!(state, task)
@@ -1086,7 +1095,7 @@ function fire_tasks!(ctx, thunks::Vector{<:Tuple}, (gproc, proc), state)
                            thunk.get_result, thunk.persist, thunk.cache, thunk.meta, options,
                            propagated, ids, positions,
                            (log_sink=ctx.log_sink, profile=ctx.profile),
-                           sch_handle, state.uid])
+                           sch_handle, state.uid, thunk.result_scope])
     end
     # N.B. We don't batch these because we might get a deserialization
     # error due to something not being defined on the worker, and then we don't
@@ -1305,7 +1314,7 @@ function start_processor_runner!(istate::ProcessorInternalState, uid::UInt64, re
                         task = task_spec[]
                         scope = task[5]
                         if !isa(constrain(scope, Dagger.ExactScope(to_proc)),
-                                Dagger.InvalidScope) &&
+                                InvalidScope) &&
                            typemax(UInt32) - proc_occupancy_cached >= occupancy
                             # Compatible, steal this task
                             return dequeue_pair!(queue)
@@ -1488,7 +1497,7 @@ function do_task(to_proc, task_desc)
         scope, Tf, data,
         send_result, persist, cache, meta,
         options, propagated, ids, positions,
-        ctx_vars, sch_handle, sch_uid = task_desc
+        ctx_vars, sch_handle, sch_uid, result_scope = task_desc
     ctx = Context(Processor[]; log_sink=ctx_vars.log_sink, profile=ctx_vars.profile)
 
     from_proc = OSProc()
@@ -1696,7 +1705,7 @@ function do_task(to_proc, task_desc)
 
         # Construct result
         # TODO: We should cache this locally
-        send_result || meta ? res : tochunk(res, to_proc; device, persist, cache=persist ? true : cache,
+        send_result || meta ? res : tochunk(res, to_proc, result_scope; device, persist, cache=persist ? true : cache,
                                             tag=options.storage_root_tag,
                                             leaf_tag=something(options.storage_leaf_tag, MemPool.Tag()),
                                             retain=options.storage_retain)

--- a/src/sch/util.jl
+++ b/src/sch/util.jl
@@ -42,9 +42,7 @@ function get_propagated_options(thunk)
     nt = NamedTuple()
     for key in thunk.propagates
         value = if key == :scope
-            isa(thunk.f, Chunk) ? thunk.f.scope : DefaultScope()
-        elseif key == :processor
-            isa(thunk.f, Chunk) ? thunk.f.processor : OSProc()
+            thunk.compute_scope
         elseif key in fieldnames(Thunk)
             getproperty(thunk, key)
         elseif key in fieldnames(ThunkOptions)
@@ -340,7 +338,7 @@ function can_use_proc(state, task, gproc, proc, opts, scope)
             scope = constrain(scope, Dagger.ExactScope(proc))
         elseif opts.proclist isa Vector
             if !(typeof(proc) in opts.proclist)
-                @dagdebug task :scope "Rejected $proc: !(typeof(proc) in proclist)"
+                @dagdebug task :scope "Rejected $proc: !(typeof(proc) in proclist) ($(opts.proclist))"
                 return false, scope
             end
             scope = constrain(scope,

--- a/test/options.jl
+++ b/test/options.jl
@@ -28,7 +28,6 @@ end
     for (option, default, value, value2) in [
         # Special handling
         (:scope, AnyScope(), ProcessScope(first_wid), ProcessScope(last_wid)),
-        (:processor, OSProc(), Dagger.ThreadProc(first_wid, 1), Dagger.ThreadProc(last_wid, 1)),
         # ThunkOptions field
         (:single, 0, first_wid, last_wid),
         # Thunk field
@@ -80,7 +79,7 @@ end
         @test fetch(Dagger.@spawn sf(obj)) == 0
         @test fetch(Dagger.@spawn sf(obj)) == 0
     end
-    Dagger.with_options(;scope=Dagger.ExactScope(Dagger.ThreadProc(1,1)), processor=OSProc(1), meta=true) do
+    Dagger.with_options(;scope=Dagger.ExactScope(Dagger.ThreadProc(1,1)), meta=true) do
         @test fetch(Dagger.@spawn sf(obj)) == 43
         @test fetch(Dagger.@spawn sf(obj)) == 43
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,7 @@ tests = [
     ("Options", "options.jl"),
     ("Mutation", "mutation.jl"),
     ("Task Queues", "task-queues.jl"),
+    ("Task Affinity", "task-affinity.jl"),
     ("Datadeps", "datadeps.jl"),
     ("Streaming", "streaming.jl"),
     ("Domain Utilities", "domain.jl"),

--- a/test/scheduler.jl
+++ b/test/scheduler.jl
@@ -1,3 +1,4 @@
+import Dagger: Chunk
 import Dagger.Sch: SchedulerOptions, ThunkOptions, SchedulerHaltedException, ComputeState, ThunkID, sch_handle
 
 @everywhere begin
@@ -162,10 +163,8 @@ end
             @test Dagger.default_enabled(Dagger.ThreadProc(1,1)) == true
             @test Dagger.default_enabled(FakeProc()) == false
 
-            opts = Dagger.Sch.ThunkOptions(;proclist=[Dagger.ThreadProc])
-            as = [delayed(identity; options=opts)(i) for i in 1:5]
-            opts = Dagger.Sch.ThunkOptions(;proclist=[FakeProc])
-            b = delayed(fakesum; options=opts)(as...)
+            as = [delayed(identity; proclist=[Dagger.ThreadProc])(i) for i in 1:5]
+            b = delayed(fakesum; proclist=[FakeProc], compute_scope=Dagger.AnyScope())(as...)
 
             @test collect(Context(), b) == FakeVal(57)
         end

--- a/test/task-affinity.jl
+++ b/test/task-affinity.jl
@@ -1,0 +1,457 @@
+@testset "Task affinity" begin
+    fetch_or_invalidscope(x::DTask) = try
+        fetch(x; raw=true)
+        nothing
+    catch err
+        @assert Dagger.Sch.unwrap_nested_exception(err) isa Dagger.Sch.SchedulingException
+        return Dagger.InvalidScope
+    end
+    get_compute_scope(x::DTask) = Dagger.Sch._find_thunk(x).compute_scope
+
+    get_result_scope(x::DTask) = Dagger.Sch._find_thunk(x).result_scope
+
+    get_final_result_scope(x::DTask) = @something(fetch_or_invalidscope(x), fetch(x; raw=true).scope)
+
+    function get_execution_scope(x::DTask)
+        res = fetch_or_invalidscope(x)
+        if res !== nothing
+            return res
+        end
+        thunk = Dagger.Sch._find_thunk(x)
+        compute_scope = thunk.compute_scope
+        result_scope = thunk.result_scope
+        f_scope = thunk.f isa Dagger.Chunk ? thunk.f.scope : Dagger.AnyScope()
+        inputs_scopes = Dagger.AbstractScope[]
+        for input in thunk.inputs
+            if input isa Dagger.Chunk
+                push!(inputs_scopes, input.scope)
+            else
+                push!(inputs_scopes, Dagger.AnyScope())
+            end
+        end
+        return Dagger.constrain(compute_scope, result_scope, f_scope, inputs_scopes...)
+    end
+
+    availprocs  = collect(Dagger.all_processors())
+    availscopes = shuffle!(Dagger.ExactScope.(availprocs))
+    numscopes   = length(availscopes)
+
+    master_proc  = Dagger.ThreadProc(1, 1)
+    master_scope = Dagger.ExactScope(master_proc)
+
+    @testset "scope, compute_scope and result_scope" begin
+        @everywhere f(x) = x + 1
+
+        @testset "scope" begin
+            scope_only = Dagger.UnionScope(rand(availscopes, rand(1:length(availscopes))))
+
+            task1 = Dagger.@spawn scope=scope_only f(10); fetch(task1)
+            @test get_compute_scope(task1) == scope_only
+            @test get_result_scope(task1) == Dagger.AnyScope()
+            @test get_final_result_scope(task1) == Dagger.AnyScope()
+            @test issubset(get_execution_scope(task1), scope_only)
+        end
+
+        @testset "compute_scope" begin
+            compute_scope_only = Dagger.UnionScope(rand(availscopes, rand(1:length(availscopes))))
+            scope              = Dagger.UnionScope(rand(availscopes, rand(1:length(availscopes))))
+
+            task1 = Dagger.@spawn compute_scope=compute_scope_only f(10);             fetch(task1)
+            task2 = Dagger.@spawn scope=scope compute_scope=compute_scope_only f(20); fetch(task2) 
+
+            @test get_compute_scope(task1) == get_compute_scope(task2) == compute_scope_only
+            @test get_result_scope(task1)  == get_result_scope(task2)  == Dagger.AnyScope()
+            @test get_final_result_scope(task1) == get_final_result_scope(task2) == Dagger.AnyScope()
+            @test issubset(get_execution_scope(task1), compute_scope_only) &&
+                  issubset(get_execution_scope(task2), compute_scope_only)
+        end
+
+        @testset "result_scope" begin
+            result_scope_only = Dagger.UnionScope(rand(availscopes, rand(1:length(availscopes))))
+
+            task1 = Dagger.@spawn result_scope=result_scope_only f(10); fetch(task1)
+
+            @test get_compute_scope(task1) == Dagger.DefaultScope()
+            @test get_result_scope(task1)  == result_scope_only
+            @test get_final_result_scope(task1) == result_scope_only
+            @test issubset(get_execution_scope(task1), result_scope_only)
+        end
+
+        @testset "compute_scope and result_scope with intersection" begin
+            if numscopes >= 3
+                n = cld(numscopes, 3)
+
+                scope_a = availscopes[1:n]
+                scope_b = availscopes[n+1:2n]
+                scope_c = availscopes[2n+1:end]
+
+                compute_scope_intersect  = Dagger.UnionScope(scope_a..., scope_b...)
+                scope_intersect          = compute_scope_intersect
+                scope_rand               = Dagger.UnionScope(rand(availscopes, rand(1:length(availscopes))))
+                result_scope_intersect   = Dagger.UnionScope(scope_b..., scope_c...)
+                all_scope_intersect      = Dagger.constrain(compute_scope_intersect, result_scope_intersect)
+
+                task1 = Dagger.@spawn compute_scope=compute_scope_intersect result_scope=result_scope_intersect f(10);                  fetch(task1)
+                task2 = Dagger.@spawn scope=scope_intersect result_scope=result_scope_intersect f(20);                                  fetch(task2)
+                task3 = Dagger.@spawn compute_scope=compute_scope_intersect scope=scope_rand result_scope=result_scope_intersect f(30); fetch(task3)
+
+                @test get_compute_scope(task1) == get_compute_scope(task2) == get_compute_scope(task3) == compute_scope_intersect
+                @test get_result_scope(task1)  == get_result_scope(task2)  == get_result_scope(task3)  == result_scope_intersect
+                @test get_final_result_scope(task1) == get_final_result_scope(task2) == get_final_result_scope(task3) == all_scope_intersect
+                @test issubset(get_execution_scope(task1), all_scope_intersect) &&
+                      issubset(get_execution_scope(task2), all_scope_intersect) &&
+                      issubset(get_execution_scope(task3), all_scope_intersect)
+            end
+        end
+
+        @testset "compute_scope and result_scope without intersection" begin
+            if length(availscopes) >= 2
+                n = cld(numscopes, 2)
+
+                scope_a = availscopes[1:n]
+                scope_b = availscopes[n+1:end]
+
+                compute_scope_no_intersect = Dagger.UnionScope(scope_a...)
+                scope_no_intersect         = Dagger.UnionScope(scope_a...)
+                scope_rand                 = Dagger.UnionScope(rand(availscopes, rand(1:length(availscopes))))
+                result_scope_no_intersect  = Dagger.UnionScope(scope_b...)
+
+                task1 = Dagger.@spawn compute_scope=compute_scope_no_intersect result_scope=result_scope_no_intersect f(10);                  wait(task1)
+                task2 = Dagger.@spawn scope=scope_no_intersect result_scope=result_scope_no_intersect f(20);                                  wait(task2)
+                task3 = Dagger.@spawn compute_scope=compute_scope_no_intersect scope=scope_rand result_scope=result_scope_no_intersect f(30); wait(task3)
+
+                @test get_compute_scope(task1) == get_compute_scope(task2) == get_compute_scope(task3) == compute_scope_no_intersect
+                @test get_result_scope(task1)  == get_result_scope(task2)  == get_result_scope(task3)  == result_scope_no_intersect
+                @test get_final_result_scope(task1) == get_final_result_scope(task2) == get_final_result_scope(task3) == Dagger.InvalidScope
+                @test get_execution_scope(task1) == get_execution_scope(task2) == get_execution_scope(task3) == Dagger.InvalidScope
+            end
+        end
+    end
+
+    @testset "Chunk function, scope, compute_scope and result_scope" begin 
+        @everywhere g(x, y) = x * 2 + y * 3
+
+        n = cld(numscopes, 3)
+
+        shuffle!(availscopes)
+        scope_a = availscopes[1:n]
+        scope_b = availscopes[n+1:2n]
+        scope_c = availscopes[2n+1:end]
+        @testset "scope" begin
+            scope_only  = Dagger.UnionScope(scope_a..., scope_b...)
+            chunk_proc = rand(availprocs)
+            chunk_scope = Dagger.UnionScope(scope_b..., scope_c...)
+            all_scope = Dagger.constrain(scope_only, chunk_scope)
+
+            g_chunk = Dagger.tochunk(g, chunk_proc, chunk_scope)
+            task1  = Dagger.@spawn scope=scope_only g_chunk(10, 11); fetch(task1)
+
+            @test get_compute_scope(task1) == scope_only
+            @test get_result_scope(task1)  == Dagger.AnyScope()
+            @test get_final_result_scope(task1) == Dagger.AnyScope()
+            @test issetequal(get_execution_scope(task1), all_scope)
+        end
+
+        shuffle!(availscopes)
+        scope_a = availscopes[1:n]
+        scope_b = availscopes[n+1:2n]
+        scope_c = availscopes[2n+1:end]
+        @testset "compute_scope" begin
+            compute_scope_only = Dagger.UnionScope(scope_a..., scope_b...)
+            scope              = Dagger.UnionScope(scope_c...)
+            chunk_proc         = rand(availprocs)
+            chunk_scope        = Dagger.UnionScope(scope_b..., scope_c...)
+            all_scope          = Dagger.constrain(compute_scope_only, chunk_scope)
+
+            g_chunk = Dagger.tochunk(g, chunk_proc, chunk_scope)
+            task1  = Dagger.@spawn compute_scope=compute_scope_only g_chunk(10, 11);             fetch(task1)
+            task2  = Dagger.@spawn scope=scope compute_scope=compute_scope_only g_chunk(20, 21); fetch(task2)
+
+            @test get_compute_scope(task1) == get_compute_scope(task2) == compute_scope_only
+            @test get_result_scope(task1)  == get_result_scope(task2)  == Dagger.AnyScope()
+            @test get_final_result_scope(task1) == get_final_result_scope(task2) == Dagger.AnyScope()
+            @test issetequal(get_execution_scope(task1),
+                                 get_execution_scope(task2),
+                                 all_scope)
+        end
+
+        shuffle!(availscopes)
+        scope_a = availscopes[1:n]
+        scope_b = availscopes[n+1:2n]
+        scope_c = availscopes[2n+1:end]
+        @testset "result_scope" begin
+            result_scope_only = Dagger.UnionScope(scope_a..., scope_b...)
+            chunk_proc         = rand(availprocs)
+            chunk_scope        = Dagger.UnionScope(scope_b..., scope_c...)
+            all_scope = Dagger.constrain(result_scope_only, chunk_scope)
+
+            g_chunk = Dagger.tochunk(g, chunk_proc, chunk_scope)
+            task1  = Dagger.@spawn result_scope=result_scope_only g_chunk(10, 11); fetch(task1)
+
+            @test get_compute_scope(task1) == Dagger.DefaultScope()
+            @test get_result_scope(task1)  == result_scope_only
+            @test get_final_result_scope(task1) == result_scope_only
+            @test issetequal(get_execution_scope(task1), all_scope)
+        end
+
+        shuffle!(availscopes)
+        scope_a = availscopes[1:n]
+        scope_b = availscopes[n+1:2n]
+        scope_c = availscopes[2n+1:end]
+        @testset "compute_scope and result_scope with intersection" begin
+            if length(availscopes) >= 3
+                compute_scope_intersect  = Dagger.UnionScope(scope_a..., scope_b...)
+                scope_intersect          = compute_scope_intersect
+                scope_rand               = Dagger.UnionScope(rand(availscopes, rand(1:length(availscopes))))
+                result_scope_intersect   = Dagger.UnionScope(scope_b..., scope_c...)
+                chunk_proc               = rand(availprocs)
+                chunk_scope              = Dagger.UnionScope(scope_b..., scope_c...)
+                all_scope = Dagger.constrain(compute_scope_intersect, result_scope_intersect, chunk_scope)
+
+                g_chunk = Dagger.tochunk(g, chunk_proc, chunk_scope)
+                task1  = Dagger.@spawn compute_scope=compute_scope_intersect result_scope=result_scope_intersect g_chunk(10, 11);                  fetch(task1)
+                task2  = Dagger.@spawn scope=scope_intersect result_scope=result_scope_intersect g_chunk(20, 21);                                  fetch(task2)
+                task3  = Dagger.@spawn compute_scope=compute_scope_intersect scope=scope_rand result_scope=result_scope_intersect g_chunk(30, 31); fetch(task3)
+
+                @test get_compute_scope(task1) == get_compute_scope(task2) == get_compute_scope(task3) == compute_scope_intersect
+                @test get_result_scope(task1)  == get_result_scope(task2)  == get_result_scope(task3)  == result_scope_intersect
+                @test get_final_result_scope(task1) == get_final_result_scope(task2) == get_final_result_scope(task3) == result_scope_intersect
+                @test issetequal(get_execution_scope(task1),
+                                     get_execution_scope(task2),
+                                     get_execution_scope(task3),
+                                     all_scope)
+            end
+        end
+
+        shuffle!(availscopes)
+        scope_a = availscopes[1:n]
+        scope_b = availscopes[n+1:end]
+        @testset "compute_scope and result_scope without intersection" begin
+            if length(availscopes) >= 2
+                n = cld(length(availscopes), 2)
+
+                compute_scope_no_intersect = Dagger.UnionScope(scope_a...)
+                scope_no_intersect         = Dagger.UnionScope(scope_a...)
+                scope_rand                 = Dagger.UnionScope(rand(availscopes, rand(1:length(availscopes))))
+                result_scope_no_intersect  = Dagger.UnionScope(scope_b...)
+                chunk_proc                 = rand(availprocs)
+                chunk_scope                = Dagger.UnionScope(scope_b..., scope_c...)
+
+                g_chunk = Dagger.tochunk(g, chunk_proc, chunk_scope)
+                task1  = Dagger.@spawn compute_scope=compute_scope_no_intersect result_scope=result_scope_no_intersect g_chunk(10, 11);                  wait(task1)
+                task2  = Dagger.@spawn scope=scope_no_intersect result_scope=result_scope_no_intersect g_chunk(20, 21);                                  wait(task2)
+                task3  = Dagger.@spawn compute_scope=compute_scope_no_intersect scope=scope_rand result_scope=result_scope_no_intersect g_chunk(30, 31); wait(task3)
+
+                @test get_compute_scope(task1) == get_compute_scope(task2) == get_compute_scope(task3) == compute_scope_no_intersect
+                @test get_result_scope(task1)  == get_result_scope(task2)  == get_result_scope(task3)  == result_scope_no_intersect
+                @test get_final_result_scope(task1) == get_final_result_scope(task2) == get_final_result_scope(task3) == Dagger.InvalidScope
+                @test get_execution_scope(task1) == get_execution_scope(task2) == get_execution_scope(task3) == Dagger.InvalidScope
+            end
+        end
+
+    end 
+
+    @testset "Chunk arguments, scope, compute_scope and result_scope with non-intersection of chunk arg and scope" begin 
+        @everywhere g(x, y) = x * 2 + y * 3
+
+        n = cld(numscopes, 2)
+        scope_a = availscopes[1:n]
+        scope_b = availscopes[n+1:end]
+
+        arg_scope = Dagger.UnionScope(scope_a...)
+        arg_proc = rand(availprocs)
+        arg    = Dagger.tochunk(g(1, 2), arg_proc, arg_scope)
+
+        @testset "scope" begin
+            scope_only  = Dagger.UnionScope(rand(scope_b, rand(1:length(scope_b))))
+
+            task11 = Dagger.@spawn scope=scope_only g(arg, 11); wait(task11)
+
+            @test get_compute_scope(task11) == scope_only
+            @test get_result_scope(task11)  == Dagger.AnyScope()
+            @test get_final_result_scope(task11) == Dagger.InvalidScope
+            execution_scope11     = get_execution_scope(task11)
+
+            @test execution_scope11 == Dagger.InvalidScope
+        end
+
+        @testset "compute_scope" begin
+            compute_scope_only = Dagger.UnionScope(rand(scope_b, rand(1:length(scope_b))))
+            scope              = Dagger.UnionScope(rand(scope_b, rand(1:length(scope_b))))
+
+            task11 = Dagger.@spawn compute_scope=compute_scope_only  g(arg, 11);            wait(task11)
+            task21 = Dagger.@spawn scope=scope compute_scope=compute_scope_only g(arg, 21); wait(task21)
+
+            @test get_compute_scope(task11) == get_compute_scope(task21) == compute_scope_only
+            @test get_result_scope(task11)  == get_result_scope(task21)  == Dagger.AnyScope()
+            @test get_final_result_scope(task11) == get_final_result_scope(task21) == Dagger.InvalidScope
+            @test get_execution_scope(task11) == get_execution_scope(task21) == Dagger.InvalidScope
+        end
+
+        @testset "result_scope" begin
+            result_scope_only = Dagger.UnionScope(rand(scope_b, rand(1:length(scope_b))))
+
+            task11  = Dagger.@spawn result_scope=result_scope_only g(arg, 11); wait(task11)
+
+            @test get_compute_scope(task11) == Dagger.DefaultScope()
+            @test get_result_scope(task11)  == result_scope_only
+            @test get_final_result_scope(task11) == Dagger.InvalidScope
+            @test get_execution_scope(task11) == Dagger.InvalidScope
+        end
+
+        @testset "compute_scope and result_scope with intersection" begin
+            if length(scope_b) >= 3
+                n = cld(length(scope_b), 3)
+
+                scope_ba = scope_b[1:n]
+                scope_bb = scope_b[n+1:2n]
+                scope_bc = scope_b[2n+1:end]
+
+                compute_scope_intersect  = Dagger.UnionScope(scope_ba..., scope_bb...)
+                scope_intersect          = compute_scope_intersect
+                scope_rand               = Dagger.UnionScope(rand(availscopes, rand(1:length(availscopes))))
+                result_scope_intersect   = Dagger.UnionScope(scope_bb..., scope_bc...)
+
+                task11  = Dagger.@spawn compute_scope=compute_scope_intersect result_scope=result_scope_intersect g(arg, 11);                          wait(task11)
+                task21  = Dagger.@spawn scope=scope_intersect result_scope=result_scope_intersect g(arg, 21);                                          wait(task21)
+                task31  = Dagger.@spawn compute_scope=compute_scope_intersect scope=scope_rand result_scope=result_scope_intersect g(arg, 31);         wait(task31)
+
+                @test get_compute_scope(task11) == get_compute_scope(task21) == get_compute_scope(task31) == compute_scope_intersect
+                @test get_result_scope(task11)  == get_result_scope(task21)  == get_result_scope(task31)  == result_scope_intersect
+                @test get_final_result_scope(task11) == get_final_result_scope(task21) == get_final_result_scope(task31) == Dagger.InvalidScope
+                @test get_execution_scope(task11) == get_execution_scope(task21) == get_execution_scope(task31) == Dagger.InvalidScope
+            end
+        end
+
+        @testset "compute_scope and result_scope without intersection" begin
+            if length(scope_b) >= 2
+                n = cld(length(scope_b), 2)
+
+                scope_ba = scope_b[1:n]
+                scope_bb = scope_b[n+1:end]
+
+                compute_scope_no_intersect = Dagger.UnionScope(scope_ba...)
+                scope_no_intersect         = Dagger.UnionScope(scope_ba...)
+                scope_rand                 = Dagger.UnionScope(rand(availscopes, rand(1:length(availscopes))))
+                result_scope_no_intersect  = Dagger.UnionScope(scope_bb...)
+
+                task11  = Dagger.@spawn compute_scope=compute_scope_no_intersect result_scope=result_scope_no_intersect g(arg, 11);                  wait(task11)
+                task21  = Dagger.@spawn scope=scope_no_intersect result_scope=result_scope_no_intersect g(arg, 21);                                  wait(task21)
+                task31  = Dagger.@spawn compute_scope=compute_scope_no_intersect scope=scope_rand result_scope=result_scope_no_intersect g(arg, 31); wait(task31)
+
+                @test get_compute_scope(task11) == get_compute_scope(task21) == get_compute_scope(task31) == compute_scope_no_intersect
+                @test get_result_scope(task11)  == get_result_scope(task21)  == get_result_scope(task31)  == result_scope_no_intersect
+                @test get_final_result_scope(task11) == get_final_result_scope(task21) == get_final_result_scope(task31) == Dagger.InvalidScope
+                @test get_execution_scope(task11) == get_execution_scope(task21) == get_execution_scope(task31) == Dagger.InvalidScope
+            end
+        end
+
+    end
+
+    @testset "Chunk arguments, scope, compute_scope and result_scope with intersection of chunk arg and scope" begin 
+        @everywhere g(x, y) = x * 2 + y * 3
+
+        shuffle!(availscopes)
+        n = cld(numscopes, 3)
+        scope_a = availscopes[1:n]
+        scope_b = availscopes[n+1:2n]
+        scope_c = availscopes[2n+1:end]
+
+        arg_scope = Dagger.UnionScope(scope_a..., scope_b...)
+        arg_proc = rand(availprocs)
+        arg    = Dagger.tochunk(g(1, 2), arg_proc, arg_scope)
+
+        @testset "scope" begin
+            scope_only  = Dagger.UnionScope(scope_b..., scope_c...)
+            all_scope   = Dagger.constrain(scope_only, arg_scope)
+
+            task11  = Dagger.@spawn scope=scope_only g(arg, 11); fetch(task11)
+
+            @test get_compute_scope(task11) == scope_only
+            @test get_result_scope(task11)  == Dagger.AnyScope()
+            @test get_final_result_scope(task11) == Dagger.AnyScope()
+            @test issetequal(get_execution_scope(task11), all_scope)
+        end
+
+        @testset "compute_scope" begin
+            compute_scope_only = Dagger.UnionScope(scope_b..., scope_c...)
+            scope              = Dagger.UnionScope(scope_b..., scope_c...)
+            all_scope          = Dagger.constrain(compute_scope_only, arg_scope)
+
+            task11  = Dagger.@spawn compute_scope=compute_scope_only g(arg, 11);             fetch(task11)
+            task21  = Dagger.@spawn scope=scope compute_scope=compute_scope_only g(arg, 21); fetch(task21)
+
+            @test get_compute_scope(task11) == get_compute_scope(task21) == compute_scope_only
+            @test get_result_scope(task11)  == get_result_scope(task21)  == Dagger.AnyScope()
+            @test get_final_result_scope(task11) == get_final_result_scope(task21) == Dagger.AnyScope()
+            @test issetequal(get_execution_scope(task11),
+                                 get_execution_scope(task21),
+                                 all_scope)
+        end
+
+        @testset "result_scope" begin
+            result_scope_only  = Dagger.UnionScope(scope_b..., scope_c...)
+            all_scope          = Dagger.constrain(result_scope_only, arg_scope)
+
+            task11  = Dagger.@spawn result_scope=result_scope_only g(arg, 11); fetch(task11)
+
+            @test get_compute_scope(task11) == Dagger.DefaultScope()
+            @test get_result_scope(task11)  == result_scope_only 
+            @test get_final_result_scope(task11) == result_scope_only
+            @test issetequal(get_execution_scope(task11), all_scope)
+        end
+
+        @testset "compute_scope and result_scope with intersection" begin
+            scope_bc = [scope_b...,scope_c...]
+            if length(scope_bc) >= 3
+                n = cld(length(scope_bc), 3)
+
+                scope_bca = scope_bc[1:n]
+                scope_bcb = scope_bc[n+1:2n]
+                scope_bcc = scope_bc[2n+1:end]
+
+                compute_scope_intersect  = Dagger.UnionScope(scope_bca..., scope_bcb...)
+                scope_intersect          = compute_scope_intersect
+                scope_rand               = Dagger.UnionScope(rand(availscopes, rand(1:length(availscopes))))
+                result_scope_intersect   = Dagger.UnionScope(scope_bcb..., scope_bcc...)
+                all_scope                = Dagger.constrain(compute_scope_intersect, result_scope_intersect, arg_scope)
+
+                task11  = Dagger.@spawn compute_scope=compute_scope_intersect result_scope=result_scope_intersect g(arg, 11);                  fetch(task11)
+                task21  = Dagger.@spawn scope=scope_intersect result_scope=result_scope_intersect g(arg, 21);                                  fetch(task21)
+                task31  = Dagger.@spawn compute_scope=compute_scope_intersect scope=scope_rand result_scope=result_scope_intersect g(arg, 31); fetch(task31)
+
+                @test get_compute_scope(task11) == get_compute_scope(task21) == get_compute_scope(task31) == compute_scope_intersect
+                @test get_result_scope(task11)  == get_result_scope(task21)  == get_result_scope(task31)  == result_scope_intersect
+                @test get_final_result_scope(task11) == get_final_result_scope(task21) == get_final_result_scope(task31) == result_scope_intersect
+                @test issetequal(get_execution_scope(task11),
+                                     get_execution_scope(task21),
+                                     get_execution_scope(task31),
+                                     all_scope)
+            end
+        end
+
+        @testset "compute_scope and result_scope without intersection" begin
+            scope_bc = [scope_b...,scope_c...]
+            if length(scope_bc) >= 2
+                n = cld(length(scope_bc), 2)
+
+                scope_bca = scope_bc[1:n]
+                scope_bcb = scope_bc[n+1:end]
+
+                compute_scope_no_intersect = Dagger.UnionScope(scope_bca...)
+                scope_no_intersect         = Dagger.UnionScope(scope_bca...)
+                scope_rand                 = Dagger.UnionScope(rand(availscopes, rand(1:length(availscopes))))
+                result_scope_no_intersect  = Dagger.UnionScope(scope_bcb...)
+
+                task11  = Dagger.@spawn compute_scope=compute_scope_no_intersect result_scope=result_scope_no_intersect g(arg, 11);                  wait(task11)
+                task21  = Dagger.@spawn scope=scope_no_intersect result_scope=result_scope_no_intersect g(arg, 21);                                  wait(task21)
+                task31  = Dagger.@spawn compute_scope=compute_scope_no_intersect scope=scope_rand result_scope=result_scope_no_intersect g(arg, 31); wait(task31)
+
+                @test get_compute_scope(task11) == get_compute_scope(task21) == get_compute_scope(task31) == compute_scope_no_intersect
+                @test get_result_scope(task11)  == get_result_scope(task21)  == get_result_scope(task31)  == result_scope_no_intersect
+                @test get_final_result_scope(task11) == get_final_result_scope(task21) == get_final_result_scope(task31) == Dagger.InvalidScope
+                @test get_execution_scope(task11) == get_execution_scope(task21) == get_execution_scope(task31) == Dagger.InvalidScope
+            end
+        end
+    end
+end


### PR DESCRIPTION
- Enhanced the Thunk struct to include `compute_scope` and `result_scope` for better task execution control.
- Updated the Thunk constructor to accept new scope parameters.
- Modified the `@spawn` macro to handle the new scope parameters appropriately.
- Introduced a new test suite for task affinity, covering various scenarios with scope interactions.
- Added comprehensive documentation for task affinity, detailing the usage of `scope`, `compute_scope`, and `result_scope`.
- Implemented tests to validate behavior when using function, chunk, chunk arguments as inputs in tasks, ensuring correct scope handling.