### PR TITLE
Free GPU memory eagerly, and various linalg fixes

### DIFF
--- a/ext/CUDAExt.jl
+++ b/ext/CUDAExt.jl
@@ -335,6 +335,37 @@ for lib in [BLAS, LAPACK]
     end
 end
 
+# Adapt RefValue
+Dagger.move(from_proc::CPUProc, to_proc::CuArrayDeviceProc, x::Base.RefValue) =
+    Dagger.GPURef(Dagger.move(from_proc, to_proc, x[]), only(Dagger.memory_spaces(to_proc)))
+Dagger.move(from_proc::CuArrayDeviceProc, to_proc::CPUProc, x::Dagger.GPURef{T,CUDAVRAMMemorySpace} where T) =
+    Ref(Dagger.move(from_proc, to_proc, x[]))
+function Dagger.move!(dep_mod, to_space::CPURAMMemorySpace, from_space::CUDAVRAMMemorySpace, to::Base.RefValue, from::Dagger.GPURef)
+    if Dagger.type_may_alias(typeof(from[]))
+        Dagger.move!(dep_mod, to_space, from_space, to[], from[])
+    else
+        to[] = dep_mod(from[])
+    end
+    return
+end
+function Dagger.move!(dep_mod, to_space::CUDAVRAMMemorySpace, from_space::CPURAMMemorySpace, to::Dagger.GPURef, from::Base.RefValue)
+    if Dagger.type_may_alias(typeof(from[]))
+        Dagger.move!(dep_mod, to_space, from_space, to[], from[])
+    else
+        to[] = dep_mod(from[])
+    end
+    return
+end
+function Dagger.move!(dep_mod, to_space::CUDAVRAMMemorySpace, from_space::CUDAVRAMMemorySpace, to::Dagger.GPURef, from::Dagger.GPURef)
+    if Dagger.type_may_alias(typeof(from[]))
+        Dagger.move!(dep_mod, to_space, from_space, to[], from[])
+    else
+        to[] = dep_mod(from[])
+    end
+    return
+end
+
+# Adapt HaloArray
 CuArray(H::Dagger.HaloArray) = convert(CuArray, H)
 Base.convert(::Type{C}, H::Dagger.HaloArray) where {C<:CuArray} =
     Dagger.HaloArray(C(H.center),

--- a/ext/CUDAExt.jl
+++ b/ext/CUDAExt.jl
@@ -56,6 +56,11 @@ function Dagger.aliasing(x::CuArray{T}) where T
     return Dagger.ContiguousAliasing(Dagger.MemorySpan{S}(rptr, sizeof(T)*length(x)))
 end
 
+function Dagger.unsafe_free!(x::CuArray)
+    CUDA.unsafe_free!(x)
+    return
+end
+
 Dagger.memory_spaces(proc::CuArrayDeviceProc) = Set([CUDAVRAMMemorySpace(proc.owner, proc.device, proc.device_uuid)])
 Dagger.processors(space::CUDAVRAMMemorySpace) = Set([CuArrayDeviceProc(space.owner, space.device, space.device_uuid)])
 

--- a/ext/CUDAExt.jl
+++ b/ext/CUDAExt.jl
@@ -316,11 +316,14 @@ end
 
 # Adapt BLAS/LAPACK functions
 import LinearAlgebra: BLAS, LAPACK
+_keep_blas_functions = Set(["iamax"])
 for lib in [BLAS, LAPACK]
     for name in names(lib; all=true)
         name == nameof(lib) && continue
         startswith(string(name), '#') && continue
-        endswith(string(name), '!') || continue
+        if !endswith(string(name), '!') && !any(endswith(string(name), func) for func in _keep_blas_functions)
+            continue
+        end
 
         for culib in [CUBLAS, CUSOLVER]
             if name in names(culib; all=true)

--- a/ext/IntelExt.jl
+++ b/ext/IntelExt.jl
@@ -283,6 +283,37 @@ function Dagger.execute!(proc::oneArrayDeviceProc, f, args...; kwargs...)
     end
 end
 
+# Adapt RefValue
+Dagger.move(from_proc::CPUProc, to_proc::oneArrayDeviceProc, x::Base.RefValue) =
+    Dagger.GPURef(Dagger.move(from_proc, to_proc, x[]), only(Dagger.memory_spaces(to_proc)))
+Dagger.move(from_proc::oneArrayDeviceProc, to_proc::CPUProc, x::Dagger.GPURef{T,IntelVRAMMemorySpace} where T) =
+    Ref(Dagger.move(from_proc, to_proc, x[]))
+function Dagger.move!(dep_mod, to_space::CPURAMMemorySpace, from_space::IntelVRAMMemorySpace, to::Base.RefValue, from::Dagger.GPURef)
+    if Dagger.type_may_alias(typeof(from[]))
+        Dagger.move!(dep_mod, to_space, from_space, to[], from[])
+    else
+        to[] = dep_mod(from[])
+    end
+    return
+end
+function Dagger.move!(dep_mod, to_space::IntelVRAMMemorySpace, from_space::CPURAMMemorySpace, to::Dagger.GPURef, from::Base.RefValue)
+    if Dagger.type_may_alias(typeof(from[]))
+        Dagger.move!(dep_mod, to_space, from_space, to[], from[])
+    else
+        to[] = dep_mod(from[])
+    end
+    return
+end
+function Dagger.move!(dep_mod, to_space::IntelVRAMMemorySpace, from_space::IntelVRAMMemorySpace, to::Dagger.GPURef, from::Dagger.GPURef)
+    if Dagger.type_may_alias(typeof(from[]))
+        Dagger.move!(dep_mod, to_space, from_space, to[], from[])
+    else
+        to[] = dep_mod(from[])
+    end
+    return
+end
+
+# Adapt HaloArray
 oneArray(H::Dagger.HaloArray) = convert(oneArray, H)
 Base.convert(::Type{C}, H::Dagger.HaloArray) where {C<:oneArray} =
     Dagger.HaloArray(C(H.center),

--- a/ext/IntelExt.jl
+++ b/ext/IntelExt.jl
@@ -248,12 +248,16 @@ Dagger.move(from_proc::CPUProc, to_proc::oneArrayDeviceProc, x::Function) = x
 Dagger.move(from_proc::CPUProc, to_proc::oneArrayDeviceProc, x::Chunk{T}) where {T<:Function} =
     Dagger.move(from_proc, to_proc, fetch(x))
 
+# Adapt BLAS/LAPACK functions (same pattern as CUDAExt/ROCExt)
 import LinearAlgebra: BLAS, LAPACK
+_keep_blas_functions = Set(["iamax"])
 for lib in [BLAS, LAPACK]
     for name in names(lib; all=true)
         name == nameof(lib) && continue
         startswith(string(name), '#') && continue
-        endswith(string(name), '!') || continue
+        if !endswith(string(name), '!') && !(string(name) in _keep_blas_functions)
+            continue
+        end
         if name in names(oneAPI.oneMKL; all=true)
             fn = getproperty(lib, name)
             mklfn = getproperty(oneAPI.oneMKL, name)

--- a/ext/IntelExt.jl
+++ b/ext/IntelExt.jl
@@ -55,6 +55,11 @@ function Dagger.aliasing(x::oneArray{T}) where T
     return Dagger.ContiguousAliasing(Dagger.MemorySpan{S}(rptr, sizeof(T)*length(x)))
 end
 
+function Dagger.unsafe_free!(x::oneArray)
+    oneAPI.unsafe_free!(x)
+    return
+end
+
 Dagger.memory_spaces(proc::oneArrayDeviceProc) = Set([IntelVRAMMemorySpace(proc.owner, proc.device_id)])
 Dagger.processors(space::IntelVRAMMemorySpace) = Set([oneArrayDeviceProc(space.owner, space.device_id)])
 

--- a/ext/MetalExt.jl
+++ b/ext/MetalExt.jl
@@ -52,6 +52,11 @@ function Dagger.aliasing(x::MtlArray{T}) where T
     return Dagger.ContiguousAliasing(Dagger.MemorySpan{S}(rptr, sizeof(T)*length(x)))
 end
 
+function Dagger.unsafe_free!(x::MtlArray)
+    Metal.unsafe_free!(x)
+    return
+end
+
 Dagger.memory_spaces(proc::MtlArrayDeviceProc) = Set([MetalVRAMMemorySpace(proc.owner, proc.device_id)])
 Dagger.processors(space::MetalVRAMMemorySpace) = Set([MtlArrayDeviceProc(space.owner, space.device_id)])
 

--- a/ext/MetalExt.jl
+++ b/ext/MetalExt.jl
@@ -311,6 +311,37 @@ function Dagger.execute!(proc::MtlArrayDeviceProc, f, args...; kwargs...)
     end
 end
 
+# Adapt RefValue
+Dagger.move(from_proc::CPUProc, to_proc::MtlArrayDeviceProc, x::Base.RefValue) =
+    Dagger.GPURef(Dagger.move(from_proc, to_proc, x[]), only(Dagger.memory_spaces(to_proc)))
+Dagger.move(from_proc::MtlArrayDeviceProc, to_proc::CPUProc, x::Dagger.GPURef{T,MetalVRAMMemorySpace} where T) =
+    Ref(Dagger.move(from_proc, to_proc, x[]))
+function Dagger.move!(dep_mod, to_space::CPURAMMemorySpace, from_space::MetalVRAMMemorySpace, to::Base.RefValue, from::Dagger.GPURef)
+    if Dagger.type_may_alias(typeof(from[]))
+        Dagger.move!(dep_mod, to_space, from_space, to[], from[])
+    else
+        to[] = dep_mod(from[])
+    end
+    return
+end
+function Dagger.move!(dep_mod, to_space::MetalVRAMMemorySpace, from_space::CPURAMMemorySpace, to::Dagger.GPURef, from::Base.RefValue)
+    if Dagger.type_may_alias(typeof(from[]))
+        Dagger.move!(dep_mod, to_space, from_space, to[], from[])
+    else
+        to[] = dep_mod(from[])
+    end
+    return
+end
+function Dagger.move!(dep_mod, to_space::MetalVRAMMemorySpace, from_space::MetalVRAMMemorySpace, to::Dagger.GPURef, from::Dagger.GPURef)
+    if Dagger.type_may_alias(typeof(from[]))
+        Dagger.move!(dep_mod, to_space, from_space, to[], from[])
+    else
+        to[] = dep_mod(from[])
+    end
+    return
+end
+
+# Adapt HaloArray
 MtlArray(H::Dagger.HaloArray) = convert(MtlArray, H)
 Base.convert(::Type{C}, H::Dagger.HaloArray) where {C<:MtlArray} =
     Dagger.HaloArray(C(H.center),

--- a/ext/OpenCLExt.jl
+++ b/ext/OpenCLExt.jl
@@ -52,6 +52,11 @@ function Dagger.aliasing(x::CLArray{T}) where T
     return Dagger.ContiguousAliasing(Dagger.MemorySpan{S}(rptr, sizeof(T)*length(x)))
 end
 
+function Dagger.unsafe_free!(x::CLArray)
+    OpenCL.unsafe_free!(x)
+    return
+end
+
 Dagger.memory_spaces(proc::CLArrayDeviceProc) = Set([CLMemorySpace(proc.owner, proc.device)])
 Dagger.processors(space::CLMemorySpace) = Set([CLArrayDeviceProc(space.owner, space.device)])
 

--- a/ext/OpenCLExt.jl
+++ b/ext/OpenCLExt.jl
@@ -285,6 +285,37 @@ function Dagger.execute!(proc::CLArrayDeviceProc, f, args...; kwargs...)
     end
 end
 
+# Adapt RefValue
+Dagger.move(from_proc::CPUProc, to_proc::CLArrayDeviceProc, x::Base.RefValue) =
+    Dagger.GPURef(Dagger.move(from_proc, to_proc, x[]), only(Dagger.memory_spaces(to_proc)))
+Dagger.move(from_proc::CLArrayDeviceProc, to_proc::CPUProc, x::Dagger.GPURef{T,CLMemorySpace} where T) =
+    Ref(Dagger.move(from_proc, to_proc, x[]))
+function Dagger.move!(dep_mod, to_space::CPURAMMemorySpace, from_space::CLMemorySpace, to::Base.RefValue, from::Dagger.GPURef)
+    if Dagger.type_may_alias(typeof(from[]))
+        Dagger.move!(dep_mod, to_space, from_space, to[], from[])
+    else
+        to[] = dep_mod(from[])
+    end
+    return
+end
+function Dagger.move!(dep_mod, to_space::CLMemorySpace, from_space::CPURAMMemorySpace, to::Dagger.GPURef, from::Base.RefValue)
+    if Dagger.type_may_alias(typeof(from[]))
+        Dagger.move!(dep_mod, to_space, from_space, to[], from[])
+    else
+        to[] = dep_mod(from[])
+    end
+    return
+end
+function Dagger.move!(dep_mod, to_space::CLMemorySpace, from_space::CLMemorySpace, to::Dagger.GPURef, from::Dagger.GPURef)
+    if Dagger.type_may_alias(typeof(from[]))
+        Dagger.move!(dep_mod, to_space, from_space, to[], from[])
+    else
+        to[] = dep_mod(from[])
+    end
+    return
+end
+
+# Adapt HaloArray
 CLArray(H::Dagger.HaloArray) = convert(CLArray, H)
 Base.convert(::Type{C}, H::Dagger.HaloArray) where {C<:CLArray} =
     Dagger.HaloArray(C(H.center),

--- a/ext/ROCExt.jl
+++ b/ext/ROCExt.jl
@@ -268,11 +268,14 @@ Dagger.move(from_proc::CPUProc, to_proc::ROCArrayDeviceProc, x::Chunk{T}) where 
 
 # Adapt BLAS/LAPACK functions
 import LinearAlgebra: BLAS, LAPACK
+_keep_blas_functions = Set(["iamax"])
 for lib in [BLAS, LAPACK]
     for name in names(lib; all=true)
         name == nameof(lib) && continue
         startswith(string(name), '#') && continue
-        endswith(string(name), '!') || continue
+        if !endswith(string(name), '!') && !any(endswith(string(name), func) for func in _keep_blas_functions)
+            continue
+        end
 
         for roclib in [rocBLAS, rocSOLVER]
             if name in names(roclib; all=true)

--- a/ext/ROCExt.jl
+++ b/ext/ROCExt.jl
@@ -266,27 +266,6 @@ Dagger.move(from_proc::CPUProc, to_proc::ROCArrayDeviceProc, x::Function) = x
 Dagger.move(from_proc::CPUProc, to_proc::ROCArrayDeviceProc, x::Chunk{T}) where {T<:Function} =
     Dagger.move(from_proc, to_proc, fetch(x))
 
-# Adapt BLAS/LAPACK functions
-import LinearAlgebra: BLAS, LAPACK
-_keep_blas_functions = Set(["iamax"])
-for lib in [BLAS, LAPACK]
-    for name in names(lib; all=true)
-        name == nameof(lib) && continue
-        startswith(string(name), '#') && continue
-        if !endswith(string(name), '!') && !any(endswith(string(name), func) for func in _keep_blas_functions)
-            continue
-        end
-
-        for roclib in [rocBLAS, rocSOLVER]
-            if name in names(roclib; all=true)
-                fn = getproperty(lib, name)
-                rocfn = getproperty(roclib, name)
-                @eval Dagger.move(from_proc::CPUProc, to_proc::ROCArrayDeviceProc, ::$(typeof(fn))) = $rocfn
-            end
-        end
-    end
-end
-
 # Task execution
 function Dagger.execute!(proc::ROCArrayDeviceProc, f, args...; kwargs...)
     @nospecialize f args kwargs
@@ -308,6 +287,58 @@ function Dagger.execute!(proc::ROCArrayDeviceProc, f, args...; kwargs...)
     end
 end
 
+# Adapt BLAS/LAPACK functions
+import LinearAlgebra: BLAS, LAPACK
+_keep_blas_functions = Set(["iamax"])
+for lib in [BLAS, LAPACK]
+    for name in names(lib; all=true)
+        name == nameof(lib) && continue
+        startswith(string(name), '#') && continue
+        if !endswith(string(name), '!') && !any(endswith(string(name), func) for func in _keep_blas_functions)
+            continue
+        end
+
+        for roclib in [rocBLAS, rocSOLVER]
+            if name in names(roclib; all=true)
+                fn = getproperty(lib, name)
+                rocfn = getproperty(roclib, name)
+                @eval Dagger.move(from_proc::CPUProc, to_proc::ROCArrayDeviceProc, ::$(typeof(fn))) = $rocfn
+            end
+        end
+    end
+end
+
+# Adapt RefValue
+Dagger.move(from_proc::CPUProc, to_proc::ROCArrayDeviceProc, x::Base.RefValue) =
+    Dagger.GPURef(Dagger.move(from_proc, to_proc, x[]), only(Dagger.memory_spaces(to_proc)))
+Dagger.move(from_proc::ROCArrayDeviceProc, to_proc::CPUProc, x::Dagger.GPURef{T,ROCVRAMMemorySpace} where T) =
+    Ref(Dagger.move(from_proc, to_proc, x[]))
+function Dagger.move!(dep_mod, to_space::CPURAMMemorySpace, from_space::ROCVRAMMemorySpace, to::Base.RefValue, from::Dagger.GPURef)
+    if Dagger.type_may_alias(typeof(from[]))
+        Dagger.move!(dep_mod, to_space, from_space, to[], from[])
+    else
+        to[] = dep_mod(from[])
+    end
+    return
+end
+function Dagger.move!(dep_mod, to_space::ROCVRAMMemorySpace, from_space::CPURAMMemorySpace, to::Dagger.GPURef, from::Base.RefValue)
+    if Dagger.type_may_alias(typeof(from[]))
+        Dagger.move!(dep_mod, to_space, from_space, to[], from[])
+    else
+        to[] = dep_mod(from[])
+    end
+    return
+end
+function Dagger.move!(dep_mod, to_space::ROCVRAMMemorySpace, from_space::ROCVRAMMemorySpace, to::Dagger.GPURef, from::Dagger.GPURef)
+    if Dagger.type_may_alias(typeof(from[]))
+        Dagger.move!(dep_mod, to_space, from_space, to[], from[])
+    else
+        to[] = dep_mod(from[])
+    end
+    return
+end
+
+# Adapt HaloArray
 ROCArray(H::Dagger.HaloArray) = convert(ROCArray, H)
 Base.convert(::Type{C}, H::Dagger.HaloArray) where {C<:ROCArray} =
     Dagger.HaloArray(C(H.center),

--- a/ext/ROCExt.jl
+++ b/ext/ROCExt.jl
@@ -47,6 +47,11 @@ function Dagger.aliasing(x::ROCArray{T}) where T
     return Dagger.ContiguousAliasing(Dagger.MemorySpan{S}(rptr, sizeof(T)*length(x)))
 end
 
+function Dagger.unsafe_free!(x::ROCArray)
+    AMDGPU.unsafe_free!(x)
+    return
+end
+
 Dagger.memory_spaces(proc::ROCArrayDeviceProc) = Set([ROCVRAMMemorySpace(proc.owner, proc.device_id)])
 Dagger.processors(space::ROCVRAMMemorySpace) = Set([ROCArrayDeviceProc(space.owner, space.device_id)])
 

--- a/src/array/copy.jl
+++ b/src/array/copy.jl
@@ -18,6 +18,18 @@ function copy_buffered(f, args...)
     for (buf_arg, arg) in zip(buffered_args, real_args)
         copyto!(arg, buf_arg)
     end
+
+    # Free the buffers
+    foreach(unsafe_free!, buffered_args)
+
+    # If the result is one of the buffered args, return the corresponding
+    # original arg instead (since we've already copied data back to it,
+    # and the buffer has been freed)
+    result_idx = findfirst(buf_arg -> buf_arg === result, buffered_args)
+    if result_idx !== nothing
+        return real_args[result_idx]
+    end
+
     return result
 end
 function allocate_copy_buffer(part::Blocks{N}, A::DArray{T,N}) where {T,N}

--- a/src/array/darray.jl
+++ b/src/array/darray.jl
@@ -143,7 +143,7 @@ mutable struct DArray{T,N,B<:AbstractBlocks{N},F} <: ArrayOp{T, N}
     end
 end
 
-const WrappedDArray{T,N} = Union{<:DArray{T,N}, Transpose{<:DArray{T,N}}, Adjoint{<:DArray{T,N}}}
+const WrappedDArray{T,N} = Union{<:DArray{T,N}, Transpose{T, <:DArray{T,N}}, Adjoint{T, <:DArray{T,N}}}
 const WrappedDMatrix{T} = WrappedDArray{T,2}
 const WrappedDVector{T} = WrappedDArray{T,1}
 const DMatrix{T} = DArray{T,2}
@@ -594,6 +594,12 @@ DArray{T}(::UndefInitializer, dims::NTuple{N,Int}; assignment::AssignmentType{N}
     DArray{T,N}(undef, auto_blocks(dims), dims; assignment)
 DArray{T}(::UndefInitializer, dims::Vararg{Int,N}; assignment::AssignmentType{N} = :arbitrary) where {T,N} =
     DArray{T,N}(undef, auto_blocks((dims...,)), (dims...,); assignment)
+
+function DArray(A::WrappedDArray{T}; assignment::AssignmentType = :arbitrary) where T
+    B = DArray{T}(undef, size(A); assignment)
+    copyto!(B, A)
+    return B
+end
 
 function Base.:(==)(x::ArrayOp{T,N}, y::AbstractArray{S,N}) where {T,S,N}
     collect(x) == y

--- a/src/array/darray.jl
+++ b/src/array/darray.jl
@@ -323,6 +323,8 @@ end
 
 Base.similar(D::DArray{T,N} where T, ::Type{S}, dims::Dims{N}) where {S,N} =
     DArray{S,N}(undef, D.partitioning, dims)
+Base.similar(D::DArray{T,N1} where T, ::Type{S}, dims::Dims{N2}) where {S,N1,N2} =
+    DArray{S,N2}(undef, auto_blocks(dims), dims)
 
 Base.copy(x::DArray{T,N,B,F}) where {T,N,B,F} =
     map(identity, x)::DArray{T,N,B,F}

--- a/src/array/linalg.jl
+++ b/src/array/linalg.jl
@@ -33,10 +33,25 @@ function LinearAlgebra.norm2(A::LowerTriangular{T,<:DArray{T,2}}) where T
     return sqrt(sum(lower_norms_values; init=zeroRT) + sum(diag_norms_values; init=zeroRT))
 end
 
-# Use allowscalar for ≈ so that GPU array chunks (ROCArray, CuArray, etc.) can be
-# compared without triggering scalar-indexing errors in norm/isapprox.
-is_cross_hermitian(A1, A2) = GPUArraysCore.allowscalar(() -> A1 ≈ A2')
-is_cross_symmetric(A1, A2) = GPUArraysCore.allowscalar(() -> A1 ≈ LinearAlgebra.transpose(A2))
+# Frobenius norm via sum(abs2, ...) to avoid scalar indexing on GPU arrays (LinearAlgebra.norm
+# can dispatch to norm_recursive_check which iterates).
+function _frobenius_norm(A)
+    return sqrt(sum(abs2, A))
+end
+
+# Chunkwise equality via norms (broadcast reductions on GPU); avoids scalar ≈.
+function is_cross_hermitian(A1, A2)
+    B = A2'
+    Tf = float(real(promote_type(eltype(A1), eltype(B))))
+    rtol = sqrt(eps(Tf))
+    return _frobenius_norm(A1 - B) <= rtol * max(_frobenius_norm(A1), _frobenius_norm(B))
+end
+function is_cross_symmetric(A1, A2)
+    B = LinearAlgebra.transpose(A2)
+    Tf = float(real(promote_type(eltype(A1), eltype(B))))
+    rtol = sqrt(eps(Tf))
+    return _frobenius_norm(A1 - B) <= rtol * max(_frobenius_norm(A1), _frobenius_norm(B))
+end
 function LinearAlgebra.issymmetric(A::DArray{T,2}) where T
     if size(A, 1) != size(A, 2)
         return false

--- a/src/array/linalg.jl
+++ b/src/array/linalg.jl
@@ -156,6 +156,8 @@ function LinearAlgebra.inv(A::DMatrix{T}) where T
     dest = DMatrix{S0}(I, n, n, A.partitioning)
     F = factorize(convert(AbstractMatrix{S}, A))
     LinearAlgebra.ldiv!(F, dest)
+    unsafe_free!(F.factors)
+    unsafe_free!(F.ipiv)
     return dest
 end
 
@@ -200,7 +202,10 @@ function LinearAlgebra.ldiv!(Y::DArray, A::DMatrix, B::DArray)
 end
 
 function LinearAlgebra.ldiv!(A::DMatrix, B::DArray)
-    LinearAlgebra.ldiv!(LinearAlgebra.lu(A), B)
+    F = LinearAlgebra.lu(A)
+    LinearAlgebra.ldiv!(F, B)
+    unsafe_free!(F.factors)
+    unsafe_free!(F.ipiv)
 end
 
 function LinearAlgebra.ldiv!(C::DVecOrMat, A::Union{LowerTriangular{<:Any,<:DMatrix},UnitLowerTriangular{<:Any,<:DMatrix},UpperTriangular{<:Any,<:DMatrix},UnitUpperTriangular{<:Any,<:DMatrix}}, B::DVecOrMat)

--- a/src/array/linalg.jl
+++ b/src/array/linalg.jl
@@ -33,8 +33,10 @@ function LinearAlgebra.norm2(A::LowerTriangular{T,<:DArray{T,2}}) where T
     return sqrt(sum(lower_norms_values; init=zeroRT) + sum(diag_norms_values; init=zeroRT))
 end
 
-is_cross_hermitian(A1, A2) = A1 ≈ A2'
-is_cross_symmetric(A1, A2) = A1 ≈ LinearAlgebra.transpose(A2)
+# Use allowscalar for ≈ so that GPU array chunks (ROCArray, CuArray, etc.) can be
+# compared without triggering scalar-indexing errors in norm/isapprox.
+is_cross_hermitian(A1, A2) = GPUArraysCore.allowscalar(() -> A1 ≈ A2')
+is_cross_symmetric(A1, A2) = GPUArraysCore.allowscalar(() -> A1 ≈ LinearAlgebra.transpose(A2))
 function LinearAlgebra.issymmetric(A::DArray{T,2}) where T
     if size(A, 1) != size(A, 2)
         return false
@@ -92,10 +94,22 @@ function LinearAlgebra.ishermitian(A::DArray{T,2}) where T
     return all(fetch, to_check)
 end
 
+# Check finiteness of a single chunk. For GPU arrays uses all(isfinite, A) (GPU
+# reduction via mapreduce); for CPU arrays uses LAPACK.chkfinite. Throws
+# ArgumentError("matrix has Inf or NaN") if any element is non-finite.
+function _chkfinite_chunk(A)
+    if A isa GPUArraysCore.AbstractGPUArray
+        all(isfinite, A) || throw(ArgumentError("matrix has Inf or NaN"))
+    else
+        LinearAlgebra.LAPACK.chkfinite(A)
+    end
+    return nothing
+end
+
 function LinearAlgebra.LAPACK.chkfinite(A::DArray)
     Ac = A.chunks
     chunk_finite = [Ref(true) for _ in Ac]
-    chkfinite!(finite, A) = finite[] = LinearAlgebra.LAPACK.chkfinite(A)
+    chkfinite!(finite, A) = (_chkfinite_chunk(A); finite[] = true)
     Dagger.spawn_datadeps() do
         for idx in eachindex(Ac)
             Dagger.@spawn chkfinite!(Out(chunk_finite[idx]), In(Ac[idx]))

--- a/src/array/linalg.jl
+++ b/src/array/linalg.jl
@@ -224,22 +224,43 @@ function LinearAlgebra.ldiv!(C::Cholesky{T,<:DMatrix}, B::DVecOrMat) where T
     parent_A = factors
     dB = B isa DVecOrMat ? B : (B isa AbstractMatrix ? view(B, factors.partitioning) : view(B, AutoBlocks()))
     min_bsa = min(parent_A.partitioning.blocksize...)
+    partB = Blocks(ntuple(_->min_bsa, ndims(B))...)
 
-    if C.uplo == 'U'
-        # A = U'U → solve U'y = B, then Ux = y
-        maybe_copy_buffered(parent_A => Blocks(min_bsa, min_bsa), dB => Blocks(min_bsa, min_bsa)) do pA, pB
-            Dagger.trsm!('L', 'U', trans, 'N', alpha, pA, pB)
-        end
-        maybe_copy_buffered(parent_A => Blocks(min_bsa, min_bsa), dB => Blocks(min_bsa, min_bsa)) do pA, pB
-            Dagger.trsm!('L', 'U', 'N', 'N', alpha, pA, pB)
+    if B isa DVector
+        if C.uplo == 'U'
+            # A = U'U → solve U'y = B, then Ux = y
+            maybe_copy_buffered(parent_A => Blocks(min_bsa, min_bsa), dB => partB) do pA, pB
+                Dagger.trsv!('U', trans, 'N', alpha, pA, pB)
+            end
+            maybe_copy_buffered(parent_A => Blocks(min_bsa, min_bsa), dB => partB) do pA, pB
+                Dagger.trsv!('U', 'N', 'N', alpha, pA, pB)
+            end
+        else
+            # A = LL' → solve Ly = B, then L'x = y
+            maybe_copy_buffered(parent_A => Blocks(min_bsa, min_bsa), dB => partB) do pA, pB
+                Dagger.trsv!('L', 'N', 'N', alpha, pA, pB)
+            end
+            maybe_copy_buffered(parent_A => Blocks(min_bsa, min_bsa), dB => partB) do pA, pB
+                Dagger.trsv!('L', trans, 'N', alpha, pA, pB)
+            end
         end
     else
-        # A = LL' → solve Ly = B, then L'x = y
-        maybe_copy_buffered(parent_A => Blocks(min_bsa, min_bsa), dB => Blocks(min_bsa, min_bsa)) do pA, pB
-            Dagger.trsm!('L', 'L', 'N', 'N', alpha, pA, pB)
-        end
-        maybe_copy_buffered(parent_A => Blocks(min_bsa, min_bsa), dB => Blocks(min_bsa, min_bsa)) do pA, pB
-            Dagger.trsm!('L', 'L', trans, 'N', alpha, pA, pB)
+        if C.uplo == 'U'
+            # A = U'U → solve U'y = B, then Ux = y
+            maybe_copy_buffered(parent_A => Blocks(min_bsa, min_bsa), dB => partB) do pA, pB
+                Dagger.trsm!('L', 'U', trans, 'N', alpha, pA, pB)
+            end
+            maybe_copy_buffered(parent_A => Blocks(min_bsa, min_bsa), dB => partB) do pA, pB
+                Dagger.trsm!('L', 'U', 'N', 'N', alpha, pA, pB)
+            end
+        else
+            # A = LL' → solve Ly = B, then L'x = y
+            maybe_copy_buffered(parent_A => Blocks(min_bsa, min_bsa), dB => partB) do pA, pB
+                Dagger.trsm!('L', 'L', 'N', 'N', alpha, pA, pB)
+            end
+            maybe_copy_buffered(parent_A => Blocks(min_bsa, min_bsa), dB => partB) do pA, pB
+                Dagger.trsm!('L', 'L', trans, 'N', alpha, pA, pB)
+            end
         end
     end
 

--- a/src/array/lu.jl
+++ b/src/array/lu.jl
@@ -62,7 +62,7 @@ function search_and_update_ipiv!(ipiv_chunk::AbstractVector{Int}, info::Ref{Int}
                                   offdiag_blocks::Vararg{AbstractMatrix{T}}) where T
     # Search diagonal block column p (rows p:end)
     diag_col = view(diag_block, p:min(mb, m-(k-1)*mb), p:p)
-    max_idx = LinearAlgebra.BLAS.iamax(diag_col[:])
+    max_idx = move(task_processor(), LinearAlgebra.BLAS.iamax)(diag_col[:])
     best_piv_idx = (p - 1) + max_idx
     best_piv_val = diag_col[max_idx]
     best_block = 1
@@ -70,7 +70,7 @@ function search_and_update_ipiv!(ipiv_chunk::AbstractVector{Int}, info::Ref{Int}
     # Search off-diagonal block columns
     for (bi, blk) in enumerate(offdiag_blocks)
         col = view(blk, :, p:p)
-        idx = LinearAlgebra.BLAS.iamax(col[:])
+        idx = move(task_processor(), LinearAlgebra.BLAS.iamax)(col[:])
         val = col[idx]
         abs_best = best_piv_val isa Real ? abs(best_piv_val) : abs(real(best_piv_val)) + abs(imag(best_piv_val))
         abs_val = val isa Real ? abs(val) : abs(real(val)) + abs(imag(val))
@@ -100,48 +100,29 @@ function swaprows_panel!(A::AbstractMatrix{T}, M::AbstractMatrix{T}, ipiv_chunk:
     end
 end
 
-@static if !isdefined(LinearAlgebra.BLAS, :geru!)
-    for elty in (:Float64, :Float32)
-        @eval begin
-            geru!(α::$elty, x::AbstractVector{$elty}, y::AbstractVector{$elty}, A::AbstractMatrix{$elty}) =
-                LinearAlgebra.BLAS.ger!(α, x, y, A)
-        end
-    end
-    for (fname, elty) in ((:zgeru_,:ComplexF64), (:cgeru_,:ComplexF32))
-        @eval begin
-            function geru!(α::$elty, x::AbstractVector{$elty}, y::AbstractVector{$elty}, A::AbstractMatrix{$elty})
-                Base.require_one_based_indexing(A, x, y)
-                m, n = size(A)
-                if m != length(x) || n != length(y)
-                    throw(DimensionMismatch(lazy"A has size ($m,$n), x has length $(length(x)), y has length $(length(y))"))
-                end
-                px, stx = LinearAlgebra.BLAS.vec_pointer_stride(x, ArgumentError("input vector with 0 stride is not allowed"))
-                py, sty = LinearAlgebra.BLAS.vec_pointer_stride(y, ArgumentError("input vector with 0 stride is not allowed"))
-                GC.@preserve x y ccall((LinearAlgebra.BLAS.@blasfunc($fname), LinearAlgebra.BLAS.libblas), Cvoid,
-                    (Ref{Int64}, Ref{Int64}, Ref{$elty}, Ptr{$elty},
-                     Ref{Int64}, Ptr{$elty}, Ref{Int64}, Ptr{$elty},
-                     Ref{Int64}),
-                     m, n, α, px, stx, py, sty, A, max(1,stride(A,2)))
-                A
-            end
-        end
-    end
-else
-    geru! = LinearAlgebra.BLAS.geru!
+@kernel function _geru_kernel!(alpha, x, y, A)
+    i, j = @index(Global, NTuple)
+    @inbounds A[i, j] = A[i, j] + alpha * x[i] * y[j]
+end
+
+function geru!(α::T, x::AbstractVector{T}, y::AbstractVector{T}, A::AbstractMatrix{T}) where T
+    isempty(A) && return A
+    Kernel(_geru_kernel!)(α, x, y, A; ndrange=size(A))
+    return A
 end
 
 # Update panel on the diagonal block (rows p+1:end). Receives the full block.
 function update_panel_diag!(A::AbstractMatrix{T}, p::Int, row_end::Int) where T
     M = view(A, p+1:row_end, :)
     Acinv = one(T) / A[p,p]
-    LinearAlgebra.BLAS.scal!(Acinv, view(M, :, p))
+    view(M, :, p) .= Acinv .* view(M, :, p)
     geru!(-one(T), view(M, :, p), view(A, p, p+1:size(A,2)), view(M, :, p+1:size(M,2)))
 end
 
 # Update panel on an off-diagonal block. Receives full Chunks.
 function update_panel_offdiag!(M::AbstractMatrix{T}, A::AbstractMatrix{T}, p::Int) where T
     Acinv = one(T) / A[p,p]
-    LinearAlgebra.BLAS.scal!(Acinv, view(M, :, p))
+    view(M, :, p) .= Acinv .* view(M, :, p)
     geru!(-one(T), view(M, :, p), view(A, p, p+1:size(A,2)), view(M, :, p+1:size(M,2)))
 end
 

--- a/src/array/lu.jl
+++ b/src/array/lu.jl
@@ -52,54 +52,60 @@ end
 # The full-Chunk approach is used here for simplicity,
 # but ChunkViews could be used for finer-grained dependencies if needed.
 
-# Combined search+reduce: searches all block columns for the pivot and
-# updates ipiv. Receives full Chunks for the diagonal block and off-diagonal
-# blocks; creates column views internally.
-# Uses allowscalar for the pivot value reads and ipiv write when chunks are GPU arrays.
+# Column pivot metric matches BLAS iamax: max abs (real) or max |Re|+|Im| (complex).
+function _lu_pivot_col_metric(col::AbstractVector{T}) where T
+    if T <: Real
+        findmax(abs.(col))
+    else
+        findmax(@. abs(real(col)) + abs(imag(col)))
+    end
+end
+
+# Combined search+reduce: pivot via findmax (GPU-friendly broadcast+reduction).
 function search_and_update_ipiv!(ipiv_chunk::AbstractVector{Int}, info::Ref{Int},
                                   diag_block::AbstractMatrix{T},
                                   k::Int, p::Int, mb::Int, m::Int,
                                   n_offdiag::Int,
                                   offdiag_blocks::Vararg{AbstractMatrix{T}}) where T
+    diag_col = view(diag_block, p:min(mb, m-(k-1)*mb), p:p)
+    isempty(diag_col) && return
+    diag_vec = vec(diag_col)
+    best_mag, rel_idx = _lu_pivot_col_metric(diag_vec)
+    best_piv_idx = (p - 1) + rel_idx
+    best_block = 1
+
+    for (bi, blk) in enumerate(offdiag_blocks)
+        col = view(blk, :, p:p)
+        colv = vec(col)
+        isempty(colv) && continue
+        mag_max, idx = _lu_pivot_col_metric(colv)
+        if mag_max > best_mag
+            best_mag = mag_max
+            best_piv_idx = idx
+            best_block = bi + 1
+        end
+    end
+
+    Tf = real(float(T))
+    if info[] == 0 && best_mag <= eps(Tf)
+        info[] = (k-1)*mb + p
+    end
+
+    # Scalar write; wrap in allowscalar when ipiv_chunk is a GPU array (e.g. ROCArray).
     GPUArraysCore.allowscalar() do
-        # Search diagonal block column p (rows p:end)
-        diag_col = view(diag_block, p:min(mb, m-(k-1)*mb), p:p)
-        max_idx = move(task_processor(), LinearAlgebra.BLAS.iamax)(diag_col[:])
-        best_piv_idx = (p - 1) + max_idx
-        best_piv_val = diag_col[max_idx]
-        best_block = 1
-
-        # Search off-diagonal block columns
-        for (bi, blk) in enumerate(offdiag_blocks)
-            col = view(blk, :, p:p)
-            idx = move(task_processor(), LinearAlgebra.BLAS.iamax)(col[:])
-            val = col[idx]
-            abs_best = best_piv_val isa Real ? abs(best_piv_val) : abs(real(best_piv_val)) + abs(imag(best_piv_val))
-            abs_val = val isa Real ? abs(val) : abs(real(val)) + abs(imag(val))
-            if abs_val > abs_best
-                best_piv_idx = idx
-                best_piv_val = val
-                best_block = bi + 1
-            end
-        end
-
-        # Singularity detection
-        abs_best = best_piv_val isa Real ? abs(best_piv_val) : abs(real(best_piv_val)) + abs(imag(best_piv_val))
-        if info[] == 0 && isapprox(abs_best, zero(T); atol=eps(real(T)))
-            info[] = (k-1)*mb + p
-        end
-
-        # Update ipiv
-        ipiv_chunk[p] = (best_block+k-2)*mb + best_piv_idx
+        ipiv_chunk[p] = (best_block + k - 2) * mb + best_piv_idx
     end
 end
 
 # Swap rows in the panel column. Receives full Chunks.
+# Uses allowscalar for ipiv read and row swap when chunks are GPU arrays.
 function swaprows_panel!(A::AbstractMatrix{T}, M::AbstractMatrix{T}, ipiv_chunk::AbstractVector{Int}, m::Int, p::Int, mb::Int) where T
-    q = div(ipiv_chunk[p]-1,mb) + 1
-    r = (ipiv_chunk[p]-1)%mb+1
-    if m == q
-        A[p,:], M[r,:] = M[r,:], A[p,:]
+    GPUArraysCore.allowscalar() do
+        q = div(ipiv_chunk[p]-1,mb) + 1
+        r = (ipiv_chunk[p]-1)%mb+1
+        if m == q
+            A[p,:], M[r,:] = M[r,:], A[p,:]
+        end
     end
 end
 
@@ -114,28 +120,40 @@ function geru!(α::T, x::AbstractVector{T}, y::AbstractVector{T}, A::AbstractMat
     return A
 end
 
+function _lu_inv_diag_el(A::AbstractMatrix{T}, p::Int) where T
+    if A isa GPUArraysCore.AbstractGPUArray
+        return one(T) / Array(@view A[p:p, p:p])[1]
+    end
+    return one(T) / A[p, p]
+end
+
 # Update panel on the diagonal block (rows p+1:end). Receives the full block.
 function update_panel_diag!(A::AbstractMatrix{T}, p::Int, row_end::Int) where T
     M = view(A, p+1:row_end, :)
-    Acinv = one(T) / A[p,p]
+    Acinv = _lu_inv_diag_el(A, p)
     view(M, :, p) .= Acinv .* view(M, :, p)
     geru!(-one(T), view(M, :, p), view(A, p, p+1:size(A,2)), view(M, :, p+1:size(M,2)))
+    return A
 end
 
 # Update panel on an off-diagonal block. Receives full Chunks.
 function update_panel_offdiag!(M::AbstractMatrix{T}, A::AbstractMatrix{T}, p::Int) where T
-    Acinv = one(T) / A[p,p]
+    Acinv = _lu_inv_diag_el(A, p)
     view(M, :, p) .= Acinv .* view(M, :, p)
     geru!(-one(T), view(M, :, p), view(A, p, p+1:size(A,2)), view(M, :, p+1:size(M,2)))
+    return M
 end
 
 # Swap rows in trailing columns. Receives full Chunks.
+# Uses allowscalar for ipiv reads and row swaps when chunks are GPU arrays.
 function swaprows_trail!(A::AbstractMatrix{T}, M::AbstractMatrix{T}, ipiv::AbstractVector{Int}, m::Int, mb::Int) where T
-    for p in eachindex(ipiv)
-        q = div(ipiv[p]-1,mb) + 1
-        r = (ipiv[p]-1)%mb+1
-        if m == q
-            A[p,:], M[r,:] = M[r,:], A[p,:]
+    GPUArraysCore.allowscalar() do
+        for p in eachindex(ipiv)
+            q = div(ipiv[p]-1,mb) + 1
+            r = (ipiv[p]-1)%mb+1
+            if m == q
+                A[p,:], M[r,:] = M[r,:], A[p,:]
+            end
         end
     end
 end

--- a/src/array/lu.jl
+++ b/src/array/lu.jl
@@ -55,40 +55,43 @@ end
 # Combined search+reduce: searches all block columns for the pivot and
 # updates ipiv. Receives full Chunks for the diagonal block and off-diagonal
 # blocks; creates column views internally.
+# Uses allowscalar for the pivot value reads and ipiv write when chunks are GPU arrays.
 function search_and_update_ipiv!(ipiv_chunk::AbstractVector{Int}, info::Ref{Int},
                                   diag_block::AbstractMatrix{T},
                                   k::Int, p::Int, mb::Int, m::Int,
                                   n_offdiag::Int,
                                   offdiag_blocks::Vararg{AbstractMatrix{T}}) where T
-    # Search diagonal block column p (rows p:end)
-    diag_col = view(diag_block, p:min(mb, m-(k-1)*mb), p:p)
-    max_idx = move(task_processor(), LinearAlgebra.BLAS.iamax)(diag_col[:])
-    best_piv_idx = (p - 1) + max_idx
-    best_piv_val = diag_col[max_idx]
-    best_block = 1
+    GPUArraysCore.allowscalar() do
+        # Search diagonal block column p (rows p:end)
+        diag_col = view(diag_block, p:min(mb, m-(k-1)*mb), p:p)
+        max_idx = move(task_processor(), LinearAlgebra.BLAS.iamax)(diag_col[:])
+        best_piv_idx = (p - 1) + max_idx
+        best_piv_val = diag_col[max_idx]
+        best_block = 1
 
-    # Search off-diagonal block columns
-    for (bi, blk) in enumerate(offdiag_blocks)
-        col = view(blk, :, p:p)
-        idx = move(task_processor(), LinearAlgebra.BLAS.iamax)(col[:])
-        val = col[idx]
-        abs_best = best_piv_val isa Real ? abs(best_piv_val) : abs(real(best_piv_val)) + abs(imag(best_piv_val))
-        abs_val = val isa Real ? abs(val) : abs(real(val)) + abs(imag(val))
-        if abs_val > abs_best
-            best_piv_idx = idx
-            best_piv_val = val
-            best_block = bi + 1
+        # Search off-diagonal block columns
+        for (bi, blk) in enumerate(offdiag_blocks)
+            col = view(blk, :, p:p)
+            idx = move(task_processor(), LinearAlgebra.BLAS.iamax)(col[:])
+            val = col[idx]
+            abs_best = best_piv_val isa Real ? abs(best_piv_val) : abs(real(best_piv_val)) + abs(imag(best_piv_val))
+            abs_val = val isa Real ? abs(val) : abs(real(val)) + abs(imag(val))
+            if abs_val > abs_best
+                best_piv_idx = idx
+                best_piv_val = val
+                best_block = bi + 1
+            end
         end
-    end
 
-    # Singularity detection
-    abs_best = best_piv_val isa Real ? abs(best_piv_val) : abs(real(best_piv_val)) + abs(imag(best_piv_val))
-    if info[] == 0 && isapprox(abs_best, zero(T); atol=eps(real(T)))
-        info[] = (k-1)*mb + p
-    end
+        # Singularity detection
+        abs_best = best_piv_val isa Real ? abs(best_piv_val) : abs(real(best_piv_val)) + abs(imag(best_piv_val))
+        if info[] == 0 && isapprox(abs_best, zero(T); atol=eps(real(T)))
+            info[] = (k-1)*mb + p
+        end
 
-    # Update ipiv
-    ipiv_chunk[p] = (best_block+k-2)*mb + best_piv_idx
+        # Update ipiv
+        ipiv_chunk[p] = (best_block+k-2)*mb + best_piv_idx
+    end
 end
 
 # Swap rows in the panel column. Receives full Chunks.

--- a/src/array/operators.jl
+++ b/src/array/operators.jl
@@ -134,6 +134,39 @@ end
 Base.first(A::DArray) = A[begin]
 Base.last(A::DArray) = A[end]
 
+# Addition and subtraction
+
+function elementwise_op!(f, C, A, B)
+    @assert size(C) == size(A) == size(B)
+    C .= f.(A, B)
+    return
+end
+function elementwise_op(f, A::DArray, B::DArray)
+    if size(A) != size(B)
+        throw(DimensionMismatch("Sizes of A and B must match"))
+    end
+    A_part = A.partitioning
+    B_part = B.partitioning
+    if A.partitioning != B.partitioning
+        B_part = A_part
+    end
+    C = similar(A)
+    maybe_copy_buffered(B=>B_part, A=>A_part) do B, A
+        Ac = A.chunks
+        Bc = B.chunks
+        Cc = C.chunks
+        Dagger.spawn_datadeps() do
+            for idx in eachindex(Cc)
+                Dagger.@spawn elementwise_op!(f, Out(Cc[idx]), In(Ac[idx]), In(Bc[idx]))
+            end
+        end
+        return
+    end
+    return C
+end
+Base.:(+)(A::DArray, B::DArray) = elementwise_op(+, A, B)
+Base.:(-)(A::DArray, B::DArray) = elementwise_op(-, A, B)
+
 # In-place operations
 
 function imap!(f, A)

--- a/src/array/qr.jl
+++ b/src/array/qr.jl
@@ -26,6 +26,7 @@ function _apply_dense_qr!(side::Char, trans::Char, Q::QRCompactWYQ{T, <:DMatrix{
     end
     pormqr!(side, trans, Q.factors, Q.T, Cd)
     copyto!(M, collect(Cd))
+    unsafe_free!(Cd)
     return M
 end
 LinearAlgebra.lmul!(B::QRCompactWYQ{T, <:DMatrix{T}}, A::StridedVecOrMat{T}) where {T} = _apply_dense_qr!('L', 'N', B, A)
@@ -241,6 +242,8 @@ function _pormqr_irregular!(side::Char, trans::Char, A::DMatrix{T}, Tm::DMatrix{
               side == 'R' ? C * Qop :
               throw(ArgumentError("side must be 'L' or 'R', got '$side'"))
     copyto!(C, updated)
+    unsafe_free!(updated)
+    unsafe_free!(Q)
     return C
 end
 

--- a/src/array/qr.jl
+++ b/src/array/qr.jl
@@ -34,21 +34,38 @@ function LinearAlgebra.lmul!(B::AdjointQ{T, <:QRCompactWYQ{T, <:DMatrix{T}}}, A:
     trans = T <: Complex ? 'C' : 'T'
     return _apply_dense_qr!('L', trans, B.Q, A)
 end
+function LinearAlgebra.lmul!(B::AdjointQ{T, <:QRCompactWYQ{T, <:DMatrix{T}}}, A::DVector{T}) where {T}
+    trans = T <: Complex ? 'C' : 'T'
+    A_mat = similar(A, T, (size(A, 1), 1))::DMatrix
+    copyto!(A_mat, A)
+    pormqr!('L', trans, B.Q.factors, B.Q.T, A_mat)
+    copyto!(A, A_mat)
+    unsafe_free!(A_mat)
+    return A
+end
 
 LinearAlgebra.rmul!(A::DMatrix{T}, B::QRCompactWYQ{T, <:DMatrix{T}}) where {T} = pormqr!('R', 'N', B.factors, B.T, A)
-function LinearAlgebra.rmul!(A::DMatrix{T}, B::AdjointQ{T, <:QRCompactWYQ{T, <:DMatrix{T}}}) where {T} 
+function LinearAlgebra.rmul!(A::DMatrix{T}, B::AdjointQ{T, <:QRCompactWYQ{T, <:DMatrix{T}}}) where {T}
     trans = T <: Complex ? 'C' : 'T'
     pormqr!('R', trans, B.Q.factors, B.Q.T, A)
 end
-LinearAlgebra.rmul!(A::StridedVecOrMat{T}, B::QRCompactWYQ{T, <:DMatrix{T}}) where {T} = _apply_dense_qr!('R', 'N', B, A)
-function LinearAlgebra.rmul!(A::StridedVecOrMat{T}, B::AdjointQ{<:Any, <:QRCompactWYQ{T, <:DMatrix{T}, <:DMatrix{T}}}) where {T<:Union{Float32,Float64}}
-    trans = T <: Complex ? 'C' : 'T'
-    return _apply_dense_qr!('R', trans, B.Q, A)
+for AT in (Vector, Matrix)
+    LinearAlgebra.rmul!(A::AT{T}, B::QRCompactWYQ{T, <:DMatrix{T}}) where {T} = _apply_dense_qr!('R', 'N', B, A)
+    function LinearAlgebra.rmul!(A::AT{T}, B::AdjointQ{T, <:QRCompactWYQ{T, <:DMatrix{T}, <:DMatrix{T}}}) where {T}
+        trans = T <: Complex ? 'C' : 'T'
+        return _apply_dense_qr!('R', trans, B.Q, A)
+    end
 end
-function LinearAlgebra.rmul!(A::StridedVecOrMat{T}, B::AdjointQ{<:Any, <:QRCompactWYQ{T, <:DMatrix{T}, <:DMatrix{T}}}) where {T<:Union{ComplexF32,ComplexF64}}
+function LinearAlgebra.rmul!(A::DVector{T}, B::AdjointQ{T, <:QRCompactWYQ{T, <:DMatrix{T}, <:DMatrix{T}}}) where {T}
     trans = T <: Complex ? 'C' : 'T'
-    return _apply_dense_qr!('R', trans, B.Q, A)
+    A_mat = similar(A, T, (1, size(A, 2)))
+    copyto!(A_mat, A)
+    pormqr!('R', trans, B.Q.factors, B.Q.T, A_mat)
+    copyto!(A, A_mat)
+    unsafe_free!(A_mat)
+    return A
 end
+
 
 """
     _infer_caqr_p(A, Tm) -> Int
@@ -796,4 +813,29 @@ function LinearAlgebra.qr!(A::DMatrix{T}; ib::Int=1, p::Int=1) where {T<:Number}
     end
 
     return _qr_impl!(A; ib=ib, p=1)
+end
+
+function LinearAlgebra.ldiv!(F::QRCompactWY{T, <:DMatrix{T}}, B::DVecOrMat) where T
+    m, n = size(F)
+    # Apply Q' to B in-place using the existing distributed lmul! dispatches
+    LinearAlgebra.lmul!(LinearAlgebra.adjoint(F.Q), B)
+    # Solve R*x = (Q'B) where R = UpperTriangular(F.factors)
+    if m == n
+        # Square case: F.factors is n×n, delegate to the distributed triangular ldiv!
+        LinearAlgebra.ldiv!(UpperTriangular(F.factors), B)
+    else
+        # Overdetermined (m > n): R occupies only the leading n×n block.
+        # Collect and solve the triangular system locally, then distribute back.
+        b_local = collect(B)
+        R_local = UpperTriangular(collect(F.factors)[1:n, 1:n])
+        b_view = B isa DVector ? view(b_local, 1:n) : view(b_local, 1:n, :)
+        LinearAlgebra.ldiv!(R_local, b_view)
+        copyto!(B, distribute(b_local, B.partitioning))
+    end
+    return B
+end
+
+function LinearAlgebra.ldiv!(X::DVecOrMat, F::QRCompactWY{T, <:DMatrix{T}}, B::DVecOrMat) where T
+    copyto!(X, B)
+    LinearAlgebra.ldiv!(F, X)
 end

--- a/src/array/stencil.jl
+++ b/src/array/stencil.jl
@@ -631,6 +631,7 @@ end
 function inner_stencil!(f, output, read_vars)
     processor = task_processor()
     inner_stencil_proc!(processor, f, output, read_vars)
+    foreach(v -> v isa HaloArray && unsafe_free!(v), values(read_vars))
 end
 
 # Non-KA (for CPUs)

--- a/src/array/trsm.jl
+++ b/src/array/trsm.jl
@@ -28,7 +28,7 @@ function trsv!(uplo::Char, trans::Char, diag::Char, alpha::T, A::DMatrix{T}, B::
                     lalpha = (k == 1) ? alpha : zone
                     Dagger.@spawn BLAS.trsv!('U', trans, diag, In(Ac[k, k]), InOut(Bc[k]))
                     for i in k+1:Bnt
-                        Dagger.@spawn BLAS.gemv!(trans, mzone, In(Ac[k, i]), In(Bc[i]), lalpha, InOut(Bc[k]))
+                        Dagger.@spawn BLAS.gemv!(trans, mzone, In(Ac[k, i]), In(Bc[k]), lalpha, InOut(Bc[i]))
                     end
                 end
             end
@@ -46,7 +46,7 @@ function trsv!(uplo::Char, trans::Char, diag::Char, alpha::T, A::DMatrix{T}, B::
                     lalpha = (k == Bnt) ? alpha : zone
                     Dagger.@spawn BLAS.trsv!('L', trans, diag, In(Ac[k, k]), InOut(Bc[k]))
                     for i in 1:k-1
-                        Dagger.@spawn BLAS.gemv!(trans, mzone, In(Ac[k, i]), In(Bc[i]), lalpha, InOut(Bc[k]))
+                        Dagger.@spawn BLAS.gemv!(trans, mzone, In(Ac[k, i]), In(Bc[k]), lalpha, InOut(Bc[i]))
                     end
                 end
             end

--- a/src/cancellation.jl
+++ b/src/cancellation.jl
@@ -99,8 +99,7 @@ function _cancel!(state, tid, force, graceful, halt_sch)
         tid !== nothing && task.id != tid && continue
         @dagdebug tid :cancel "Cancelling ready task"
         ex = DTaskFailedException(task, task, InterruptException())
-        Sch.store_result!(state, task, ex; error=true)
-        Sch.finish_failed!(state, task, task)
+        Sch.set_failed!(state, task; ex)
     end
     if tid === nothing
         empty!(state.ready)
@@ -114,8 +113,7 @@ function _cancel!(state, tid, force, graceful, halt_sch)
         tid !== nothing && task.id != tid && continue
         @dagdebug tid :cancel "Cancelling waiting task"
         ex = DTaskFailedException(task, task, InterruptException())
-        Sch.store_result!(state, task, ex; error=true)
-        Sch.finish_failed!(state, task, task)
+        Sch.set_failed!(state, task; ex)
     end
     if tid === nothing
         empty!(state.waiting)

--- a/src/datadeps/aliasing.jl
+++ b/src/datadeps/aliasing.jl
@@ -246,14 +246,19 @@ struct AliasedObjectCacheStore
     derived::Dict{AbstractAliasing,AbstractAliasing}
     stored::Dict{MemorySpace,Set{AbstractAliasing}}
     values::Dict{MemorySpace,Dict{AbstractAliasing,Chunk}}
+    originals::Set{AbstractAliasing}
 end
 AliasedObjectCacheStore() =
     AliasedObjectCacheStore(Vector{AbstractAliasing}(),
                             Dict{AbstractAliasing,AbstractAliasing}(),
                             Dict{MemorySpace,Set{AbstractAliasing}}(),
-                            Dict{MemorySpace,Dict{AbstractAliasing,Chunk}}())
+                            Dict{MemorySpace,Dict{AbstractAliasing,Chunk}}(),
+                            Set{AbstractAliasing}())
 
 function is_stored(cache::AliasedObjectCacheStore, space::MemorySpace, ainfo::AbstractAliasing)
+    if !(ainfo in cache.originals)
+        push!(cache.originals, ainfo)
+    end
     if !haskey(cache.stored, space)
         return false
     end

--- a/src/datadeps/queue.jl
+++ b/src/datadeps/queue.jl
@@ -147,6 +147,25 @@ function distribute_tasks!(queue::DataDepsTaskQueue)
             @maybelog ctx timespan_finish(ctx, :datadeps_copy_skip, (;id), (;thunk_id=0, from_space=origin_space, to_space=origin_space, arg_w, from_arg=arg, to_arg=arg))
         end
     end
+    write_num += 1
+
+    # Free all allocated buffers
+    obj_cache = unwrap(state.ainfo_backing_chunk)
+    for remote_space in keys(obj_cache.values)
+        for (ainfo, remote_arg) in obj_cache.values[remote_space]
+            if !(ainfo in obj_cache.originals)
+                # We allocated this buffer, we can free it
+                remote_proc = first(processors(remote_space))
+                free_scope = ExactScope(remote_proc)
+                free_syncdeps = Set{ThunkSyncdep}()
+                # FIXME: Send ainfo through aliasing! to calculate overlaps
+                #ainfo = AliasingWrapper(aliasing(arg, identity))
+                @assert haskey(state.ainfo_arg, ainfo)
+                get_write_deps!(state, remote_space, ainfo, write_num, free_syncdeps)
+                Dagger.@spawn scope=free_scope syncdeps=free_syncdeps Dagger.unsafe_free!(remote_arg)
+            end
+        end
+    end
 end
 struct DataDepsTaskDependency
     arg_w::ArgumentWrapper

--- a/src/gpu.jl
+++ b/src/gpu.jl
@@ -104,3 +104,33 @@ gpu_synchronize(::Val{:CPU}) = nothing
 
 with_context!(proc::Processor) = nothing
 with_context!(space::MemorySpace) = nothing
+
+# Adapt RefValue
+mutable struct GPURef{T,S<:MemorySpace} <: Ref{T}
+    value::T
+    space::S # This is ignored for aliasing
+end
+Base.getindex(x::GPURef) = x.value
+Base.setindex!(x::GPURef, value) = x.value = value
+# FIXME: Wire up with adapt
+function aliasing(x::GPURef)
+    addr = UInt(Base.pointer_from_objref(x) + fieldoffset(typeof(x), 1))
+    ptr = RemotePtr{Cvoid}(addr, x.space)
+    ainfo = ObjectAliasing(ptr, sizeof(x.value))
+    return CombinedAliasing([ainfo])
+end
+memory_space(x::GPURef) = x.space
+function read_remainder!(copies::Vector{UInt8}, copies_offset::UInt64, from::GPURef, from_ptr::UInt64, n::UInt64)
+    if from_ptr == UInt64(Base.pointer_from_objref(from) + fieldoffset(typeof(from), 1))
+        unsafe_copyto!(pointer(copies, copies_offset), Ptr{UInt8}(from_ptr), n)
+    else
+        read_remainder!(copies, copies_offset, from[], from_ptr, n)
+    end
+end
+function write_remainder!(copies::Vector{UInt8}, copies_offset::UInt64, to::GPURef, to_ptr::UInt64, n::UInt64)
+    if to_ptr == UInt64(Base.pointer_from_objref(to) + fieldoffset(typeof(to), 1))
+        unsafe_copyto!(Ptr{UInt8}(to_ptr), pointer(copies, copies_offset), n)
+    else
+        write_remainder!(copies, copies_offset, to[], to_ptr, n)
+    end
+end

--- a/src/memory-spaces.jl
+++ b/src/memory-spaces.jl
@@ -314,8 +314,10 @@ memory_spans(::NoAliasing) = MemorySpan{CPURAMMemorySpace}[]
 struct UnknownAliasing <: AbstractAliasing end
 memory_spans(::UnknownAliasing) = [MemorySpan{CPURAMMemorySpace}(C_NULL, typemax(UInt))]
 
-warn_unknown_aliasing(T) =
-    @warn "Cannot resolve aliasing for object of type $T\nExecution may become sequential"
+error_unknown_aliasing(T) =
+    throw(ConcurrencyViolationError("Cannot resolve aliasing for object of type $T, execution may become sequential"))
+error_unknown_aliasing(T, x) =
+    throw(ConcurrencyViolationError("Cannot resolve aliasing for object of type $T (element of $(typeof(x))), execution may become sequential"))
 
 struct CombinedAliasing <: AbstractAliasing
     sub_ainfos::Vector{AbstractAliasing}
@@ -381,7 +383,7 @@ function aliasing(x::T) where T
         end
         return CombinedAliasing(as)
     else
-        warn_unknown_aliasing(T)
+        error_unknown_aliasing(T)
         return UnknownAliasing()
     end
 end
@@ -430,7 +432,7 @@ function aliasing(x::Array{T}) where T
     else
         # FIXME: Also ContiguousAliasing of container
         #return IteratedAliasing(x)
-        warn_unknown_aliasing(T)
+        error_unknown_aliasing(T, x)
         return UnknownAliasing()
     end
 end
@@ -484,7 +486,7 @@ function aliasing(x::SubArray{T,N}) where {T,N}
     else
         # FIXME: Also ContiguousAliasing of container
         #return IteratedAliasing(x)
-        warn_unknown_aliasing(T)
+        error_unknown_aliasing(T, x)
         return UnknownAliasing()
     end
 end

--- a/src/memory-spaces.jl
+++ b/src/memory-spaces.jl
@@ -602,3 +602,12 @@ function will_alias(x_span::MemorySpan, y_span::MemorySpan)
     y_end = y_span.ptr + y_span.len - 1
     return x_span.ptr <= y_end && y_span.ptr <= x_end
 end
+
+### Unsafe Free
+
+unsafe_free!(x::Chunk) = remotecall_fetch(root_worker_id(x), x) do x
+    unsafe_free!(unwrap(x))
+    return
+end
+unsafe_free!(x::DTask) = unsafe_free!(fetch(x; raw=true))
+unsafe_free!(x) = nothing # Do nothing by default

--- a/src/sch/Sch.jl
+++ b/src/sch/Sch.jl
@@ -563,7 +563,7 @@ end
             if haskey(state.errored, task)
                 # An error was eagerly propagated to this task
                 @dagdebug task :schedule "Task received upstream error, finishing"
-                finish_failed!(state, task)
+                set_failed!(state, task)
             else
                 # This shouldn't have happened
                 @dagdebug task :schedule "Scheduling inconsistency: Task being scheduled is already cached!"
@@ -598,8 +598,7 @@ end
                           @something(options.result_scope, AnyScope()))
         if scope isa InvalidScope
             ex = SchedulingException("compute_scope and result_scope are not compatible: $(scope.x), $(scope.y)")
-            store_result!(state, task, ex; error=true)
-            finish_failed!(state, task)
+            set_failed!(state, task; ex)
             @goto pop_task
         end
         for arg in task.inputs
@@ -615,8 +614,7 @@ end
             scope = constrain(scope, chunk.scope)
             if scope isa InvalidScope
                 ex = SchedulingException("Current scope and argument Chunk scope are not compatible: $(scope.x), $(scope.y)")
-                store_result!(state, task, ex; error=true)
-                finish_failed!(state, task)
+                set_failed!(state, task; ex)
                 @goto pop_task
             end
         end
@@ -677,8 +675,7 @@ end
         end
 
         ex = SchedulingException("No processors available, try widening scope")
-        store_result!(state, task, ex; error=true)
-        finish_failed!(state, task)
+        set_failed!(state, task; ex)
         @dagdebug task :schedule "No processors available, skipping"
         sorted_procs_cleanup()
         costs_cleanup()
@@ -750,7 +747,7 @@ function finish_task!(ctx, state, node, thunk_failed)
     pop!(state.running, node)
     delete!(state.running_on, node)
     if thunk_failed
-        set_failed!(state, node)
+        set_failed!(state, node; ex=load_result(state, node))
     end
     schedule_dependents!(state, node, thunk_failed)
     fill_registered_futures!(state, node, thunk_failed)

--- a/src/sch/util.jl
+++ b/src/sch/util.jl
@@ -232,39 +232,49 @@ end
 const RESCHEDULE_SYNCDEPS_SEEN_CACHE = TaskLocalValue{ReusableCache{Set{Thunk},Nothing}}(()->ReusableCache(Set{Thunk}, nothing, 1))
 
 "Marks `thunk` and all dependent thunks as failed."
-function set_failed!(state, origin, thunk=origin)
+function set_failed!(state, origin::Thunk, thunk::Thunk=origin; ex=nothing)
     @assert islocked(state.lock)
     has_result(state, thunk) && return
     @dagdebug thunk :finish "Setting as failed"
-    filter!(x -> x !== thunk, state.ready)
-    # N.B. If origin === thunk, we assume that the caller has already set the error
-    if origin !== thunk && !has_result(state, thunk)
-        origin_ex = load_result(state, origin)
-        if origin_ex isa RemoteException
-            origin_ex = origin_ex.captured
-        end
-        ex = DTaskFailedException(thunk, origin, origin_ex)
+
+    if origin === thunk && ex !== nothing
         store_result!(state, thunk, ex; error=true)
     end
-    finish_failed!(state, thunk, origin)
-end
-function finish_failed!(state, thunk, origin=nothing)
-    @assert islocked(state.lock)
-    fill_registered_futures!(state, thunk, true)
-    if haskey(state.waiting_data, thunk)
-        for dep in state.waiting_data[thunk]
-            haskey(state.waiting, dep) &&
-                delete!(state.waiting, dep)
-            haskey(state.errored, dep) &&
-                continue
-            origin !== nothing && set_failed!(state, origin, dep)
+
+    seen = Set{Thunk}()
+    to_visit = Thunk[thunk]
+    while !isempty(to_visit)
+        thunk = pop!(to_visit)
+        push!(seen, thunk)
+
+        filter!(x -> x !== thunk, state.ready)
+
+        if !has_result(state, thunk) && origin !== thunk
+            origin_ex = load_result(state, origin)
+            if origin_ex isa RemoteException
+                origin_ex = origin_ex.captured
+            end
+            if origin_ex isa DTaskFailedException
+                origin_ex = origin_ex.ex
+            end
+            ex = DTaskFailedException(thunk, origin, origin_ex)
+            store_result!(state, thunk, ex; error=true)
         end
-        delete!(state.waiting_data, thunk)
-        thunk.sch_accessible = false
-        delete_unused_task!(state, thunk)
-    end
-    if haskey(state.waiting, thunk)
-        delete!(state.waiting, thunk)
+
+        fill_registered_futures!(state, thunk, true)
+        if haskey(state.waiting_data, thunk)
+            for dep in state.waiting_data[thunk]
+                haskey(state.errored, dep) && continue
+                dep in seen && continue
+                push!(to_visit, dep)
+            end
+            delete!(state.waiting_data, thunk)
+            thunk.sch_accessible = false
+            delete_unused_task!(state, thunk)
+        end
+        if haskey(state.waiting, thunk)
+            delete!(state.waiting, thunk)
+        end
     end
 end
 

--- a/src/utils/haloarray.jl
+++ b/src/utils/haloarray.jl
@@ -201,6 +201,11 @@ function move_rewrap(cache::AliasedObjectCache, from_proc::Processor, to_proc::P
     end
 end
 
+function Dagger.unsafe_free!(A::HaloArray)
+    unsafe_free!(A.center)
+    foreach(unsafe_free!, A.halos)
+end
+
 function find_object_holding_ptr(object::HaloArray, ptr::UInt64)
     for i in 1:length(object.halos)
         halo = object.halos[i]

--- a/test/array/linalg/arithmetic.jl
+++ b/test/array/linalg/arithmetic.jl
@@ -1,0 +1,38 @@
+@testset "$T" for T in (Float32, Float64, ComplexF32, ComplexF64)
+    N = 32
+    bs = 16
+
+    A = rand(T, N, N)
+    B = rand(T, N, N)
+    DA = DArray(A, Blocks(bs, bs))
+    DB = DArray(B, Blocks(bs, bs))
+
+    @testset "DMatrix +" begin
+        DC = DA + DB
+        @test DC isa DArray
+        @test collect(DC) == A + B
+    end
+
+    @testset "DMatrix -" begin
+        DC = DA - DB
+        @test DC isa DArray
+        @test collect(DC) == A - B
+    end
+
+    a = rand(T, N)
+    b = rand(T, N)
+    Da = DArray(a, Blocks(bs))
+    Db = DArray(b, Blocks(bs))
+
+    @testset "DVector +" begin
+        Dc = Da + Db
+        @test Dc isa DArray
+        @test collect(Dc) == a + b
+    end
+
+    @testset "DVector -" begin
+        Dc = Da - Db
+        @test Dc isa DArray
+        @test collect(Dc) == a - b
+    end
+end

--- a/test/array/linalg/solve.jl
+++ b/test/array/linalg/solve.jl
@@ -1,10 +1,12 @@
 @testset "$T" for T in (Float32, Float64, ComplexF32, ComplexF64)
+    tol = T in (Float32, ComplexF32) ? 1e-3 : 1e-10
+
     for i_block_scale in (1.0, 0.5), j_block_scale in (1.0, 0.5)
         N = 128
         bs_i = round(Int, N*i_block_scale)
         bs_j = round(Int, N*j_block_scale)
 
-        # LU decomposition
+        # LU decomposition — DMatrix RHS
         A = rand(T, N, N)
         B = rand(T, N, N)
         DA = DArray(A, Blocks(bs_i, bs_j))
@@ -16,7 +18,32 @@
         LinearAlgebra.ldiv!(lu_DA, DB)
         @test collect(DB) ≈ B
 
-        # Cholesky decomposition
+        # LU decomposition — DVector RHS
+        A = rand(T, N, N)
+        b = rand(T, N)
+        b_ref = copy(b)
+        DA = DArray(A, Blocks(bs_i, bs_j))
+        Db = DArray(b, Blocks(bs_i))
+
+        lu_A = lu(A, RowMaximum())
+        lu_DA = lu(DA, RowMaximum())
+        LinearAlgebra.ldiv!(lu_A, b_ref)
+        LinearAlgebra.ldiv!(lu_DA, Db)
+        @test collect(Db) ≈ b_ref rtol=tol
+
+        # LU decomposition — plain Vector RHS
+        A = rand(T, N, N)
+        b = rand(T, N)
+        b_ref = copy(b)
+        DA = DArray(A, Blocks(bs_i, bs_j))
+
+        lu_A = lu(A, RowMaximum())
+        lu_DA = lu(DA, RowMaximum())
+        LinearAlgebra.ldiv!(lu_A, b_ref)
+        LinearAlgebra.ldiv!(lu_DA, b)
+        @test b ≈ b_ref rtol=tol
+
+        # Cholesky decomposition — DMatrix RHS
         A = rand(T, N, N)
         A = A'A + I
         B = rand(T, N, N)
@@ -28,5 +55,19 @@
         LinearAlgebra.ldiv!(chol_A, B)
         LinearAlgebra.ldiv!(chol_DA, DB)
         @test collect(DB) ≈ B
+
+        # Cholesky decomposition — DVector RHS
+        A = rand(T, N, N)
+        A = A'A + I
+        b = rand(T, N)
+        b_ref = copy(b)
+        DA = DArray(A, Blocks(bs_i, bs_j))
+        Db = DArray(b, Blocks(bs_i))
+
+        chol_A = cholesky(A)
+        chol_DA = cholesky(DA)
+        LinearAlgebra.ldiv!(chol_A, b_ref)
+        LinearAlgebra.ldiv!(chol_DA, Db)
+        @test collect(Db) ≈ b_ref rtol=tol
     end
 end

--- a/test/gpu.jl
+++ b/test/gpu.jl
@@ -163,6 +163,20 @@ end
                 @test collect(DA * DB) ≈ collect(DA) * collect(DB)
             end
 
+            # Matrix addition / subtraction
+            Dagger.with_options(;scope=local_scope) do
+                @test collect(DA + DB) == collect(DA) + collect(DB)
+                @test collect(DA - DB) == collect(DA) - collect(DB)
+            end
+
+            # Vector addition / subtraction
+            Da = rand(Blocks(4), 8)
+            Db_vec = rand(Blocks(4), 8)
+            Dagger.with_options(;scope=local_scope) do
+                @test collect(Da + Db_vec) == collect(Da) + collect(Db_vec)
+                @test collect(Da - Db_vec) == collect(Da) - collect(Db_vec)
+            end
+
             # Out-of-place Cholesky
             A = rand(8, 8)
             A = A * A'
@@ -277,6 +291,20 @@ end
             # Out-of-place Matmul
             Dagger.with_options(;scope=local_scope) do
                 @test collect(DA * DB) ≈ collect(DA) * collect(DB)
+            end
+
+            # Matrix addition / subtraction
+            Dagger.with_options(;scope=local_scope) do
+                @test collect(DA + DB) == collect(DA) + collect(DB)
+                @test collect(DA - DB) == collect(DA) - collect(DB)
+            end
+
+            # Vector addition / subtraction
+            Da = rand(Blocks(4), 8)
+            Db_vec = rand(Blocks(4), 8)
+            Dagger.with_options(;scope=local_scope) do
+                @test collect(Da + Db_vec) == collect(Da) + collect(Db_vec)
+                @test collect(Da - Db_vec) == collect(Da) - collect(Db_vec)
             end
 
             # Out-of-place Cholesky

--- a/test/gpu.jl
+++ b/test/gpu.jl
@@ -487,7 +487,6 @@ end
             end
         end
 
-        #= FIXME: Requires more generic matmul, missing Cholesky methods
         @testset "Datadeps (GPU $gpu)" for gpu in gpu_configs
             local_scope = Dagger.scope(worker=1, intel_gpus=(gpu == :all ? Colon() : [gpu]))
 
@@ -506,6 +505,20 @@ end
                 @test collect(DA * DB) ≈ collect(DA) * collect(DB)
             end
 
+            # Matrix addition / subtraction
+            Dagger.with_options(;scope=local_scope) do
+                @test collect(DA + DB) == collect(DA) + collect(DB)
+                @test collect(DA - DB) == collect(DA) - collect(DB)
+            end
+
+            # Vector addition / subtraction
+            Da = rand(Blocks(4), Float32, 8)
+            Db_vec = rand(Blocks(4), Float32, 8)
+            Dagger.with_options(;scope=local_scope) do
+                @test collect(Da + Db_vec) == collect(Da) + collect(Db_vec)
+                @test collect(Da - Db_vec) == collect(Da) - collect(Db_vec)
+            end
+
             # Out-of-place Cholesky
             A = rand(Float32, 8, 8)
             A = A * A'
@@ -514,8 +527,48 @@ end
             Dagger.with_options(;scope=local_scope) do
                 @test collect(cholesky(DA).U) ≈ cholesky(collect(DA)).U
             end
+
+            # Out-of-place LU
+            A = rand(Float32, 8, 8)
+            DA = DArray(A, Blocks(4, 4))
+            Dagger.with_options(;scope=local_scope) do
+                lu_DA = lu(DA, RowMaximum())
+                L_DA = collect(lu_DA.L)
+                U_DA = collect(lu_DA.U)
+                P_DA = collect(lu_DA.P)
+                @test P_DA * A ≈ L_DA * U_DA rtol=1e-5
+            end
+
+            # ldiv! with DVector RHS — LU
+            A = rand(Float32, 8, 8)
+            b = rand(Float32, 8)
+            b_ref = copy(b)
+            DA = DArray(A, Blocks(4, 4))
+            Db = DArray(b, Blocks(4))
+            lu_ref = lu(A, RowMaximum())
+            LinearAlgebra.ldiv!(lu_ref, b_ref)
+            Dagger.with_options(;scope=local_scope) do
+                lu_DA = lu(DA, RowMaximum())
+                LinearAlgebra.ldiv!(lu_DA, Db)
+            end
+            @test collect(Db) ≈ b_ref rtol=1e-5
+
+            # ldiv! with DVector RHS — Cholesky
+            A = rand(Float32, 8, 8)
+            A = A * A'
+            A[diagind(A)] .+= size(A, 1)
+            b = rand(Float32, 8)
+            b_ref = copy(b)
+            DA = DArray(A, Blocks(4, 4))
+            Db = DArray(b, Blocks(4))
+            chol_ref = cholesky(A)
+            LinearAlgebra.ldiv!(chol_ref, b_ref)
+            Dagger.with_options(;scope=local_scope) do
+                chol_DA = cholesky(DA)
+                LinearAlgebra.ldiv!(chol_DA, Db)
+            end
+            @test collect(Db) ≈ b_ref rtol=1e-5
         end
-        =#
     end
 end
 

--- a/test/gpu.jl
+++ b/test/gpu.jl
@@ -185,6 +185,47 @@ end
             Dagger.with_options(;scope=local_scope) do
                 @test collect(cholesky(DA).U) ≈ cholesky(collect(DA)).U
             end
+
+            # Out-of-place LU
+            A = rand(8, 8)
+            DA = DArray(A, Blocks(4, 4))
+            Dagger.with_options(;scope=local_scope) do
+                lu_DA = lu(DA, RowMaximum())
+                L_DA = collect(lu_DA.L)
+                U_DA = collect(lu_DA.U)
+                P_DA = collect(lu_DA.P)
+                @test P_DA * A ≈ L_DA * U_DA rtol=1e-5
+            end
+
+            # ldiv! with DVector RHS — LU
+            A = rand(8, 8)
+            b = rand(8)
+            b_ref = copy(b)
+            DA = DArray(A, Blocks(4, 4))
+            Db = DArray(b, Blocks(4))
+            lu_ref = lu(A, RowMaximum())
+            LinearAlgebra.ldiv!(lu_ref, b_ref)
+            Dagger.with_options(;scope=local_scope) do
+                lu_DA = lu(DA, RowMaximum())
+                LinearAlgebra.ldiv!(lu_DA, Db)
+            end
+            @test collect(Db) ≈ b_ref rtol=1e-5
+
+            # ldiv! with DVector RHS — Cholesky
+            A = rand(8, 8)
+            A = A * A'
+            A[diagind(A)] .+= size(A, 1)
+            b = rand(8)
+            b_ref = copy(b)
+            DA = DArray(A, Blocks(4, 4))
+            Db = DArray(b, Blocks(4))
+            chol_ref = cholesky(A)
+            LinearAlgebra.ldiv!(chol_ref, b_ref)
+            Dagger.with_options(;scope=local_scope) do
+                chol_DA = cholesky(DA)
+                LinearAlgebra.ldiv!(chol_DA, Db)
+            end
+            @test collect(Db) ≈ b_ref rtol=1e-5
         end
     end
 end
@@ -315,6 +356,47 @@ end
             Dagger.with_options(;scope=local_scope) do
                 @test collect(cholesky(DA).U) ≈ cholesky(collect(DA)).U
             end
+
+            # Out-of-place LU
+            A = rand(8, 8)
+            DA = DArray(A, Blocks(4, 4))
+            Dagger.with_options(;scope=local_scope) do
+                lu_DA = lu(DA, RowMaximum())
+                L_DA = collect(lu_DA.L)
+                U_DA = collect(lu_DA.U)
+                P_DA = collect(lu_DA.P)
+                @test P_DA * A ≈ L_DA * U_DA rtol=1e-5
+            end
+
+            # ldiv! with DVector RHS — LU
+            A = rand(8, 8)
+            b = rand(8)
+            b_ref = copy(b)
+            DA = DArray(A, Blocks(4, 4))
+            Db = DArray(b, Blocks(4))
+            lu_ref = lu(A, RowMaximum())
+            LinearAlgebra.ldiv!(lu_ref, b_ref)
+            Dagger.with_options(;scope=local_scope) do
+                lu_DA = lu(DA, RowMaximum())
+                LinearAlgebra.ldiv!(lu_DA, Db)
+            end
+            @test collect(Db) ≈ b_ref rtol=1e-5
+
+            # ldiv! with DVector RHS — Cholesky
+            A = rand(8, 8)
+            A = A * A'
+            A[diagind(A)] .+= size(A, 1)
+            b = rand(8)
+            b_ref = copy(b)
+            DA = DArray(A, Blocks(4, 4))
+            Db = DArray(b, Blocks(4))
+            chol_ref = cholesky(A)
+            LinearAlgebra.ldiv!(chol_ref, b_ref)
+            Dagger.with_options(;scope=local_scope) do
+                chol_DA = cholesky(DA)
+                LinearAlgebra.ldiv!(chol_DA, Db)
+            end
+            @test collect(Db) ≈ b_ref rtol=1e-5
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,7 @@ tests = [
     ("Array - MapReduce", "array/mapreduce.jl"),
     ("Array - Broadcast", "array/broadcast.jl"),
     ("Array - LinearAlgebra - Core", "array/linalg/core.jl"),
+    ("Array - LinearAlgebra - Arithmetic", "array/linalg/arithmetic.jl"),
     ("Array - LinearAlgebra - Matmul", "array/linalg/matmul.jl"),
     ("Array - LinearAlgebra - Cholesky", "array/linalg/cholesky.jl"),
     ("Array - LinearAlgebra - LU", "array/linalg/lu.jl"),


### PR DESCRIPTION
We now use `unsafe_free!` to eagerly free Datadeps and DArray GPU allocations when safe to do so.

This PR also:
- Fixes LU for GPUs
- Fixes Cholesky for `DVector` inputs
- Adds `+` and `-` methods for `DArray`s
- Fixes a scheduler bug around error reporting in large task graphs
- Adapts `RefValue` to a new `GPURef`, required for LU and other algorithms

Todo:
- [x] Add `unsafe_free!` to stencils
- [x] Evaluate if QR/CAQR can use `unsafe_free!`
- [x] Add CPU/GPU tests for Cholesky with `DVector` inputs
- [x] Add GPU tests for Cholesky and LU
- [x] Add GPU tests for `+` and `-`
- [ ] Add BLAS alternatives for GPU backends which don't have BLAS wired up