### PR TITLE
Sch: Don't overwrite error result

### DIFF
--- a/src/sch/Sch.jl
+++ b/src/sch/Sch.jl
@@ -599,6 +599,10 @@ function scheduler_run(ctx, state::ComputeState, d::Thunk, options)
                     state.transfer_rate[] = (state.transfer_rate[] + metadata.transfer_rate) ÷ 2
                 end
             end
+            if thunk_failed && res isa RemoteException
+                res = res.captured
+            end
+            @assert !haskey(state.cache, node)
             state.cache[node] = res
             state.errored[node] = thunk_failed
             if node.options !== nothing && node.options.checkpoint !== nothing


### PR DESCRIPTION
If the upstream tip of a diamond dependency DAG fails, the downstream tip should contain an error referencing the upstream tip. Previously, it was possible for an edge of the diamond to overwrite the downstream tip's error, wiping out this error information and making debugging failing DAGs difficult. This PR fixes that and other possible overwriting situations.