### PR TITLE
CI: Add multi-threaded job

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -53,6 +53,17 @@ steps:
       - JuliaCI/julia-coverage#v1:
           codecov: true
 
+  - label: Julia 1.11 (threads)
+    timeout_in_minutes: 120
+    <<: *test
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.11"
+      - JuliaCI/julia-test#v1:
+          julia_args: "--threads=auto"
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+
   - label: Julia 1
     timeout_in_minutes: 120
     <<: *test


### PR DESCRIPTION
Let's see if we can speed up CI by giving Dagger some threads to work with.