### PR TITLE
Re-fix stupid "fix" for 663

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,3 +142,17 @@ lesson.
    `with_options(scope=...)` as the measurement. More generally: when this
    suite jumps on a scheduler change, first ask whether placement changed
    before hunting for a stray closure or box.
+
+15. **A per-candidate term folded into a shared scalar is a no-op, and the
+   tests won't tell you.** `estimate_task_costs!` compares candidate
+   processors, so only terms that *differ per candidate* can change its
+   decision. Accumulating one — e.g. summing every candidate's compute
+   pressure and adding that total to `est_time_util` — leaves a constant
+   offset that cancels out of both the comparison and the `sort!`, so the
+   scheduler's ordering is bit-for-bit unchanged while the code reads as
+   though the term is now considered. `test/scheduler.jl`'s cost assertions
+   run against an *idle* scheduler where every pressure is zero, which makes
+   summed and per-processor forms indistinguishable; a test that pins the
+   term to one candidate and asserts the *other* one wins is what catches it.
+   The behavioral check is cheaper still: 40 sleeping tasks over 4 workers
+   land `[1 => 40]` when the term is dead and `10/10/10/10` when it is live.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,3 +129,16 @@ lesson.
    (compile-time explosion, tuple re-boxing), and don't erase types on the
    path where the compiler genuinely uses them (kernel invocation, argument
    moves). A function barrier at the boundary lets each side be what it is.
+
+14. **`test/allocations.jl` measures scheduling overhead only while every
+   task really is pinned.** Its bounds assume the pinned scope holds for the
+   whole suite, but `allocate_array` tasks (the ones building each
+   `let`-block DArray) take no `Chunk` inputs, so they carry *zero*
+   data-transfer cost — nothing anchors them to a worker, and the scheduler
+   spreads them the moment it can see per-processor load. The measured call,
+   still pinned to worker 1, then pays to pull those chunks back, and a
+   scheduler change shows up as a 5x allocation "regression" that is really
+   cross-worker data movement. Build the fixtures inside the same
+   `with_options(scope=...)` as the measurement. More generally: when this
+   suite jumps on a scheduler change, first ask whether placement changed
+   before hunting for a stray closure or box.

--- a/src/sch/util.jl
+++ b/src/sch/util.jl
@@ -776,8 +776,15 @@ const EMPTY_TRANSFER_RATES = Dict{Processor,UInt64}()
             # TODO: Actually estimate/benchmark this
             task_xfer_cost = pid != myid() ? 1_000_000 : 0 # 1ms
 
+            # N.B. `tx_rate` is in bytes per *second* (see the `transfer_rate`
+            # metadata `do_task` reports, which divides by a nanosecond
+            # duration scaled by 10^9), so `bytes/tx_rate` comes out in
+            # seconds while every other term here is in nanoseconds. Scale it
+            # up, or transfer cost is discounted by a factor of a billion and
+            # data locality never affects the choice of processor.
             tx_rate = get(get(wtr, pid, EMPTY_TRANSFER_RATES), proc, DEFAULT_TRANSFER_RATE)
-            cost = est_time_util + pressures[idx] + (tx_costs[gproc]/tx_rate) + task_xfer_cost
+            tx_cost = (tx_costs[gproc]/tx_rate) * 1e9
+            cost = est_time_util + pressures[idx] + tx_cost + task_xfer_cost
             costs[proc] = cost
             if idx == 1
                 first_cost = cost

--- a/src/sch/util.jl
+++ b/src/sch/util.jl
@@ -738,20 +738,27 @@ const EMPTY_TRANSFER_RATES = Dict{Processor,UInt64}()
     end
     empty!(chunks)
 
-    # Estimate each candidate processor's currently-reserved compute pressure
-    # (from tasks already scheduled to it but not yet finished), so that busy
+    # Look up each candidate processor's currently-reserved compute pressure
+    # (tasks already scheduled to it but not yet finished), so that busy
     # processors are considered costlier than idle ones.
-    est_time_util += lock(state.worker_time_pressure) do wtp
-        local pressure_sum = UInt64(0)
-        for proc in procs
+    # N.B. This is inherently *per-processor*: folding it into a single sum
+    # added to every candidate is a constant offset that cancels out of the
+    # comparison, leaving the scheduler blind to which processors are idle.
+    # Gathered in its own pass so `worker_time_pressure` is locked once, and
+    # not nested inside the `worker_transfer_rate` hold below.
+    pressures = @reusable_vector :estimate_task_costs_pressures UInt64 UInt64(0) 32
+    resize!(pressures, length(procs))
+    lock(state.worker_time_pressure) do wtp
+        for (idx, proc) in enumerate(procs)
             pid = Dagger.root_worker_id(get_parent(proc))
             proc_map = get(wtp, pid, nothing)
