### PR TITLE
Implement RowMaximum Pivoting Strategy for Distributed LU Factorization without `view`

### DIFF
--- a/docs/src/darray.md
+++ b/docs/src/darray.md
@@ -694,7 +694,7 @@ From `LinearAlgebra`:
 - `*` (Out-of-place Matrix-(Matrix/Vector) multiply)
 - `mul!` (In-place Matrix-Matrix multiply)
 - `cholesky`/`cholesky!` (In-place/Out-of-place Cholesky factorization)
-- `lu`/`lu!` (In-place/Out-of-place LU factorization (`NoPivot` only))
+- `lu`/`lu!` (In-place/Out-of-place LU factorization (`NoPivot` and `RowMaximum` only))
 
 From `AbstractFFTs`:
 - `fft`/`fft!`

--- a/docs/src/darray.md
+++ b/docs/src/darray.md
@@ -684,6 +684,9 @@ From `Base`:
 From `Random`:
 - `rand!`/`randn!`
 
+From `SparseArrays`:
+- `sprand`
+
 From `Statistics`:
 - `mean`
 - `var`

--- a/src/Dagger.jl
+++ b/src/Dagger.jl
@@ -7,7 +7,7 @@ import SparseArrays: sprand, SparseMatrixCSC
 import MemPool
 import MemPool: DRef, FileRef, poolget, poolset
 
-import Base: collect, reduce
+import Base: collect, reduce, view
 
 import LinearAlgebra
 import LinearAlgebra: Adjoint, BLAS, Diagonal, Bidiagonal, Tridiagonal, LAPACK, LowerTriangular, PosDefException, Transpose, UpperTriangular, UnitLowerTriangular, UnitUpperTriangular, diagind, ishermitian, issymmetric

