### PR TITLE
Revert "Use correct world in task execution"

### DIFF
--- a/ext/CUDAExt.jl
+++ b/ext/CUDAExt.jl
@@ -253,13 +253,13 @@ Dagger.move(from_proc::CPUProc, to_proc::CuArrayDeviceProc, x::Chunk{T}) where {
     Dagger.move(from_proc, to_proc, fetch(x))
 
 # Task execution
-function Dagger.execute!(proc::CuArrayDeviceProc, world::UInt64, f, args...; kwargs...)
+function Dagger.execute!(proc::CuArrayDeviceProc, f, args...; kwargs...)
     @nospecialize f args kwargs
     tls = Dagger.get_tls()
     task = Threads.@spawn begin
         Dagger.set_tls!(tls)
         with_context!(proc)
-        result = Base.invoke_in_world(world, f, args...; kwargs...)
+        result = Base.@invokelatest f(args...; kwargs...)
         # N.B. Synchronization must be done when accessing result or args
         return result
     end

--- a/ext/IntelExt.jl
+++ b/ext/IntelExt.jl
@@ -239,13 +239,13 @@ end
 =#
 
 # Task execution
-function Dagger.execute!(proc::oneArrayDeviceProc, world::UInt64, f, args...; kwargs...)
+function Dagger.execute!(proc::oneArrayDeviceProc, f, args...; kwargs...)
     @nospecialize f args kwargs
     tls = Dagger.get_tls()
     task = Threads.@spawn begin
         Dagger.set_tls!(tls)
         with_context!(proc)
-        result = Base.invoke_in_world(world, f, args...; kwargs...)
+        result = Base.@invokelatest f(args...; kwargs...)
         # N.B. Synchronization must be done when accessing result or args
         return result
     end

--- a/ext/MetalExt.jl
+++ b/ext/MetalExt.jl
@@ -254,13 +254,13 @@ function Dagger.move_optimized(
 end
 
 # Task execution
-function Dagger.execute!(proc::MtlArrayDeviceProc, world::UInt64, f, args...; kwargs...)
+function Dagger.execute!(proc::MtlArrayDeviceProc, f, args...; kwargs...)
     @nospecialize f args kwargs
     tls = Dagger.get_tls()
     task = Threads.@spawn begin
         Dagger.set_tls!(tls)
         with_context!(proc)
-        result = Base.invoke_in_world(world, f, args...; kwargs...)
+        result = Base.@invokelatest f(args...; kwargs...)
         # N.B. Synchronization must be done when accessing result or args
         return result
     end

--- a/ext/OpenCLExt.jl
+++ b/ext/OpenCLExt.jl
@@ -222,13 +222,13 @@ Dagger.move(from_proc::CPUProc, to_proc::CLArrayDeviceProc, x::Chunk{T}) where {
     Dagger.move(from_proc, to_proc, fetch(x))
 
 # Task execution
-function Dagger.execute!(proc::CLArrayDeviceProc, world::UInt64, f, args...; kwargs...)
+function Dagger.execute!(proc::CLArrayDeviceProc, f, args...; kwargs...)
     @nospecialize f args kwargs
     tls = Dagger.get_tls()
     task = Threads.@spawn begin
         Dagger.set_tls!(tls)
         with_context!(proc)
-        result = Base.invoke_in_world(world, f, args...; kwargs...)
+        result = Base.@invokelatest f(args...; kwargs...)
         # N.B. Synchronization must be done when accessing result or args
         return result
     end

--- a/ext/PythonExt.jl
+++ b/ext/PythonExt.jl
@@ -32,8 +32,7 @@ Dagger.move(::CPUProc, ::PythonProcessor, x::Py) = x
 Dagger.move(::CPUProc, ::PythonProcessor, x::PyArray) = x
 # FIXME: Conversion from Python to Julia
 
-# N.B. We ignore world here because Python doesn't have world ages
-function Dagger.execute!(::PythonProcessor, world::UInt64, f, args...; kwargs...)
+function Dagger.execute!(::PythonProcessor, f, args...; kwargs...)
     @assert f isa Py "Function must be a Python object"
     return f(args...; kwargs...)
 end

--- a/ext/ROCExt.jl
+++ b/ext/ROCExt.jl
@@ -241,13 +241,13 @@ for lib in [BLAS, LAPACK]
 end
 
 # Task execution
-function Dagger.execute!(proc::ROCArrayDeviceProc, world::UInt64, f, args...; kwargs...)
+function Dagger.execute!(proc::ROCArrayDeviceProc, f, args...; kwargs...)
     @nospecialize f args kwargs
     tls = Dagger.get_tls()
     task = Threads.@spawn begin
         Dagger.set_tls!(tls)
         with_context!(proc)
-        result = Base.invoke_in_world(world, f, args...; kwargs...)
+        result = Base.@invokelatest f(args...; kwargs...)
         # N.B. Synchronization must be done when accessing result or args
         return result
     end

--- a/src/processor.jl
+++ b/src/processor.jl
@@ -31,12 +31,11 @@ function delete_processor_callback!(name::Symbol)
 end
 
 """
-    execute!(proc::Processor, world::UInt64, f, args...; kwargs...) -> Any
+    execute!(proc::Processor, f, args...; kwargs...) -> Any
 
 Executes the function `f` with arguments `args` and keyword arguments `kwargs`
-in inference world `world` on processor `proc`. This function can be overloaded
-by `Processor` subtypes to allow executing function calls differently than
-normal Julia.
+on processor `proc`. This function can be overloaded by `Processor` subtypes to
+allow executing function calls differently than normal Julia.
 """
 function execute! end
 

--- a/src/queue.jl
+++ b/src/queue.jl
@@ -1,6 +1,5 @@
 mutable struct DTaskSpec
     fargs::Vector{Argument}
-    world::UInt64
     options::Options
 end
 

--- a/src/sch/Sch.jl
+++ b/src/sch/Sch.jl
@@ -805,7 +805,6 @@ struct TaskSpec
     scope::Dagger.AbstractScope
     Tf::Type
     data::Vector{Argument}
-    world::UInt64
     options::Options
     ctx_vars::NamedTuple
     sch_handle::SchedulerHandle
@@ -857,7 +856,7 @@ Base.hash(task::TaskSpec, h::UInt) = hash(task.thunk_id, hash(TaskSpec, h))
         push!(to_send, TaskSpec(
             thunk.id,
             task_spec.est_time_util, task_spec.est_alloc_util, task_spec.est_occupancy,
-            task_spec.scope, Tf, args, thunk.world, options,
+            task_spec.scope, Tf, args, options,
             (log_sink=ctx.log_sink, profile=ctx.profile),
             sch_handle, state.uid))
     end
@@ -1522,7 +1521,7 @@ Executes a single task specified by `task` on `to_proc`.
 
         result = Dagger.with_options(propagated) do
             # Execute
-            execute!(to_proc, task.world, f, fetched_args...; fetched_kwargs...)
+            execute!(to_proc, f, fetched_args...; fetched_kwargs...)
         end
 
         # Check if result is safe to store

--- a/src/sch/dynamic.jl
+++ b/src/sch/dynamic.jl
@@ -235,6 +235,6 @@ function _add_thunk!(ctx, state, task, tid, (f, args, options, future))
             push!(fargs, Dagger.Argument(pos, arg))
         end
     end
-    payload = Dagger.PayloadOne(UInt(0), future, fargs, Base.get_world_counter(), _options, true)
+    payload = Dagger.PayloadOne(UInt(0), future, fargs, _options, true)
     return Dagger.eager_submit_internal!(ctx, state, task, tid, payload)
 end

--- a/src/threadproc.jl
+++ b/src/threadproc.jl
@@ -10,8 +10,7 @@ end
 iscompatible(proc::ThreadProc, opts, f, args...) = true
 iscompatible_func(proc::ThreadProc, opts, f) = true
 iscompatible_arg(proc::ThreadProc, opts, x) = true
-function execute!(proc::ThreadProc, world::UInt64, f, args...; kwargs...)
-    @nospecialize f args kwargs
+function execute!(proc::ThreadProc, @nospecialize(f), @nospecialize(args...); @nospecialize(kwargs...))
     tls = get_tls()
     # FIXME: Use return type of the call to specialize container
     result = Ref{Any}()
@@ -20,7 +19,7 @@ function execute!(proc::ThreadProc, world::UInt64, f, args...; kwargs...)
         if task_logging_enabled()
             TimespanLogging.prof_task_put!(tls.sch_handle.thunk_id.id)
         end
-        result[] = Base.invoke_in_world(world, f, args...; kwargs...)
+        result[] = @invokelatest f(args...; kwargs...)
         return
     end
     set_task_tid!(task, proc.tid)

--- a/test/fakeproc.jl
+++ b/test/fakeproc.jl
@@ -20,6 +20,6 @@ Dagger.iscompatible_arg(proc::FakeProc, opts, ::Type{<:Integer}) = true
 Dagger.iscompatible_arg(proc::FakeProc, opts, ::Type{<:FakeVal}) = true
 Dagger.move(from_proc::OSProc, to_proc::FakeProc, x::Integer) = FakeVal(x)
 Dagger.move(from_proc::ThreadProc, to_proc::FakeProc, x::Integer) = FakeVal(x)
-Dagger.execute!(proc::FakeProc, world, func, args...) = FakeVal(42+func(args...).x)
+Dagger.execute!(proc::FakeProc, func, args...) = FakeVal(42+func(args...).x)
 
 end


### PR DESCRIPTION
Reverts JuliaParallel/Dagger.jl#652

Unfortunately, I had not considered the fact that world ages may differ between workers, so this would never have been semantically correct under distributed execution. I'll have to think harder to determine how to do world tracking correctly without killing performance...