### PR TITLE
Fix incorrect one-arg Base.hash for ArgumentWrapper

### DIFF
--- a/src/datadeps/aliasing.jl
+++ b/src/datadeps/aliasing.jl
@@ -229,7 +229,7 @@ struct ArgumentWrapper
         return new(arg, dep_mod, h)
     end
 end
-Base.hash(aw::ArgumentWrapper) = hash(ArgumentWrapper, aw.hash)
+Base.hash(aw::ArgumentWrapper, h::UInt) = hash(aw.hash, hash(ArgumentWrapper, h))
 Base.:(==)(aw1::ArgumentWrapper, aw2::ArgumentWrapper) =
     aw1.hash == aw2.hash
 Base.isequal(aw1::ArgumentWrapper, aw2::ArgumentWrapper) =


### PR DESCRIPTION
Generated as part of an ecosystem-wide audit for one-arg hash methods.

## Summary

`Base.hash(aw::ArgumentWrapper)` in `src/datadeps/aliasing.jl` only defines a one-arg `Base.hash`. This means the two-arg fallback `hash(x, h::UInt)` uses `objectid`-based hashing instead, which can cause:

- **Correctness bugs**: equal `ArgumentWrapper`s may hash differently when used as compound keys in `Dict` or `Set`
- **Performance issues**: excessive method invalidation across the ecosystem
- **Julia 1.13+ breakage**: the default hash seed is changing from `zero(UInt)` to a random value

This does **not** affect `==`/`isequal`, which compare the `.hash` struct field directly rather than calling `Base.hash()`.

## Fix

Convert to a proper two-arg `hash(aw::ArgumentWrapper, h::UInt)` that chains the pre-computed hash value through the seed.

## Test plan

- Verified `==`/`isequal` don't depend on `Base.hash()` return value

---
This PR was generated with the assistance of generative AI.

Co-Authored-By: Claude <noreply@anthropic.com>