### PR TITLE
Update Buildkite pipeline for the new JuliaGPU cluster

### DIFF
--- a/.buildkite/pipeline-julia.yml
+++ b/.buildkite/pipeline-julia.yml
@@ -90,22 +90,6 @@ steps:
       - JuliaCI/julia-coverage#v1:
           codecov: true
 
-  - label: Julia 1.11 (Metal)
-    timeout_in_minutes: 20
-    <<: *gputest
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "1.11"
-      - JuliaCI/julia-test#v1: ~
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
-    agents:
-      queue: "juliaecosystem"
-      os: "macos"
-      arch: "aarch64"
-    env:
-      CI_USE_METAL: "1"
-
   - label: Julia 1.11 (OpenCL)
     timeout_in_minutes: 20
     <<: *gputest

--- a/.buildkite/pipeline-julia.yml
+++ b/.buildkite/pipeline-julia.yml
@@ -1,0 +1,163 @@
+.test: &test
+  if: build.message !~ /\[skip tests\]/
+  agents:
+    queue: "juliaecosystem"
+    sandbox_capable: "true"
+    os: linux
+    arch: x86_64
+  command: "julia --project -e 'using Pkg; Pkg.develop(;path=\"lib/TimespanLogging\")'"
+
+.gputest: &gputest
+  if: build.message !~ /\[skip tests\]/
+
+.bench: &bench
+  if: build.message =~ /\[run benchmarks\]/
+  agents:
+    queue: "juliaecosystem"
+    sandbox_capable: "true"
+    os: linux
+    arch: x86_64
+    num_cpus: 16
+
+steps:
+  - label: Julia 1.10
+    timeout_in_minutes: 120
+    <<: *test
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.10"
+      - JuliaCI/julia-test#v1:
+          julia_args: "--threads=1"
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+
+  - label: Julia 1.11
+    timeout_in_minutes: 120
+    <<: *test
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.11"
+      - JuliaCI/julia-test#v1:
+          julia_args: "--threads=1"
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+
+  - label: Julia 1.12
+    timeout_in_minutes: 120
+    <<: *test
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.12"
+      - JuliaCI/julia-test#v1:
+          julia_args: "--threads=1"
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+
+  - label: Julia 1
+    timeout_in_minutes: 120
+    <<: *test
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1"
+      - JuliaCI/julia-test#v1:
+          julia_args: "--threads=1"
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+
+  - label: Julia nightly
+    timeout_in_minutes: 120
+    <<: *test
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "nightly"
+      - JuliaCI/julia-test#v1:
+          julia_args: "--threads=1"
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+
+  - label: Julia 1 (macOS)
+    timeout_in_minutes: 120
+    <<: *test
+    agents:
+      queue: "juliaecosystem"
+      os: macos
+      arch: x86_64
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1"
+      - JuliaCI/julia-test#v1:
+          julia_args: "--threads=1"
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+
+  - label: Julia 1.11 (Metal)
+    timeout_in_minutes: 20
+    <<: *gputest
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.11"
+      - JuliaCI/julia-test#v1: ~
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+    agents:
+      queue: "juliaecosystem"
+      os: "macos"
+      arch: "aarch64"
+    env:
+      CI_USE_METAL: "1"
+
+  - label: Julia 1.11 (OpenCL)
+    timeout_in_minutes: 20
+    <<: *gputest
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.11"
+      - JuliaCI/julia-test#v1:
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+    agents:
+      queue: "juliaecosystem"
+      os: macos
+      arch: aarch64
+    env:
+      CI_USE_OPENCL: "1"
+
+  - label: Julia 1 - TimespanLogging
+    timeout_in_minutes: 20
+    <<: *test
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1"
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+    command: "julia --project -e 'using Pkg; Pkg.instantiate(); Pkg.develop(;path=\"lib/TimespanLogging\"); Pkg.test(\"TimespanLogging\")'"
+
+  - label: Julia 1 - DaggerWebDash
+    timeout_in_minutes: 20
+    <<: *test
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1"
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+    command: "julia -e 'using Pkg; Pkg.develop(;path=pwd()); Pkg.develop(;path=\"lib/TimespanLogging\"); Pkg.develop(;path=\"lib/DaggerWebDash\"); include(\"lib/DaggerWebDash/test/runtests.jl\")'"
+
+  - label: Benchmarks
+    timeout_in_minutes: 120
+    <<: *bench
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1"
+      - JuliaCI/julia-test#v1:
+          run_tests: false
+    command: "julia -e 'using Pkg; Pkg.add(\"BenchmarkTools\"); Pkg.develop(;path=pwd())'; JULIA_PROJECT=\"$PWD\" julia --project benchmarks/benchmark.jl"
+    env:
+      JULIA_NUM_THREADS: "4"
+      BENCHMARK: "nmf:raw,dagger"
+      BENCHMARK_PROCS: "4:4"
+      BENCHMARK_SCALE: "5:5:50"
+    artifacts:
+      - benchmarks/result*
+
+# env:
+#   SECRET_CODECOV_TOKEN: ""

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,95 +1,7 @@
-.test: &test
-  if: build.message !~ /\[skip tests\]/
-  agents:
-    queue: "juliaecosystem"
-    sandbox_capable: "true"
-    os: linux
-    arch: x86_64
-  command: "julia --project -e 'using Pkg; Pkg.develop(;path=\"lib/TimespanLogging\")'"
-
 .gputest: &gputest
   if: build.message !~ /\[skip tests\]/
 
-.bench: &bench
-  if: build.message =~ /\[run benchmarks\]/
-  agents:
-    queue: "juliaecosystem"
-    sandbox_capable: "true"
-    os: linux
-    arch: x86_64
-    num_cpus: 16
-
 steps:
