### PR TITLE
PlotsExt: Move legend to outerright of plot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Manifest.toml
 *.jls
 *.dot
 docs/build
+.vscode

--- a/docs/src/darray.md
+++ b/docs/src/darray.md
@@ -684,6 +684,9 @@ From `Base`:
 From `Random`:
 - `rand!`/`randn!`
 
+From `SparseArrays`:
+- `sprand`
+
 From `Statistics`:
 - `mean`
 - `var`

--- a/ext/PlotsExt.jl
+++ b/ext/PlotsExt.jl
@@ -185,7 +185,7 @@ function Dagger.render_logs(logs::Dict, ::Val{:plots_gantt};
                 yticks=(1.5:(nrow(df) + 0.5), u),
                 xlabel="Time (seconds)", ylabel,
                 xlim=(0.0, (global_t_end - global_t_start) / 1e9),
-                legendalpha=0,
+                legendalpha=0, legend=:outertopright,
                 kwargs...)
 end
 


### PR DESCRIPTION
For easier readability and to prevent the legend from blocking view of the data itself.