### PR TITLE
DArray/stencil: Add AntiReflect boundary condition

### DIFF
--- a/docs/src/stencils.md
+++ b/docs/src/stencils.md
@@ -12,7 +12,7 @@ Multiple stencil operations can be performed within a `begin...end` block:
 
 ```julia
 using Dagger
-import Dagger: @stencil, Wrap, Pad, Reflect, Clamp, LinearExtrapolate
+import Dagger: @stencil, Wrap, Pad, Reflect, AntiReflect, Clamp, LinearExtrapolate
 
 # Initialize a DArray
 A = zeros(Blocks(2, 2), Int, 4, 4)
@@ -114,6 +114,7 @@ The true power of stencils comes from accessing neighboring elements. The `@neig
     - `Reflect(symmetric)`: Reflects values back into the array at boundaries. The `symmetric` boolean controls whether the edge element is included in the reflection:
         - `Reflect(true)` (symmetric): Edge element IS repeated. For array `[a,b,c,d]`, extends as `[...,c,b,a,a,b,c,d,d,c,b,...]`.
         - `Reflect(false)` (mirror): Edge element NOT repeated. For array `[a,b,c,d]`, extends as `[...,d,c,b,a,b,c,d,c,b,a,...]`.
+    - `AntiReflect(symmetric)`: Reflects values as `Reflect(symmetric)` does, but negates them (an antisymmetric, or "odd", reflection). `AntiReflect()` defaults to the symmetric variant. For array `[a,b,c,d]`, `AntiReflect(true)` extends as `[...,-c,-b,-a,a,b,c,d,-d,-c,...]`. Use this for a quantity that must vanish at the boundary, such as the velocity component normal to a solid wall. Requires an element type that supports negation.
     - `Clamp()`: Clamps to the boundary value (repeats edge elements). For array `[a,b,c,d]`, extends as `[...,a,a,a,a,b,c,d,d,d,d,...]`.
     - `LinearExtrapolate()`: Linearly extrapolates using the slope at the boundary. Only works with `Real` element types. For array `[2,4,6,8]`, the slope at the low boundary is `4-2=2`, so index 0 would be `2-2=0`.
     - **Mixed BCs (Tuple)**: You can specify different boundary conditions per dimension using a tuple. For example, `(Wrap(), Pad(0))` uses `Wrap` for dimension 1 and `Pad(0)` for dimension 2.