-  - label: Julia 1.10
-    timeout_in_minutes: 120
-    <<: *test
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "1.10"
-      - JuliaCI/julia-test#v1:
-          julia_args: "--threads=1"
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
-
-  - label: Julia 1.11
-    timeout_in_minutes: 120
-    <<: *test
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "1.11"
-      - JuliaCI/julia-test#v1:
-          julia_args: "--threads=1"
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
-
-  - label: Julia 1.12
-    timeout_in_minutes: 120
-    <<: *test
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "1.12"
-      - JuliaCI/julia-test#v1:
-          julia_args: "--threads=1"
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
-
-  - label: Julia 1
-    timeout_in_minutes: 120
-    <<: *test
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "1"
-      - JuliaCI/julia-test#v1:
-          julia_args: "--threads=1"
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
-
-  - label: Julia nightly
-    timeout_in_minutes: 120
-    <<: *test
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "nightly"
-      - JuliaCI/julia-test#v1:
-          julia_args: "--threads=1"
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
-
-  - label: Julia 1 (macOS)
-    timeout_in_minutes: 120
-    <<: *test
-    agents:
-      queue: "juliaecosystem"
-      os: macos
-      arch: x86_64
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "1"
-      - JuliaCI/julia-test#v1:
-          julia_args: "--threads=1"
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
-
   - label: Julia 1.11 (CUDA)
     timeout_in_minutes: 60
     <<: *gputest
@@ -100,8 +12,7 @@ steps:
       - JuliaCI/julia-coverage#v1:
           codecov: true
     agents:
-      queue: "juliagpu"
-      cuda: "*"
+      queue: "cuda"
     env:
       CI_USE_CUDA: "1"
 
@@ -115,8 +26,7 @@ steps:
       - JuliaCI/julia-coverage#v1:
           codecov: true
     agents:
-      queue: "juliagpu"
-      rocm: "*"
+      queue: "rocm"
     env:
       CI_USE_ROCM: "1"
 
@@ -130,79 +40,9 @@ steps:
       - JuliaCI/julia-coverage#v1:
           codecov: true
     agents:
-      queue: "juliagpu"
-      intel: "*"
+      queue: "oneapi"
     env:
       CI_USE_ONEAPI: "1"
-
-  - label: Julia 1.11 (Metal)
-    timeout_in_minutes: 20
-    <<: *gputest
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "1.11"
-      - JuliaCI/julia-test#v1: ~
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
-    agents:
-      queue: "juliaecosystem"
-      os: "macos"
-      arch: "aarch64"
-    env:
-      CI_USE_METAL: "1"
-
-  - label: Julia 1.11 (OpenCL)
-    timeout_in_minutes: 20
-    <<: *gputest
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "1.11"
-      - JuliaCI/julia-test#v1:
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
-    agents:
-      queue: "juliaecosystem"
-      os: macos
-      arch: aarch64
-    env:
-      CI_USE_OPENCL: "1"
-
-  - label: Julia 1 - TimespanLogging
-    timeout_in_minutes: 20
-    <<: *test
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "1"
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
-    command: "julia --project -e 'using Pkg; Pkg.instantiate(); Pkg.develop(;path=\"lib/TimespanLogging\"); Pkg.test(\"TimespanLogging\")'"
-
-  - label: Julia 1 - DaggerWebDash
-    timeout_in_minutes: 20
-    <<: *test
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "1"
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
-    command: "julia -e 'using Pkg; Pkg.develop(;path=pwd()); Pkg.develop(;path=\"lib/TimespanLogging\"); Pkg.develop(;path=\"lib/DaggerWebDash\"); include(\"lib/DaggerWebDash/test/runtests.jl\")'"
-
-  - label: Benchmarks
-    timeout_in_minutes: 120
-    <<: *bench
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "1"
-      - JuliaCI/julia-test#v1:
-          run_tests: false
-    command: "julia -e 'using Pkg; Pkg.add(\"BenchmarkTools\"); Pkg.develop(;path=pwd())'; JULIA_PROJECT=\"$PWD\" julia --project benchmarks/benchmark.jl"
-    env:
-      JULIA_NUM_THREADS: "4"
-      BENCHMARK: "nmf:raw,dagger"
-      BENCHMARK_PROCS: "4:4"
-      BENCHMARK_SCALE: "5:5:50"
-    artifacts:
-      - benchmarks/result*
 
 # env:
 #   SECRET_CODECOV_TOKEN: ""

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,5 +44,19 @@ steps:
     env:
       CI_USE_ONEAPI: "1"
 
+  - label: Julia 1.11 (Metal)
+    timeout_in_minutes: 20
+    <<: *gputest
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.11"
+      - JuliaCI/julia-test#v1: ~
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+    agents:
+      queue: "metal"
+    env:
+      CI_USE_METAL: "1"
+
 # env:
 #   SECRET_CODECOV_TOKEN: ""


### PR DESCRIPTION
The JuliaGPU Buildkite agents have moved to a dedicated cluster, where the single `juliagpu` queue has been split into per-backend queues. Steps now select agents using `queue: "cuda"`, `queue: "rocm"` or `queue: "oneapi"` instead of `queue: "juliagpu"` combined with a `cuda`/`rocm`/`intel` tag.

Since queues are now scoped to a cluster, a single pipeline can no longer mix JuliaGPU and `juliaecosystem` jobs: `pipeline.yml` now contains only the GPU jobs, while the `juliaecosystem` steps have moved unmodified to `pipeline-julia.yml`, to be uploaded by a separate pipeline in the ecosystem cluster once that is back online.

This change only affects agent selection; the steps themselves are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)