### PR TITLE
Sch: Restore per-processor pressure in task cost estimation

### DIFF
--- a/src/sch/util.jl
+++ b/src/sch/util.jl
@@ -738,6 +738,22 @@ const EMPTY_TRANSFER_RATES = Dict{Processor,UInt64}()
     end
     empty!(chunks)
 
+    # Estimate each candidate processor's currently-reserved compute pressure
+    # (from tasks already scheduled to it but not yet finished), so that busy
+    # processors are considered costlier than idle ones.
+    est_time_util += lock(state.worker_time_pressure) do wtp
+        local pressure_sum = UInt64(0)
+        for proc in procs
+            pid = Dagger.root_worker_id(get_parent(proc))
+            proc_map = get(wtp, pid, nothing)
+            proc_map === nothing && continue
+            counter_ref = get(proc_map, proc, nothing)
+            counter_ref === nothing && continue
+            pressure_sum += counter_ref[]
+        end
+        return pressure_sum
+    end
+
     # Estimate total cost for executing this task on each candidate processor.
     # The transfer-rate table is taken once rather than once per processor.
     # N.B. `all_equal` is returned from the locked block rather than assigned

--- a/test/scheduler.jl
+++ b/test/scheduler.jl
@@ -396,8 +396,12 @@ end
         # Ensure that this worker has been used at least once
         fetch(Dagger.@spawn scope=Dagger.ExactScope(tproc2_1) 1+1)
 
-        #pres1_1 = state.worker_time_pressure[1][tproc1_1]
-        #pres2_1 = state.worker_time_pressure[first(workers())][tproc2_1]
+        get_pressure(pid, proc) = lock(state.worker_time_pressure) do wtp
+            counter_ref = get(get(wtp, pid, Dict{Dagger.Processor,Threads.Atomic{UInt64}}()), proc, nothing)
+            return counter_ref === nothing ? UInt64(0) : counter_ref[]
+        end
+        pres1_1 = get_pressure(1, tproc1_1)
+        pres2_1 = get_pressure(first(workers()), tproc2_1)
         tx_rate = lock(state.worker_transfer_rate) do wtr
             get(get(wtr, first(workers()), Dict{Dagger.Processor,UInt64}()), tproc2_1, Dagger.Sch.DEFAULT_TRANSFER_RATE)
         end
@@ -436,9 +440,9 @@ end
 
             @test haskey(costs, tproc1_1)
             @test haskey(costs, tproc2_1)
-            @test costs[tproc1_1] ≈ #=pres1_1 +=# sig_unknown_cost # All chunks are local, and this signature is unknown
+            @test costs[tproc1_1] ≈ pres1_1 + sig_unknown_cost # All chunks are local, and this signature is unknown
             if nprocs() > 1
-                @test costs[tproc2_1] ≈ (tx_size/tx_rate) + tx_xfer_cost + #=pres2_1 +=# sig_unknown_cost # All chunks are remote, and this signature is unknown
+                @test costs[tproc2_1] ≈ (tx_size/tx_rate) + tx_xfer_cost + pres2_1 + sig_unknown_cost # All chunks are remote, and this signature is unknown
             end
         end
 


### PR DESCRIPTION
estimate_task_costs! dropped the est_business term (each candidate processor's currently-reserved compute pressure) in b16afad8, leaving only a fixed per-task cross-worker transfer cost in the comparison. That fixed cost always makes the scheduler's own worker look cheapest, so under the default scope every task piled onto worker 1 regardless of how busy it became (#663).

Restore the pressure term, reading it from worker_time_pressure's current LockedObject/atomic-counter representation, so busier processors are considered costlier and work spreads across workers again.

Fixes #663

Written by Claude Sonnet