@@ -219,6 +220,47 @@ end
 # B[4]: indices 3,4,5 -> 5 reflects to 3, so [3,4,3] = 10
 @assert collect(B) == [5, 6, 9, 10]
 ```
+
+### Example: Solid Walls with `AntiReflect`
+
+`Reflect` mirrors values, which is what a scalar field wants at a wall, but not what the velocity (or momentum) component *normal* to that wall wants. A mirrored ghost cell carries the same normal flow as the cell it mirrors, so the "wall" quietly behaves like an outflow. `AntiReflect` reflects the same indices and negates the values, so the field interpolates to zero at the wall and nothing passes through it:
+
+```julia
+import Dagger: AntiReflect
+
+# Array [1, 2, 3, 4] extends as [..., -3, -2, -1, 1, 2, 3, 4, -4, -3, ...]
+A = DArray([1, 2, 3, 4], Blocks(2))
+B = zeros(Blocks(2), Int, 4)
+
+@stencil begin
+    B[idx] = sum(@neighbors(A[idx], 1, AntiReflect(true)))
+end
+
+# B[1]: indices 0,1,2 -> 0 reflects to 1 and is negated, so [-1,1,2] = 2
+# B[2]: indices 1,2,3 -> all in bounds, [1,2,3] = 6
+# B[3]: indices 2,3,4 -> all in bounds, [2,3,4] = 9
+# B[4]: indices 3,4,5 -> 5 reflects to 4 and is negated, so [3,4,-4] = 3
+@assert collect(B) == [2, 6, 9, 3]
+```
+
+`AntiReflect()` is shorthand for `AntiReflect(true)`, and `AntiReflect(false)` skips the edge element just as `Reflect(false)` does. When several dimensions are antireflected at once, the sign flips once per reflected dimension, so a corner region reflected in two dimensions keeps its original sign.
+
+In practice this is used as part of a mixed boundary condition, because only the wall-normal component flips. For 2D shallow water in a channel that is periodic in *x* and walled in *y*, the height `h` and the wall-tangential momentum `hu` reflect as usual, while the wall-normal momentum `hv` antireflects:
+
+```julia
+const BC    = (Wrap(), Reflect(true))   # h, hu -- scalar and wall-tangential
+const BC_HV = (Wrap(), AntiReflect())   # hv    -- wall-normal, so it flips sign
+
+# Sketch, with the flux computation elided:
+@stencil begin
+    h2[idx] = update_h(@neighbors(h[idx],  1, BC),
+                       @neighbors(hu[idx], 1, BC),
+                       @neighbors(hv[idx], 1, BC_HV))
+    # ... and likewise for hu2 and hv2
+end
+```
+
+Using `Reflect(true)` for all three fields here looks plausible and even animates plausibly, but the walls leak: the conserved quantity (total mass) drifts steadily. Switching `hv` to `AntiReflect()` conserves it to roundoff, which makes a conservation check the cheapest way to catch a mistaken boundary condition.
 
 ### Example: Edge Detection with `Clamp`
 

--- a/src/array/stencil.jl
+++ b/src/array/stencil.jl
@@ -456,6 +456,63 @@ function boundary_source_index(::Reflect{Symm}, arr, rc, nd, idx_d, d) where Sym
 end
 
 #############################################################################
+# AntiReflect Boundary Condition
+#############################################################################
+
+"""
+AntiReflect boundary condition. Non-local accesses are reflected back into the
+array exactly as with `Reflect`, but each reflected value has its sign flipped
+(an antisymmetric, or "odd", reflection).
+
+If `symm` is true (the default), the reflected values include the nearest center
+elements; if `symm` is false, they do not — matching `Reflect(true)` and
+`Reflect(false)` respectively. For an array `[1, 2, 3, 4]`, `AntiReflect(true)`
+extends it as `[..., -3, -2, -1, 1, 2, 3, 4, -4, -3, ...]`, while
+`AntiReflect(false)` extends it as `[..., -4, -3, -2, 1, 2, 3, 4, -3, -2, ...]`.
+
+This is the boundary condition for a quantity that must vanish at the edge of
+the domain, the classic case being the velocity (or momentum) component normal
+to a solid wall: the negated ghost value cancels the interior value, so the
+field interpolates to zero at the boundary and nothing flows through it.
+Reflecting such a quantity with `Reflect` instead leaves a non-zero normal flow
+at the wall, which quietly behaves like an outflow rather than a wall.
+
+Typically only one dimension is antireflected, via a mixed boundary condition:
+a wall-normal momentum in a channel that is periodic along dimension 1 and
+walled along dimension 2 uses `(Wrap(), AntiReflect())`, while the scalar
+fields and the wall-tangential momentum use `(Wrap(), Reflect(true))`.
+
+When `AntiReflect` is applied to several dimensions at once, the sign is
+flipped once per reflected dimension, so a corner region reflected in two
+dimensions keeps its original sign.
+
+Requires an element type that supports negation.
+"""
+struct AntiReflect{Symmetric} end
+AntiReflect(symm::Bool=true) = AntiReflect{symm}()
+
+boundary_has_transition(::AntiReflect) = true
+
+# Clamp to valid chunk indices - we stay at the boundary chunk
+boundary_transition(::AntiReflect, idx, size) =
+    CartesianIndex(ntuple(i -> clamp(idx[i], 1, size[i]), length(size)))
+
+function load_boundary_region(::AntiReflect{Symm}, arr, region_code::NTuple{N,Int}, neigh_dist, boundary_dims::NTuple{N,Bool}) where {N, Symm}
+    region = load_boundary_region(Reflect{Symm}(), arr, region_code, neigh_dist, boundary_dims)
+
+    # Flip the sign once per dimension that was actually reflected, so that this
+    # agrees with the per-dimension folding done for mixed boundary conditions
+    # (a region reflected in two dimensions is negated twice, i.e. unchanged).
+    nreflected = count(ntuple(i -> region_code[i] != 0 && boundary_dims[i], N))
+    return isodd(nreflected) ? -region : region
+end
+
+boundary_source_index(::AntiReflect{Symm}, arr, rc, nd, idx_d, d) where Symm =
+    boundary_source_index(Reflect{Symm}(), arr, rc, nd, idx_d, d)
+
+apply_boundary_value(::AntiReflect, value, arr, rc, nd, idx_d, src_idx, d) = -value
+
+#############################################################################
 # Mixed Boundary Conditions (Tuple of Boundary Conditions)
 #############################################################################
 

--- a/test/array/stencil_defs.jl
+++ b/test/array/stencil_defs.jl
@@ -2,7 +2,7 @@
 # reused both for the single-process CPU/GPU testsets below and for the
 # MPI(+GPU) suites in test/mpi.jl / test/mpi_gpu_suite.jl.
 
-@everywhere import Dagger: @stencil, Wrap, Pad, Reflect, Clamp, LinearExtrapolate
+@everywhere import Dagger: @stencil, Wrap, Pad, Reflect, AntiReflect, Clamp, LinearExtrapolate
 
 function test_stencil(; skip_highdim::Bool=false)
     @testset "Simple assignment" begin
@@ -292,6 +292,138 @@ function test_stencil(; skip_highdim::Bool=false)
             expected_B_mirror[i, j] = sum_val
         end
         @test collect(B) == expected_B_mirror
+    end
+
+    @testset "AntiReflect constructor" begin
+        # AntiReflect() is the symmetric variant, matching Reflect(true)'s indexing
+        @test AntiReflect() === AntiReflect(true)
+        @test AntiReflect(false) !== AntiReflect(true)
+    end
+
+    @testset "AntiReflect ghost values" begin
+        # The defining property: an out-of-domain neighbor is the *negated*
+        # reflected value, so the field interpolates to zero at the boundary.
+        A = DArray([1, 2, 3, 4], Blocks(2))
+        lo = zeros(Blocks(2), Int, 4)
+        hi = zeros(Blocks(2), Int, 4)
+        @stencil begin
+            lo[idx] = @neighbors(A[idx], 1, AntiReflect(true))[1]
+            hi[idx] = @neighbors(A[idx], 1, AntiReflect(true))[3]
+        end
+        # lo[1] and hi[4] are the ghosts: -A[1] and -A[4]
+        @test collect(lo) == [-1, 1, 2, 3]
+        @test collect(hi) == [2, 3, 4, -4]
+    end
+
+    @testset "AntiReflect boundary (symmetric)" begin
+        # For A = [1, 2, 3, 4] with AntiReflect(true):
+        # idx=0 → -A[1] = -1, idx=5 → -A[4] = -4 (Reflect(true) indexing, negated)
+        A = DArray([1, 2, 3, 4], Blocks(2))
+        B = zeros(Blocks(2), Int, 4)
+        @stencil B[idx] = sum(@neighbors(A[idx], 1, AntiReflect(true)))
+        # B[1]: indices 0, 1, 2 -> [-1, 1, 2] = 2
+        # B[2]: indices 1, 2, 3 -> [1, 2, 3] = 6
+        # B[3]: indices 2, 3, 4 -> [2, 3, 4] = 9
+        # B[4]: indices 3, 4, 5 -> [3, 4, -4] = 3
+        @test collect(B) == [2, 6, 9, 3]
+    end
+
+    @testset "AntiReflect boundary (mirror)" begin
+        # For A = [1, 2, 3, 4] with AntiReflect(false):
+        # idx=0 → -A[2] = -2, idx=5 → -A[3] = -3 (Reflect(false) indexing, negated)
+        A = DArray([1, 2, 3, 4], Blocks(2))
+        B = zeros(Blocks(2), Int, 4)
+        @stencil B[idx] = sum(@neighbors(A[idx], 1, AntiReflect(false)))
+        # B[1]: indices 0, 1, 2 -> [-2, 1, 2] = 1
+        # B[2]: indices 1, 2, 3 -> [1, 2, 3] = 6
+        # B[3]: indices 2, 3, 4 -> [2, 3, 4] = 9
+        # B[4]: indices 3, 4, 5 -> [3, 4, -3] = 4
+        @test collect(B) == [1, 6, 9, 4]
+    end
+
+    @testset "AntiReflect boundary 2D (symmetric)" begin
+        # Applied to every dimension, the sign flips once per reflected
+        # dimension, so corner regions (reflected twice) keep their sign.
+        A = DArray(reshape(1:16, 4, 4), Blocks(2, 2))
+        B = zeros(Blocks(2, 2), Int, 4, 4)
+        @stencil B[idx] = sum(@neighbors(A[idx], 1, AntiReflect(true)))
+        A_collected = collect(A)
+        expected_B = zeros(Int, 4, 4)
+        for i in 1:4, j in 1:4
+            sum_val = 0
+            for di in -1:1, dj in -1:1
+                ni, nj = i + di, j + dj
+                sgn = 1
+                if ni < 1
+                    ni = 1 - ni; sgn = -sgn
+                elseif ni > 4
+                    ni = 2*4 + 1 - ni; sgn = -sgn
+                end
+                if nj < 1
+                    nj = 1 - nj; sgn = -sgn
+                elseif nj > 4
+                    nj = 2*4 + 1 - nj; sgn = -sgn
+                end
+                sum_val += sgn * A_collected[ni, nj]
+            end
+            expected_B[i, j] = sum_val
+        end
+        @test collect(B) == expected_B
+    end
+
+    @testset "Mixed boundary conditions (Wrap, AntiReflect)" begin
+        # The solid-wall case: periodic along dimension 1, walled along
+        # dimension 2, for a quantity normal to that wall.
+        A = DArray(reshape(1:16, 4, 4), Blocks(2, 2))
+        B = zeros(Blocks(2, 2), Int, 4, 4)
+        @stencil B[idx] = sum(@neighbors(A[idx], 1, (Wrap(), AntiReflect(true))))
+        A_collected = collect(A)
+        expected_B = zeros(Int, 4, 4)
+        for i in 1:4, j in 1:4
+            sum_val = 0
+            for di in -1:1, dj in -1:1
+                # Dim 1: Wrap
+                ni = mod1(i + di, 4)
+                # Dim 2: AntiReflect(true) - symmetric indices, negated values
+                nj = j + dj
+                sgn = 1
+                if nj < 1
+                    nj = 1 - nj; sgn = -1
+                elseif nj > 4
+                    nj = 2*4 + 1 - nj; sgn = -1
+                end
+                sum_val += sgn * A_collected[ni, nj]
+            end
+            expected_B[i, j] = sum_val
+        end
+        @test collect(B) == expected_B
+    end
+
+    @testset "AntiReflect zeroes the flux through a wall" begin
+        # Why this boundary condition exists: for a field normal to a solid
+        # wall, the centered difference across the wall must see a ghost that
+        # cancels the edge value. With a uniform field the wall-adjacent
+        # centered difference is therefore non-zero (the flow is stopped),
+        # while Reflect leaves it at zero (the flow passes straight through).
+        A = ones(Blocks(2), Float32, 4)
+        anti = zeros(Blocks(2), Float32, 4)
+        refl = zeros(Blocks(2), Float32, 4)
+        @stencil begin
+            anti[idx] = begin
+                n = @neighbors(A[idx], 1, AntiReflect())
+                n[3] - n[1]
+            end
+            refl[idx] = begin
+                n = @neighbors(A[idx], 1, Reflect(true))
+                n[3] - n[1]
+            end
+        end
+        # Interior cells see 1 - 1 == 0 under both conditions
+        @test collect(anti)[2:3] == [0.0f0, 0.0f0]
+        @test collect(refl) == zeros(4)
+        # At the edges the antireflected ghost is -1, so the difference is ±2
+        @test collect(anti)[1] == 2.0f0
+        @test collect(anti)[4] == -2.0f0
     end
 
     @testset "Multiple expressions" begin


### PR DESCRIPTION
Reflects indices like Reflect, but negates the reflected values, for quantities that must vanish at the domain edge - most commonly the velocity or momentum component normal to a solid wall, which Reflect turns into an outflow.

Written by Claude