--- a/src/array/lu.jl
+++ b/src/array/lu.jl
@@ -7,8 +7,6 @@ function LinearAlgebra.lu!(A::DMatrix{T}, ::LinearAlgebra.NoPivot; check::Bool=t
     mzone = -one(T)
     Ac = A.chunks
     mt, nt = size(Ac)
-    iscomplex = T <: Complex
-    trans = iscomplex ? 'C' : 'T'
 
     Dagger.spawn_datadeps() do
         for k in range(1, min(mt, nt))
@@ -29,3 +27,97 @@ function LinearAlgebra.lu!(A::DMatrix{T}, ::LinearAlgebra.NoPivot; check::Bool=t
 
     return LinearAlgebra.LU{T,DMatrix{T},DVector{Int}}(A, ipiv, 0)
 end
+
+function searchmax_pivot!(piv_idx::AbstractArray{Int}, piv_val::AbstractArray{T}, A::AbstractArray{T}, offset::Int=0) where T
+    max_idx = argmax(abs.(A[:]))
+    piv_idx[1] = offset+max_idx
+    piv_val[1] = A[max_idx]
+    println("searchmax_pivot: ", piv_idx[1], "\n", abs(piv_val[1]))
+end
+
+function update_ipiv!(ipivl, piv_idx::AbstractArray{Int}, piv_val::AbstractArray{T}, k::Int, nb::Int) where T
+    max_piv_idx = argmax(abs.(piv_val))
+    ipivl[1] = (max_piv_idx+k-2)*nb +  piv_idx[max_piv_idx]
+    println("update_ipiv: ", ipivl[1])
+end
+
+function swaprows_panel!(A::AbstractArray{T}, M::AbstractArray{T}, ipivl::AbstractVector{Int}, m::Int, p::Int, nb::Int) where T
+    q = div(ipivl[1]-1,nb) + 1
+    r = (ipivl[1]-1)%nb+1
+    if m == q
+        A[p,:], M[r,:] = M[r,:], A[p,:]
+        println("swaprows_panel: ", imag.(A[p,:]), "\n", imag.(M[r,:]))
+    end
+end
+
+function update_panel!(M::AbstractArray{T}, A::AbstractArray{T}, p::Int) where T
+    Acinv = one(T) / A[p,p]  
+    LinearAlgebra.BLAS.scal!(Acinv, view(M, :, p))
+    LinearAlgebra.BLAS.ger!(-one(T), view(M, :, p), conj.(view(A, p, p+1:size(A,2))), view(M, :, p+1:size(M,2)))
+end
+
+function swaprows_trail!(A::AbstractArray{T}, M::AbstractArray{T}, ipiv::AbstractVector{Int}, m::Int, nb::Int) where T
+    for p in eachindex(ipiv)
+        q = div(ipiv[p]-1,nb) + 1
+        r = (ipiv[p]-1)%nb+1
+        if m == q
+            A[p,:], M[r,:] = M[r,:], A[p,:]
+        println("swaprows_trail: ", imag.(A[p,:]), "\n", imag.(M[r,:]))
+        end
+    end
+end
+
+function LinearAlgebra.lu(A::DMatrix{T}, ::LinearAlgebra.RowMaximum; check::Bool=true) where T
+    A_copy = LinearAlgebra._lucopy(A, LinearAlgebra.lutype(T))
+    return LinearAlgebra.lu!(A_copy, LinearAlgebra.RowMaximum(); check=check)
+end
+function LinearAlgebra.lu!(A::DMatrix{T}, ::LinearAlgebra.RowMaximum; check::Bool=true) where T
+    zone = one(T)
+    mzone = -one(T)
+
+    Ac = A.chunks
+    mt, nt = size(Ac)
+    m,  n  = size(A)
+    mb, nb = A.partitioning.blocksize
+    
+    mb != nb && error("Unequal block sizes are not supported: mb = $mb, nb = $nb")
+
+    ipiv = DVector(collect(1:min(m, n)), Blocks(mb))
+    ipivc = ipiv.chunks
+
+    max_piv_idx = zeros(Int,mt)
+    max_piv_val = zeros(T, mt)
+ 
+    Dagger.spawn_datadeps() do
+        for k in 1:min(mt, nt)
+            for p in 1:min(nb, m-(k-1)*nb, n-(k-1)*nb)
+                Dagger.@spawn searchmax_pivot!(Out(view(max_piv_idx, k:k)), Out(view(max_piv_val, k:k)), In(view(Ac[k,k],p:min(nb,m-(k-1)*nb),p:p)), p-1)
+                for i in k+1:mt
+                    Dagger.@spawn searchmax_pivot!(Out(view(max_piv_idx, i:i)), Out(view(max_piv_val, i:i)), In(view(Ac[i,k],:,p:p)))
+                end
+                Dagger.@spawn update_ipiv!(InOut(view(ipivc[k],p:p)), In(view(max_piv_idx, k:mt)), In(view(max_piv_val, k:mt)), k, nb)
+                for i in k:mt
+                    Dagger.@spawn swaprows_panel!(InOut(Ac[k, k]), InOut(Ac[i, k]), InOut(view(ipivc[k],p:p)), i, p, nb) 
+                end
+                Dagger.@spawn update_panel!(InOut(view(Ac[k,k],p+1:min(nb,m-(k-1)*nb),:)), In(Ac[k,k]), p)
+                for i in k+1:mt
+                    Dagger.@spawn update_panel!(InOut(Ac[i, k]), In(Ac[k,k]), p)
+                end
+
+            end
+            for j in Iterators.flatten((1:k-1, k+1:nt))
+                for i in k:mt
+                    Dagger.@spawn swaprows_trail!(InOut(Ac[k, j]), InOut(Ac[i, j]), In(ipivc[k]), i, mb) 
+                end
+            end
+            for j in k+1:nt
+                Dagger.@spawn BLAS.trsm!('L', 'L', 'N', 'U', zone, In(Ac[k, k]), InOut(Ac[k, j]))
+                for i in k+1:mt
+                    Dagger.@spawn BLAS.gemm!('N', 'N', mzone, In(Ac[i, k]), In(Ac[k, j]), zone, InOut(Ac[i, j]))
+                end
+            end
+        end
+    end
+
+    return LinearAlgebra.LU{T,DMatrix{T},DVector{Int}}(A, ipiv, 0)    
+end 

--- a/src/array/lu.jl
+++ b/src/array/lu.jl
@@ -49,34 +49,35 @@ function LinearAlgebra.lu!(A::DMatrix{T}, ::LinearAlgebra.NoPivot; check::Bool =
     return LinearAlgebra.LU{T,DMatrix{T},DVector{Int}}(A, ipiv, info)
 end
 
-function searchmax_pivot!(piv_idx::AbstractVector{Int}, piv_val::AbstractVector{T}, A::AbstractMatrix{T}, offset::Int=0) where T
-    max_idx = LinearAlgebra.BLAS.iamax(A[:])
-    piv_idx[1] = offset+max_idx
-    piv_val[1] = A[max_idx]
+
+function searchmax_panel!(piv_idx::AbstractVector{Int}, piv_val::AbstractVector{T}, A::AbstractMatrix{T}, p::Int, offset::Int=1) where T
+    max_idx = LinearAlgebra.BLAS.iamax(view(A, offset:size(A,1),p))
+    piv_idx[1] = offset-1+max_idx
+    piv_val[1] = A[offset-1+max_idx,p]
 end
 
-function update_ipiv!(ipivl::AbstractVector{Int}, info::Ref{Int}, piv_idx::AbstractVector{Int}, piv_val::AbstractVector{T}, k::Int, nb::Int) where T
-    max_piv_idx = LinearAlgebra.BLAS.iamax(piv_val)
-    max_piv_val = piv_val[max_piv_idx]
+function update_ipiv!(ipivl::AbstractVector{Int}, info::Ref{Int}, piv_idx::AbstractVector{Int}, piv_val::AbstractVector{T}, p::Int, k::Int, nb::Int) where T
+    max_piv_idx = LinearAlgebra.BLAS.iamax(piv_val[k:end])
+    max_piv_val = piv_val[k-1 + max_piv_idx]
     abs_max_piv_val = max_piv_val isa Real ? abs(max_piv_val) : abs(real(max_piv_val)) + abs(imag(max_piv_val))    
     if isapprox(abs_max_piv_val, zero(T); atol=eps(real(T)))
         info[] = k
     end
-    ipivl[1] = (max_piv_idx+k-2)*nb + piv_idx[max_piv_idx]
+    ipivl[p] = (max_piv_idx+k-2)*nb + piv_idx[k-1 + max_piv_idx]
 end
 
 function swaprows_panel!(A::AbstractMatrix{T}, M::AbstractMatrix{T}, ipivl::AbstractVector{Int}, m::Int, p::Int, nb::Int) where T
-    q = div(ipivl[1]-1,nb) + 1
-    r = (ipivl[1]-1)%nb+1
+    q = div(ipivl[p]-1,nb) + 1
+    r = (ipivl[p]-1)%nb+1
     if m == q
         A[p,:], M[r,:] = M[r,:], A[p,:]
     end
 end
 
-function update_panel!(M::AbstractMatrix{T}, A::AbstractMatrix{T}, p::Int) where T
+function update_panel!(M::AbstractMatrix{T}, A::AbstractMatrix{T}, p::Int, offset::Int=1) where T
     Acinv = one(T) / A[p,p]
-    LinearAlgebra.BLAS.scal!(Acinv, view(M, :, p))
-    LinearAlgebra.BLAS.ger!(-one(T), view(M, :, p), conj.(view(A, p, p+1:size(A,2))), view(M, :, p+1:size(M,2)))
+    LinearAlgebra.BLAS.scal!(Acinv, view(M,offset:size(M,1),p))
+    LinearAlgebra.BLAS.ger!(-one(T), view(M,offset:size(M,1),p), conj.(view(A,p,p+1:size(A,2))), view(M,offset:size(M,1),p+1:size(M,2)))
 end
 
 function swaprows_trail!(A::AbstractMatrix{T}, M::AbstractMatrix{T}, ipiv::AbstractVector{Int}, m::Int, nb::Int) where T
@@ -88,6 +89,7 @@ function swaprows_trail!(A::AbstractMatrix{T}, M::AbstractMatrix{T}, ipiv::Abstr
         end
     end
 end
+
 
 function LinearAlgebra.lu(A::DMatrix{T}, ::LinearAlgebra.RowMaximum; check::Bool = true, allowsingular::Bool = false) where {T<:LinearAlgebra.BlasFloat}
     A_copy = LinearAlgebra._lucopy(A, LinearAlgebra.lutype(T))
@@ -124,15 +126,15 @@ function LinearAlgebra.lu!(A::DMatrix{T}, ::LinearAlgebra.RowMaximum; check::Boo
     Dagger.spawn_datadeps() do
         for k in 1:min(mt, nt)
             for p in 1:min(nb, m-(k-1)*nb, n-(k-1)*nb)
-                Dagger.@spawn searchmax_pivot!(Out(view(max_piv_idx, k:k)), Out(view(max_piv_val, k:k)), In(view(Ac[k,k],p:min(nb,m-(k-1)*nb),p:p)), p-1)
+                Dagger.@spawn searchmax_panel!(Out(view(max_piv_idx,k:k)), Out(view(max_piv_val,k:k)), In(Ac[k,k]), p, p)
                 for i in k+1:mt
-                    Dagger.@spawn searchmax_pivot!(Out(view(max_piv_idx, i:i)), Out(view(max_piv_val, i:i)), In(view(Ac[i,k],:,p:p)))
+                    Dagger.@spawn searchmax_panel!(Out(view(max_piv_idx,i:i)), Out(view(max_piv_val,i:i)), In(Ac[i,k]), p)
                 end
-                Dagger.@spawn update_ipiv!(InOut(view(ipivc[k],p:p)), InOut(info), In(view(max_piv_idx, k:mt)), In(view(max_piv_val, k:mt)), k, nb)
+                Dagger.@spawn update_ipiv!(InOut(ipivc[k]), InOut(info), In(max_piv_idx), In(max_piv_val), p, k, nb)
                 for i in k:mt
-                    Dagger.@spawn swaprows_panel!(InOut(Ac[k, k]), InOut(Ac[i, k]), In(view(ipivc[k],p:p)), i, p, nb)
+                    Dagger.@spawn swaprows_panel!(InOut(Ac[k, k]), InOut(Ac[i, k]), In(ipivc[k]), i, p, nb)
                 end
-                Dagger.@spawn update_panel!(InOut(view(Ac[k,k],p+1:min(nb,m-(k-1)*nb),:)), In(Ac[k,k]), p)
+                Dagger.@spawn update_panel!(InOut(Ac[k,k]), In(Ac[k,k]), p, p+1)
                 for i in k+1:mt
                     Dagger.@spawn update_panel!(InOut(Ac[i, k]), In(Ac[k,k]), p)
                 end

--- a/src/array/lu.jl
+++ b/src/array/lu.jl
@@ -37,7 +37,7 @@ end
 function update_ipiv!(ipivl::AbstractVector{Int}, piv_idx::AbstractVector{Int}, piv_val::AbstractVector{T}, k::Int, nb::Int) where T
     max_piv_idx = argmax(abs.(piv_val))
     max_piv_val = abs(piv_val[max_piv_idx])
-    isapprox(max_piv_val, zero(T); atol=eps(T)) && throw(SingularException(k))
+    isapprox(max_piv_val, zero(T); atol=eps(T)) && throw(LinearAlgebra.SingularException(k))
     ipivl[1] = (max_piv_idx+k-2)*nb +  piv_idx[max_piv_idx]
 end
 

--- a/src/array/lu.jl
+++ b/src/array/lu.jl
@@ -1,12 +1,12 @@
-LinearAlgebra.lu(A::DMatrix{T}, pivot::Union{LinearAlgebra.RowMaximum,LinearAlgebra.NoPivot} = LinearAlgebra.RowMaximum(); check::Bool=true, allowsingular::Bool=false) where {T<:LinearAlgebra.BlasFloat} = LinearAlgebra.lu(A, pivot; check=check, allowsingular=allowsingular)
+LinearAlgebra.lu(A::DMatrix{T}, pivot::Union{LinearAlgebra.RowMaximum,LinearAlgebra.NoPivot} = LinearAlgebra.RowMaximum(); check::Bool=true) where {T<:LinearAlgebra.BlasFloat} = LinearAlgebra.lu(A, pivot; check=check)
 
-LinearAlgebra.lu!(A::DMatrix{T}, pivot::Union{LinearAlgebra.RowMaximum,LinearAlgebra.NoPivot} = LinearAlgebra.RowMaximum(); check::Bool=true, allowsingular::Bool=false) where {T<:LinearAlgebra.BlasFloat} = LinearAlgebra.lu(A, pivot; check=check, allowsingular=allowsingular)
+LinearAlgebra.lu!(A::DMatrix{T}, pivot::Union{LinearAlgebra.RowMaximum,LinearAlgebra.NoPivot} = LinearAlgebra.RowMaximum(); check::Bool=true) where {T<:LinearAlgebra.BlasFloat} = LinearAlgebra.lu(A, pivot; check=check)
 
-function LinearAlgebra.lu(A::DMatrix{T}, ::LinearAlgebra.NoPivot; check::Bool = true, allowsingular::Bool = false) where {T<:LinearAlgebra.BlasFloat}
+function LinearAlgebra.lu(A::DMatrix{T}, ::LinearAlgebra.NoPivot; check::Bool = true) where {T<:LinearAlgebra.BlasFloat}
     A_copy = LinearAlgebra._lucopy(A, LinearAlgebra.lutype(T))
     return LinearAlgebra.lu!(A_copy, LinearAlgebra.NoPivot(); check=check)
 end
-function LinearAlgebra.lu!(A::DMatrix{T}, ::LinearAlgebra.NoPivot; check::Bool = true, allowsingular::Bool = false) where {T<:LinearAlgebra.BlasFloat}
+function LinearAlgebra.lu!(A::DMatrix{T}, ::LinearAlgebra.NoPivot; check::Bool = true) where {T<:LinearAlgebra.BlasFloat}
   
     check && LinearAlgebra.LAPACK.chkfinite(A)
 
@@ -43,8 +43,6 @@ function LinearAlgebra.lu!(A::DMatrix{T}, ::LinearAlgebra.NoPivot; check::Bool =
     end
 
     ipiv = DVector([i for i in 1:min(size(A)...)])
-
-    check && LinearAlgebra._check_lu_success(info, allowsingular)
 
     return LinearAlgebra.LU{T,DMatrix{T},DVector{Int}}(A, ipiv, info)
 end
@@ -91,11 +89,11 @@ function swaprows_trail!(A::AbstractMatrix{T}, M::AbstractMatrix{T}, ipiv::Abstr
 end
 
 
-function LinearAlgebra.lu(A::DMatrix{T}, ::LinearAlgebra.RowMaximum; check::Bool = true, allowsingular::Bool = false) where {T<:LinearAlgebra.BlasFloat}
+function LinearAlgebra.lu(A::DMatrix{T}, ::LinearAlgebra.RowMaximum; check::Bool = true) where {T<:LinearAlgebra.BlasFloat}
     A_copy = LinearAlgebra._lucopy(A, LinearAlgebra.lutype(T))
-    return LinearAlgebra.lu!(A_copy, LinearAlgebra.RowMaximum(); check=check, allowsingular=allowsingular)
+    return LinearAlgebra.lu!(A_copy, LinearAlgebra.RowMaximum(); check=check)
 end
-function LinearAlgebra.lu!(A::DMatrix{T}, ::LinearAlgebra.RowMaximum; check::Bool = true, allowsingular::Bool = false) where {T<:LinearAlgebra.BlasFloat}
+function LinearAlgebra.lu!(A::DMatrix{T}, ::LinearAlgebra.RowMaximum; check::Bool = true) where {T<:LinearAlgebra.BlasFloat}
     
     check && LinearAlgebra.LAPACK.chkfinite(A)
 
@@ -152,8 +150,6 @@ function LinearAlgebra.lu!(A::DMatrix{T}, ::LinearAlgebra.RowMaximum; check::Boo
             end
         end
     end
-
-    check && LinearAlgebra._check_lu_success(info[], allowsingular)
 
     return LinearAlgebra.LU{T,DMatrix{T},DVector{Int}}(A, ipiv, info[])
 end

--- a/src/array/lu.jl
+++ b/src/array/lu.jl
@@ -9,7 +9,7 @@ function LinearAlgebra.lu!(A::DMatrix{T}, ::LinearAlgebra.NoPivot; check::Bool=t
     mt, nt = size(Ac)
     mb, nb = A.partitioning.blocksize
 
-    mb != nb && error("Unequal block sizes are not supported: mb = $mb, nb = $nb")
+    mb != nb && throw(ArgumentError("Unequal block sizes are not supported: mb = $mb, nb = $nb"))
 
     Dagger.spawn_datadeps() do
         for k in range(1, min(mt, nt))
@@ -82,7 +82,7 @@ function LinearAlgebra.lu!(A::DMatrix{T}, ::LinearAlgebra.RowMaximum; check::Boo
     m,  n  = size(A)
     mb, nb = A.partitioning.blocksize
 
-    mb != nb && error("Unequal block sizes are not supported: mb = $mb, nb = $nb")
+    mb != nb && throw(ArgumentError("Unequal block sizes are not supported: mb = $mb, nb = $nb"))
 
     ipiv = DVector(collect(1:min(m, n)), Blocks(mb))
     ipivc = ipiv.chunks

--- a/src/array/lu.jl
+++ b/src/array/lu.jl
@@ -28,18 +28,18 @@ function LinearAlgebra.lu!(A::DMatrix{T}, ::LinearAlgebra.NoPivot; check::Bool=t
     return LinearAlgebra.LU{T,DMatrix{T},DVector{Int}}(A, ipiv, 0)
 end
 
-function searchmax_pivot!(piv_idx::AbstractArray{Int}, piv_val::AbstractArray{T}, A::AbstractArray{T}, offset::Int=0) where T
+function searchmax_pivot!(piv_idx::AbstractVector{Int}, piv_val::AbstractVector{T}, A::AbstractMatrix{T}, offset::Int=0) where T
     max_idx = argmax(abs.(A[:]))
     piv_idx[1] = offset+max_idx
     piv_val[1] = A[max_idx]
 end
 
-function update_ipiv!(ipivl, piv_idx::AbstractArray{Int}, piv_val::AbstractArray{T}, k::Int, nb::Int) where T
+function update_ipiv!(ipivl::AbstractVector{Int}, piv_idx::AbstractVector{Int}, piv_val::AbstractVector{T}, k::Int, nb::Int) where T
     max_piv_idx = argmax(abs.(piv_val))
     ipivl[1] = (max_piv_idx+k-2)*nb +  piv_idx[max_piv_idx]
 end
 
-function swaprows_panel!(A::AbstractArray{T}, M::AbstractArray{T}, ipivl::AbstractVector{Int}, m::Int, p::Int, nb::Int) where T
+function swaprows_panel!(A::AbstractMatrix{T}, M::AbstractMatrix{T}, ipivl::AbstractVector{Int}, m::Int, p::Int, nb::Int) where T
     q = div(ipivl[1]-1,nb) + 1
     r = (ipivl[1]-1)%nb+1
     if m == q
@@ -47,13 +47,13 @@ function swaprows_panel!(A::AbstractArray{T}, M::AbstractArray{T}, ipivl::Abstra
     end
 end
 
-function update_panel!(M::AbstractArray{T}, A::AbstractArray{T}, p::Int) where T
+function update_panel!(M::AbstractMatrix{T}, A::AbstractMatrix{T}, p::Int) where T
     Acinv = one(T) / A[p,p]  
     LinearAlgebra.BLAS.scal!(Acinv, view(M, :, p))
     LinearAlgebra.BLAS.ger!(-one(T), view(M, :, p), conj.(view(A, p, p+1:size(A,2))), view(M, :, p+1:size(M,2)))
 end
 
-function swaprows_trail!(A::AbstractArray{T}, M::AbstractArray{T}, ipiv::AbstractVector{Int}, m::Int, nb::Int) where T
+function swaprows_trail!(A::AbstractMatrix{T}, M::AbstractMatrix{T}, ipiv::AbstractVector{Int}, m::Int, nb::Int) where T
     for p in eachindex(ipiv)
         q = div(ipiv[p]-1,nb) + 1
         r = (ipiv[p]-1)%nb+1

--- a/src/array/lu.jl
+++ b/src/array/lu.jl
@@ -29,7 +29,7 @@ function LinearAlgebra.lu!(A::DMatrix{T}, ::LinearAlgebra.NoPivot; check::Bool =
 
     Dagger.spawn_datadeps() do
         for k in range(1, min(mt, nt))
-            Dagger.@spawn LinearAlgebra.generic_lufact!(InOut(Ac[k, k]), LinearAlgebra.NoPivot(); check, allowsingular)
+            Dagger.@spawn LinearAlgebra.generic_lufact!(InOut(Ac[k, k]), LinearAlgebra.NoPivot(); check=check, allowsingular=allowsingular)
             for m in range(k+1, mt)
                 Dagger.@spawn BLAS.trsm!('R', 'U', 'N', 'N', zone, In(Ac[k, k]), InOut(Ac[m, k]))
             end

--- a/src/array/lu.jl
+++ b/src/array/lu.jl
@@ -36,6 +36,8 @@ end
 
 function update_ipiv!(ipivl::AbstractVector{Int}, piv_idx::AbstractVector{Int}, piv_val::AbstractVector{T}, k::Int, nb::Int) where T
     max_piv_idx = argmax(abs.(piv_val))
+    max_piv_val = abs(piv_val[max_piv_idx])
+    isapprox(max_piv_val, zero(T); atol=eps(T)) && throw(SingularException(k))
     ipivl[1] = (max_piv_idx+k-2)*nb +  piv_idx[max_piv_idx]
 end
 

--- a/src/array/lu.jl
+++ b/src/array/lu.jl
@@ -37,7 +37,7 @@ end
 function update_ipiv!(ipivl::AbstractVector{Int}, piv_idx::AbstractVector{Int}, piv_val::AbstractVector{T}, k::Int, nb::Int) where T
     max_piv_idx = argmax(abs.(piv_val))
     max_piv_val = abs(piv_val[max_piv_idx])
-    isapprox(max_piv_val, zero(T); atol=eps(T)) && throw(LinearAlgebra.SingularException(k))
+    isapprox(max_piv_val, zero(T); atol=eps(real(T))) && throw(LinearAlgebra.SingularException(k))
     ipivl[1] = (max_piv_idx+k-2)*nb +  piv_idx[max_piv_idx]
 end
 

--- a/src/array/lu.jl
+++ b/src/array/lu.jl
@@ -29,15 +29,16 @@ function LinearAlgebra.lu!(A::DMatrix{T}, ::LinearAlgebra.NoPivot; check::Bool=t
 end
 
 function searchmax_pivot!(piv_idx::AbstractVector{Int}, piv_val::AbstractVector{T}, A::AbstractMatrix{T}, offset::Int=0) where T
-    max_idx = argmax(abs.(A[:]))
+    max_idx = LinearAlgebra.BLAS.iamax(A[:])
     piv_idx[1] = offset+max_idx
     piv_val[1] = A[max_idx]
 end
 
 function update_ipiv!(ipivl::AbstractVector{Int}, piv_idx::AbstractVector{Int}, piv_val::AbstractVector{T}, k::Int, nb::Int) where T
-    max_piv_idx = argmax(abs.(piv_val))
-    max_piv_val = abs(piv_val[max_piv_idx])
-    isapprox(max_piv_val, zero(T); atol=eps(real(T))) && throw(LinearAlgebra.SingularException(k))
+    max_piv_idx = LinearAlgebra.BLAS.iamax(piv_val)
+    max_piv_val = piv_val[max_piv_idx]
+    abs_max_piv_val = max_piv_val isa Real ? abs(max_piv_val) : abs(real(max_piv_val)) + abs(imag(max_piv_val))
+    isapprox(abs_max_piv_val, zero(T); atol=eps(real(T))) && throw(LinearAlgebra.SingularException(k))
     ipivl[1] = (max_piv_idx+k-2)*nb +  piv_idx[max_piv_idx]
 end
 

--- a/src/array/lu.jl
+++ b/src/array/lu.jl
@@ -32,13 +32,11 @@ function searchmax_pivot!(piv_idx::AbstractArray{Int}, piv_val::AbstractArray{T}
     max_idx = argmax(abs.(A[:]))
     piv_idx[1] = offset+max_idx
     piv_val[1] = A[max_idx]
-    println("searchmax_pivot: ", piv_idx[1], "\n", abs(piv_val[1]))
 end
 
 function update_ipiv!(ipivl, piv_idx::AbstractArray{Int}, piv_val::AbstractArray{T}, k::Int, nb::Int) where T
     max_piv_idx = argmax(abs.(piv_val))
     ipivl[1] = (max_piv_idx+k-2)*nb +  piv_idx[max_piv_idx]
-    println("update_ipiv: ", ipivl[1])
 end
 
 function swaprows_panel!(A::AbstractArray{T}, M::AbstractArray{T}, ipivl::AbstractVector{Int}, m::Int, p::Int, nb::Int) where T
@@ -46,7 +44,6 @@ function swaprows_panel!(A::AbstractArray{T}, M::AbstractArray{T}, ipivl::Abstra
     r = (ipivl[1]-1)%nb+1
     if m == q
         A[p,:], M[r,:] = M[r,:], A[p,:]
-        println("swaprows_panel: ", imag.(A[p,:]), "\n", imag.(M[r,:]))
     end
 end
 
@@ -62,7 +59,6 @@ function swaprows_trail!(A::AbstractArray{T}, M::AbstractArray{T}, ipiv::Abstrac
         r = (ipiv[p]-1)%nb+1
         if m == q
             A[p,:], M[r,:] = M[r,:], A[p,:]
-        println("swaprows_trail: ", imag.(A[p,:]), "\n", imag.(M[r,:]))
         end
     end
 end

--- a/src/array/lu.jl
+++ b/src/array/lu.jl
@@ -1,12 +1,12 @@
-LinearAlgebra.lu(A::DMatrix{T}, pivot::Union{LinearAlgebra.RowMaximum,LinearAlgebra.NoPivot} = LinearAlgebra.RowMaximum(); check::Bool=true) where {T<:LinearAlgebra.BlasFloat} = LinearAlgebra.lu(A, pivot; check=check)
+LinearAlgebra.lu(A::DMatrix{T}, pivot::Union{LinearAlgebra.RowMaximum,LinearAlgebra.NoPivot} = LinearAlgebra.RowMaximum(); check::Bool=true, allowsingular::Bool=false) where {T<:LinearAlgebra.BlasFloat} = LinearAlgebra.lu(A, pivot; check=check, allowsingular=allowsingular)
 
-LinearAlgebra.lu!(A::DMatrix{T}, pivot::Union{LinearAlgebra.RowMaximum,LinearAlgebra.NoPivot} = LinearAlgebra.RowMaximum(); check::Bool=true) where {T<:LinearAlgebra.BlasFloat} = LinearAlgebra.lu(A, pivot; check=check)
+LinearAlgebra.lu!(A::DMatrix{T}, pivot::Union{LinearAlgebra.RowMaximum,LinearAlgebra.NoPivot} = LinearAlgebra.RowMaximum(); check::Bool=true, allowsingular::Bool=false) where {T<:LinearAlgebra.BlasFloat} = LinearAlgebra.lu(A, pivot; check=check, allowsingular=allowsingular)
 
-function LinearAlgebra.lu(A::DMatrix{T}, ::LinearAlgebra.NoPivot; check::Bool = true) where {T<:LinearAlgebra.BlasFloat}
+function LinearAlgebra.lu(A::DMatrix{T}, ::LinearAlgebra.NoPivot; check::Bool = true, allowsingular::Bool = false) where {T<:LinearAlgebra.BlasFloat}
     A_copy = LinearAlgebra._lucopy(A, LinearAlgebra.lutype(T))
-    return LinearAlgebra.lu!(A_copy, LinearAlgebra.NoPivot(); check=check)
+    return LinearAlgebra.lu!(A_copy, LinearAlgebra.NoPivot(); check=check, allowsingular=allowsingular)
 end
-function LinearAlgebra.lu!(A::DMatrix{T}, ::LinearAlgebra.NoPivot; check::Bool = true) where {T<:LinearAlgebra.BlasFloat}
+function LinearAlgebra.lu!(A::DMatrix{T}, ::LinearAlgebra.NoPivot; check::Bool = true, allowsingular::Bool = false) where {T<:LinearAlgebra.BlasFloat}
   
     check && LinearAlgebra.LAPACK.chkfinite(A)
 
@@ -43,6 +43,8 @@ function LinearAlgebra.lu!(A::DMatrix{T}, ::LinearAlgebra.NoPivot; check::Bool =
     end
 
     ipiv = DVector([i for i in 1:min(size(A)...)])
+
+    check && LinearAlgebra._check_lu_success(info, allowsingular)
 
     return LinearAlgebra.LU{T,DMatrix{T},DVector{Int}}(A, ipiv, info)
 end
@@ -89,11 +91,11 @@ function swaprows_trail!(A::AbstractMatrix{T}, M::AbstractMatrix{T}, ipiv::Abstr
 end
 
 
-function LinearAlgebra.lu(A::DMatrix{T}, ::LinearAlgebra.RowMaximum; check::Bool = true) where {T<:LinearAlgebra.BlasFloat}
+function LinearAlgebra.lu(A::DMatrix{T}, ::LinearAlgebra.RowMaximum; check::Bool = true, allowsingular::Bool = false) where {T<:LinearAlgebra.BlasFloat}
     A_copy = LinearAlgebra._lucopy(A, LinearAlgebra.lutype(T))
-    return LinearAlgebra.lu!(A_copy, LinearAlgebra.RowMaximum(); check=check)
+    return LinearAlgebra.lu!(A_copy, LinearAlgebra.RowMaximum(); check=check, allowsingular=allowsingular)
 end
-function LinearAlgebra.lu!(A::DMatrix{T}, ::LinearAlgebra.RowMaximum; check::Bool = true) where {T<:LinearAlgebra.BlasFloat}
+function LinearAlgebra.lu!(A::DMatrix{T}, ::LinearAlgebra.RowMaximum; check::Bool = true, allowsingular::Bool = false) where {T<:LinearAlgebra.BlasFloat}
     
     check && LinearAlgebra.LAPACK.chkfinite(A)
 
@@ -150,6 +152,8 @@ function LinearAlgebra.lu!(A::DMatrix{T}, ::LinearAlgebra.RowMaximum; check::Boo
             end
         end
     end
+
+    check && LinearAlgebra._check_lu_success(info[], allowsingular)
 
     return LinearAlgebra.LU{T,DMatrix{T},DVector{Int}}(A, ipiv, info[])
 end

--- a/test/array/linalg/lu.jl
+++ b/test/array/linalg/lu.jl
@@ -31,10 +31,10 @@
     @test DA ≈ A
     @test !(B ≈ A)
 
-    # Non-square block sizes are not supported
-    @test_throws ArgumentError lu(rand(Blocks(64, 32), T, 128, 128), pivot)
-    @test_throws ArgumentError lu!(rand(Blocks(64, 32), T, 128, 128), pivot)
+    # Non-square block sizes
+    @test lu(rand(Blocks(64, 32), T, 128, 128), pivot) isa LU{T,DMatrix{T},DVector{Int}}
+    @test lu!(rand(Blocks(64, 32), T, 128, 128), pivot) isa LU{T,DMatrix{T},DVector{Int}}
 
-        # Singular Values
+    # Singular Values
     pivot == RowMaximum() || @test_throws LinearAlgebra.SingularException lu(ones(Blocks(64,64), T, 128, 128)) # FIXME: NoPivot needs Singular Exception Check
 end

--- a/test/array/linalg/lu.jl
+++ b/test/array/linalg/lu.jl
@@ -7,7 +7,7 @@
     lu_A = lu(A, pivot)
     lu_DA = lu(DA, pivot)
     @test lu_DA isa LU{T,DMatrix{T},DVector{Int}}
-    if !(T in (Float32, ComplexF32) && pivot == NoPivot()) # FIXME: NoPivot is unstable for FP32
+    if !(T in (Float32, ComplexF32)) && pivot == NoPivot() # FIXME: NoPivot is unstable for FP32
         @test lu_A.L ≈ lu_DA.L
         @test lu_A.U ≈ lu_DA.U
     end
@@ -21,7 +21,7 @@
     lu_A = lu!(A_copy, pivot)
     lu_DA = lu!(DA, pivot)
     @test lu_DA isa LU{T,DMatrix{T},DVector{Int}}
-    if !(T in (Float32, ComplexF32) && pivot == NoPivot()) # FIXME: NoPivot is unstable for FP32
+    if !(T in (Float32, ComplexF32)) && pivot == NoPivot() # FIXME: NoPivot is unstable for FP32
         @test lu_A.L ≈ lu_DA.L
         @test lu_A.U ≈ lu_DA.U
     end

--- a/test/array/linalg/lu.jl
+++ b/test/array/linalg/lu.jl
@@ -36,5 +36,5 @@
     @test lu!(rand(Blocks(64, 32), T, 128, 128), pivot) isa LU{T,DMatrix{T},DVector{Int}}
 
     # Singular Values
-    @test_throws LinearAlgebra.SingularException lu(ones(Blocks(64,64), T, 128, 128)) # FIXME: NoPivot needs Singular Exception Check
+    @test_throws LinearAlgebra.SingularException lu(ones(Blocks(64,64), T, 128, 128)) # FIXME: NoPivot needs to handle info
 end

--- a/test/array/linalg/lu.jl
+++ b/test/array/linalg/lu.jl
@@ -36,5 +36,5 @@
     @test lu!(rand(Blocks(64, 32), T, 128, 128), pivot) isa LU{T,DMatrix{T},DVector{Int}}
 
     # Singular Values
-    pivot == RowMaximum() || @test_throws LinearAlgebra.SingularException lu(ones(Blocks(64,64), T, 128, 128)) # FIXME: NoPivot needs Singular Exception Check
+    @test_throws LinearAlgebra.SingularException lu(ones(Blocks(64,64), T, 128, 128)) # FIXME: NoPivot needs Singular Exception Check
 end

--- a/test/array/linalg/lu.jl
+++ b/test/array/linalg/lu.jl
@@ -34,4 +34,7 @@
     # Non-square block sizes are not supported
     @test_throws ArgumentError lu(rand(Blocks(64, 32), T, 128, 128), pivot)
     @test_throws ArgumentError lu!(rand(Blocks(64, 32), T, 128, 128), pivot)
+
+        # Singular Values
+    pivot == RowMaximum() || @test_throws LinearAlgebra.SingularException lu(rand(Blocks(64,64), T, 128, 128)) # FIXME: NoPivot needs Singular Exception Check
 end

--- a/test/array/linalg/lu.jl
+++ b/test/array/linalg/lu.jl
@@ -30,4 +30,8 @@
     # Check that changes propagated to A
     @test DA ≈ A
     @test !(B ≈ A)
+
+    # Non-square block sizes are not supported
+    @test_throws ArgumentError lu(rand(Blocks(64, 32), T, 128, 128), pivot)
+    @test_throws ArgumentError lu!(rand(Blocks(64, 32), T, 128, 128), pivot)
 end

--- a/test/array/linalg/lu.jl
+++ b/test/array/linalg/lu.jl
@@ -1,32 +1,36 @@
-@testset "$T" for T in (Float32, Float64, ComplexF32, ComplexF64)
+@testset "$T with $pivot" for T in (Float32, Float64, ComplexF32, ComplexF64), pivot in (NoPivot(), RowMaximum())
     A = rand(T, 128, 128)
     B = copy(A)
     DA = view(A, Blocks(64, 64))
 
     # Out-of-place
-    lu_A = lu(A, NoPivot())
-    lu_DA = lu(DA, NoPivot())
+    lu_A = lu(A, pivot)
+    lu_DA = lu(DA, pivot)
     @test lu_DA isa LU{T,DMatrix{T},DVector{Int}}
-    if !(T in (Float32, ComplexF32)) # FIXME: NoPivot is unstable for FP32
+    if !(T in (Float32, ComplexF32, ComplexF64)) # FIXME: NoPivot is unstable for FP32
         @test lu_A.L ≈ lu_DA.L
         @test lu_A.U ≈ lu_DA.U
     end
-    @test lu_A.P ≈ lu_DA.P
-    @test lu_A.p ≈ lu_DA.p
+    if !(T in (ComplexF32, ComplexF64))
+        @test lu_A.P ≈ lu_DA.P
+        @test lu_A.p ≈ lu_DA.p
+    end
     # Check that lu did not modify A or DA
     @test A ≈ DA ≈ B
 
     # In-place
     A_copy = copy(A)
-    lu_A = lu!(A_copy, NoPivot())
-    lu_DA = lu!(DA, NoPivot())
+    lu_A = lu!(A_copy, pivot)
+    lu_DA = lu!(DA, pivot)
     @test lu_DA isa LU{T,DMatrix{T},DVector{Int}}
-    if !(T in (Float32, ComplexF32)) # FIXME: NoPivot is unstable for FP32
+    if !(T in (Float32, ComplexF32, ComplexF64)) # FIXME: NoPivot is unstable for FP32
         @test lu_A.L ≈ lu_DA.L
         @test lu_A.U ≈ lu_DA.U
     end
-    @test lu_A.P ≈ lu_DA.P
-    @test lu_A.p ≈ lu_DA.p
+    if !(T in (ComplexF32, ComplexF64))
+        @test lu_A.P ≈ lu_DA.P
+        @test lu_A.p ≈ lu_DA.p
+    end
     # Check that changes propagated to A
     @test DA ≈ A
     @test !(B ≈ A)

--- a/test/array/linalg/lu.jl
+++ b/test/array/linalg/lu.jl
@@ -6,15 +6,13 @@
     # Out-of-place
     lu_A = lu(A, pivot)
     lu_DA = lu(DA, pivot)
-    @test lu_DA isa LU{T,DMatrix{T},DVector{Int}}
-    if !(T in (Float32, ComplexF32, ComplexF64)) # FIXME: NoPivot is unstable for FP32
+    @test lu_DA isa LU{T,DMatrix{T},DVector{Int}} 
+    if !(T in (Float32, ComplexF32)) && pivot == NoPivot() # FIXME: NoPivot is unstable for FP32
         @test lu_A.L ≈ lu_DA.L
         @test lu_A.U ≈ lu_DA.U
     end
-    if !(T in (ComplexF32, ComplexF64))
-        @test lu_A.P ≈ lu_DA.P
-        @test lu_A.p ≈ lu_DA.p
-    end
+    @test lu_A.P ≈ lu_DA.P
+    @test lu_A.p ≈ lu_DA.p
     # Check that lu did not modify A or DA
     @test A ≈ DA ≈ B
 
@@ -23,14 +21,12 @@
     lu_A = lu!(A_copy, pivot)
     lu_DA = lu!(DA, pivot)
     @test lu_DA isa LU{T,DMatrix{T},DVector{Int}}
-    if !(T in (Float32, ComplexF32, ComplexF64)) # FIXME: NoPivot is unstable for FP32
+    if !(T in (Float32, ComplexF32)) && pivot == NoPivot() # FIXME: NoPivot is unstable for FP32
         @test lu_A.L ≈ lu_DA.L
         @test lu_A.U ≈ lu_DA.U
     end
-    if !(T in (ComplexF32, ComplexF64))
-        @test lu_A.P ≈ lu_DA.P
-        @test lu_A.p ≈ lu_DA.p
-    end
+    @test lu_A.P ≈ lu_DA.P
+    @test lu_A.p ≈ lu_DA.p
     # Check that changes propagated to A
     @test DA ≈ A
     @test !(B ≈ A)

--- a/test/array/linalg/lu.jl
+++ b/test/array/linalg/lu.jl
@@ -6,7 +6,7 @@
     # Out-of-place
     lu_A = lu(A, pivot)
     lu_DA = lu(DA, pivot)
-    @test lu_DA isa LU{T,DMatrix{T},DVector{Int}} 
+    @test lu_DA isa LU{T,DMatrix{T},DVector{Int}}
     if !(T in (Float32, ComplexF32)) && pivot == NoPivot() # FIXME: NoPivot is unstable for FP32
         @test lu_A.L ≈ lu_DA.L
         @test lu_A.U ≈ lu_DA.U

--- a/test/array/linalg/lu.jl
+++ b/test/array/linalg/lu.jl
@@ -7,7 +7,7 @@
     lu_A = lu(A, pivot)
     lu_DA = lu(DA, pivot)
     @test lu_DA isa LU{T,DMatrix{T},DVector{Int}}
-    if !(T in (Float32, ComplexF32)) && pivot == NoPivot() # FIXME: NoPivot is unstable for FP32
+    if !(T in (Float32, ComplexF32) && pivot == NoPivot()) # FIXME: NoPivot is unstable for FP32
         @test lu_A.L ≈ lu_DA.L
         @test lu_A.U ≈ lu_DA.U
     end
@@ -21,7 +21,7 @@
     lu_A = lu!(A_copy, pivot)
     lu_DA = lu!(DA, pivot)
     @test lu_DA isa LU{T,DMatrix{T},DVector{Int}}
-    if !(T in (Float32, ComplexF32)) && pivot == NoPivot() # FIXME: NoPivot is unstable for FP32
+    if !(T in (Float32, ComplexF32) && pivot == NoPivot()) # FIXME: NoPivot is unstable for FP32
         @test lu_A.L ≈ lu_DA.L
         @test lu_A.U ≈ lu_DA.U
     end

--- a/test/array/linalg/lu.jl
+++ b/test/array/linalg/lu.jl
@@ -36,5 +36,5 @@
     @test_throws ArgumentError lu!(rand(Blocks(64, 32), T, 128, 128), pivot)
 
         # Singular Values
-    pivot == RowMaximum() || @test_throws LinearAlgebra.SingularException lu(rand(Blocks(64,64), T, 128, 128)) # FIXME: NoPivot needs Singular Exception Check
+    pivot == RowMaximum() || @test_throws LinearAlgebra.SingularException lu(ones(Blocks(64,64), T, 128, 128)) # FIXME: NoPivot needs Singular Exception Check
 end


### PR DESCRIPTION
Refactor LU decomposition routines to avoid using `view` with `DArray`