-            proc_map === nothing && continue
+            if proc_map === nothing
+                pressures[idx] = UInt64(0)
+                continue
+            end
             counter_ref = get(proc_map, proc, nothing)
-            counter_ref === nothing && continue
-            pressure_sum += counter_ref[]
+            pressures[idx] = counter_ref === nothing ? UInt64(0) : counter_ref[]
         end
-        return pressure_sum
     end
 
     # Estimate total cost for executing this task on each candidate processor.
@@ -770,7 +777,7 @@ const EMPTY_TRANSFER_RATES = Dict{Processor,UInt64}()
             task_xfer_cost = pid != myid() ? 1_000_000 : 0 # 1ms
 
             tx_rate = get(get(wtr, pid, EMPTY_TRANSFER_RATES), proc, DEFAULT_TRANSFER_RATE)
-            cost = est_time_util + (tx_costs[gproc]/tx_rate) + task_xfer_cost
+            cost = est_time_util + pressures[idx] + (tx_costs[gproc]/tx_rate) + task_xfer_cost
             costs[proc] = cost
             if idx == 1
                 first_cost = cost
@@ -781,6 +788,7 @@ const EMPTY_TRANSFER_RATES = Dict{Processor,UInt64}()
         return all_equal
     end
     empty!(tx_costs)
+    empty!(pressures)
 
     # Shuffle procs around, so equally-costly procs are equally considered
     np = length(procs)

--- a/src/utils/span_copy.jl
+++ b/src/utils/span_copy.jl
@@ -94,6 +94,22 @@ function _device_u32(backend, data::Vector{UInt32})
 end
 
 """
+    kernel_lock_processor(x) -> Processor
+
+The processor whose backend lock guards a native GPU call operating on `x`.
+
+Usually that is the processor running the current `DTask`. But this is also
+reached from outside any `DTask`: `move!(::RemainderAliasing, ...)` hands the
+source-side gather to the owning worker with `remotecall_fetch`, and that
+closure runs in a Distributed message-handler task, which carries no Dagger
+TLS -- so `task_processor()` there fails its `::DTaskTLS` assertion rather
+than returning a processor. Fall back to a processor of the array's own
+memory space, which is the one owning the lock we need anyway.
+"""
+kernel_lock_processor(x) =
+    in_task() ? task_processor() : first(processors(memory_space(x)))
+
+"""
     multi_span_copy!(dst, src, dst_ptrs, src_ptrs, lens)
 
 Copy `lens[i]` bytes from `src` at absolute pointer `src_ptrs[i]` into `dst` at
@@ -119,7 +135,8 @@ function multi_span_copy!(dst::AbstractArray{T}, src::AbstractArray{T},
         return
     end
 
-    backend = KernelAbstractions.get_backend(is_device_array(dst) ? dst : src)
+    dev_arr = is_device_array(dst) ? dst : src
+    backend = KernelAbstractions.get_backend(dev_arr)
     dst_offs_d = _device_u32(backend, dst_offs)
     src_offs_d = _device_u32(backend, src_offs)
     prefix_d = _device_u32(backend, prefix)
@@ -129,7 +146,7 @@ function multi_span_copy!(dst::AbstractArray{T}, src::AbstractArray{T},
     # kernel-launch lock (see e.g. OpenCLExt) to avoid deadlocking a blocking
     # recv that precedes this call against that lock; take the narrower
     # per-launch lock here instead.
-    gpu_kernel_lock(task_processor()) do
+    gpu_kernel_lock(kernel_lock_processor(dev_arr)) do
         kern(dst_vec, src_vec, dst_offs_d, src_offs_d, prefix_d; ndrange=total)
     end
     # This synchronize is required (independent of any following DtoH): the

--- a/test/allocations.jl
+++ b/test/allocations.jl
@@ -115,7 +115,16 @@ function print_alloc_report()
     println()
 end
 
+# N.B. The whole body runs under `ALLOC_TEST_SCOPE`, not just the measured
+# calls inside `test_allocs`: the `let`-block DArrays below are built by
+# `allocate_array` tasks, which take no `Chunk` inputs and so carry no
+# data-transfer cost to anchor them. Unpinned, the scheduler spreads them
+# across every worker (correctly -- that is what a distributed array is), and
+# the pinned measurement then pays to pull those chunks back, which makes the
+# counts depend on the worker topology the testsuite happens to run under --
+# exactly what the pinning above exists to prevent.
 @testset "Steady-state allocations" begin
+Dagger.with_options(; scope=ALLOC_TEST_SCOPE) do
     N, B = 128, 32
     T = Float64
 
@@ -196,6 +205,7 @@ end
     end
 
     print_alloc_report()
+end
 end
 
 # Everything above ran inside `Dagger.with_options(scope=ALLOC_TEST_SCOPE)`,

--- a/test/memory-spaces.jl
+++ b/test/memory-spaces.jl
@@ -58,4 +58,28 @@
             @test Set(Dagger.processors(w2_mem)) == filter(proc->proc isa Dagger.ThreadProc, Dagger.get_processors(OSProc(2)))
         end
     end
+
+    @testset "Kernel Lock Processor" begin
+        # `multi_span_copy!` needs a processor to pick the backend's
+        # kernel-launch lock, but it also runs outside any DTask: the
+        # source-side gather in `move!(::RemainderAliasing, ...)` is handed to
+        # the owning worker via `remotecall_fetch`, whose closure executes in a
+        # Distributed message-handler task with no Dagger TLS. Deriving the
+        # processor from the value's memory space must work there.
+        x = zeros(4)
+        outside = fetch(Threads.@spawn begin
+            @assert !Dagger.in_task()
+            Dagger.kernel_lock_processor(x)
+        end)
+        @test outside in Dagger.processors(Dagger.memory_space(x))
+        # `gpu_kernel_lock` must accept it and still run the body
+        @test Dagger.gpu_kernel_lock(()->:ran, outside) === :ran
+        # Inside a DTask the current processor still wins. Both reads have to
+        # come from the *same* task: two `@spawn`s can be scheduled onto two
+        # different `ThreadProc`s, and would then disagree for reasons that
+        # have nothing to do with what is being checked here.
+        @everywhere kernel_lock_proc_is_task_proc(x) =
+            Dagger.kernel_lock_processor(x) === Dagger.task_processor()
+        @test fetch(Dagger.@spawn kernel_lock_proc_is_task_proc(1.0))
+    end
 end

--- a/test/scheduler.jl
+++ b/test/scheduler.jl
@@ -442,7 +442,7 @@ end
             @test haskey(costs, tproc2_1)
             @test costs[tproc1_1] ≈ pres1_1 + sig_unknown_cost # All chunks are local, and this signature is unknown
             if nprocs() > 1
-                @test costs[tproc2_1] ≈ (tx_size/tx_rate) + tx_xfer_cost + pres2_1 + sig_unknown_cost # All chunks are remote, and this signature is unknown
+                @test costs[tproc2_1] ≈ (tx_size/tx_rate)*1e9 + tx_xfer_cost + pres2_1 + sig_unknown_cost # All chunks are remote, and this signature is unknown
             end
         end
 
@@ -491,7 +491,7 @@ end
             _, costs = Dagger.Sch.estimate_task_costs(state, procs, t)
 
             if nprocs() > 1
-                @test costs[tproc2_1] ≈ sig_unknown_cost + (tx_size / 500_000) + tx_xfer_cost
+                @test costs[tproc2_1] ≈ sig_unknown_cost + (tx_size / 500_000)*1e9 + tx_xfer_cost
             end
             @test costs[tproc1_1] ≈ sig_unknown_cost
 

--- a/test/scheduler.jl
+++ b/test/scheduler.jl
@@ -446,6 +446,36 @@ end
             end
         end
 
+        @testset "Per-Processor Pressure" begin
+            # Compute pressure is per-processor: an idle processor must be
+            # preferred over a busy one, even when reaching it costs a
+            # cross-worker transfer. Folding pressure into a single sum added
+            # to every candidate would make these costs indistinguishable.
+            base1 = get_pressure(1, tproc1_1)
+            base2 = get_pressure(first(workers()), tproc2_1)
+            counter_ref = lock(state.worker_time_pressure) do wtp
+                proc_map = get!(()->Dict{Dagger.Processor,Threads.Atomic{UInt64}}(), wtp, 1)
+                return get!(()->Threads.Atomic{UInt64}(UInt64(0)), proc_map, tproc1_1)
+            end
+            # Reserve/release symmetrically, so real bookkeeping is untouched
+            added = UInt64(10_000_000_000)
+            Threads.atomic_add!(counter_ref, added)
+            try
+                t = delayed(mynothing)(1, 2)
+                Dagger.Sch.collect_task_inputs!(state, t)
+                sorted_procs, costs = Dagger.Sch.estimate_task_costs(state, procs, t)
+
+                @test costs[tproc1_1] ≈ base1 + added + sig_unknown_cost
+                if nprocs() > 1
+                    @test costs[tproc2_1] ≈ tx_xfer_cost + base2 + sig_unknown_cost
+                    @test costs[tproc2_1] < costs[tproc1_1]
+                    @test sorted_procs[1] == tproc2_1
+                end
+            finally
+                Threads.atomic_sub!(counter_ref, added)
+            end
+        end
+
         @testset "Per-Processor Transfer Rate" begin
             wid = first(workers())
 


### PR DESCRIPTION
#744 did a dumb and summed the pressure across *all* workers as one scalar, rather than segregating them by worker, leading to #663 not actually being fixed - this does the right thing and corrects the issue, and also corrects a few other bugs found along the way.

Written by Claude Opus